### PR TITLE
feat(portal): "Start tilted" is a choice, not a right-drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ containing an extruded layer open tilted, because straight down a 3D block and a
 same shape — and there is now a **tilt button** beside the zoom controls, so you can look at 3D from
 the side without knowing that right-dragging the map does it.
 
+Tilt is also an authoring choice: **Start tilted**, beside *Start in 3D globe* in the portal editor's
+Layout panel, decides whether visitors open in perspective or looking straight down. The pinned start
+view always carried a pitch — until now the only way to set one was to right-drag the preview.
+
 The bar footprint is sized from the layer's own extent rather than a fixed number of metres. A fixed
 default is right at exactly one scale: a few hundred points spread across the world would otherwise
 draw bars a few thousandths of a pixel wide — rendered perfectly, and invisible.

--- a/templates/README.md
+++ b/templates/README.md
@@ -83,7 +83,10 @@ a basemap, and metadata. This is what makes templates cheap to add and features 
     it). Doubly guarded: a cached MapLibre v4 bundle has no `get/setProjection`, and every portal saved
     before this has no `projection` key — both fall through to the map default (mercator), i.e. the
     previous behaviour. The editor spreads the reported camera WHOLE (`{ ...lastView }`), so the shape
-    is owned by `portal.js::currentViewObj` alone.
+    is owned by `portal.js::currentViewObj` alone. **Tilt joined it (2026-08-07):** `setupEditMode`
+    takes a `tilt` message (`map.easeTo` between 0 and `TILT_PITCH`), the editor's "Start tilted"
+    checkbox. Unlike `projection`, no explicit `post` is needed — `easeTo` fires `moveend`, which
+    already reports the camera, and `syncTilt` keeps the on-map tilt button in step.
   - **Catalog runtime (V-14, 2026-07-30):** when the archetype is `catalog`, `setupCatalog()` fills the
     hidden `#catalog-panel` (a sibling of `#map-wrap` in `shared/layout.html`, mirroring how
     `#story-panel` stays `display:none` for other archetypes) with a search box, a **facet rail**
@@ -202,6 +205,10 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-07d (**"Start tilted" is now an authoring choice, not a right-drag.** `setupEditMode` gained a
+`tilt` message that eases the preview between 0 and `TILT_PITCH` (60°); the editor checkbox mirrors
+the on-map `TiltControl`, and the resulting pitch is pinned with the rest of the camera. Published
+portals needed no change — `initial_view.pitch` was already honoured on load.)
 2026-08-07c (**Download-by-area hit-tested the SCREEN, so it found nothing on the globe.**
 `openDownloadDialog` decided which layers to offer with `queryRenderedFeatures(pixBox, …)` —
 `pixBox` being an axis-aligned SCREEN rectangle between the two projected drag corners. On a globe

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -3289,6 +3289,13 @@
         applyProjection(d.value === 'globe' ? 'globe' : 'mercator');
         post({ type: 'view', view: currentViewObj() });
       }
+      // The editor's "Start tilted" toggle — the same two states as the on-map tilt control, so the
+      // pinned view can carry a perspective the author chose rather than one they had to right-drag
+      // into. easeTo fires moveend, so the camera reports itself back (no explicit post needed, and
+      // syncTilt keeps the on-map button in step).
+      else if (d.type === 'tilt') {
+        try { map.easeTo({ pitch: d.value ? TILT_PITCH : 0, duration: 550 }); } catch (err) {}
+      }
       else if (d.type === 'fitbbox' && Array.isArray(d.bbox) && d.bbox.length === 4) {
         try { map.fitBounds([[d.bbox[0], d.bbox[1]], [d.bbox[2], d.bbox[3]]], { padding: 30, duration: 500 }); } catch (err) {}
       }

--- a/ui/src/views/PortalEditor.vue
+++ b/ui/src/views/PortalEditor.vue
@@ -284,6 +284,12 @@
               <span class="text-muted-foreground">Start in 3D globe</span>
               <input type="checkbox" :checked="startsInGlobe" @change="e => setGlobe(e.target.checked)" />
             </label>
+            <!-- Same story as the globe: pitch was already part of the pinned view, but the only way
+                 to set it was to right-drag the preview, which nothing advertises. -->
+            <label class="flex items-center justify-between cursor-pointer">
+              <span class="text-muted-foreground">Start tilted</span>
+              <input type="checkbox" :checked="startsTilted" @change="e => setTilt(e.target.checked)" />
+            </label>
             <label v-if="!isStory && !isCatalog" class="flex items-center justify-between cursor-pointer">
               <span class="text-muted-foreground">Start collapsed</span>
               <input type="checkbox" :checked="resolvedLayout.regions.layerList.collapsed"
@@ -2110,6 +2116,20 @@ function setGlobe(on) {
   // Optimistic: the iframe reports the real camera back within a frame, but a portal that has never
   // reported one yet would otherwise leave the box unticked after a click.
   if (lastView.value) lastView.value = { ...lastView.value, projection: on ? 'globe' : 'mercator' }
+}
+
+// The on-map tilt control's two states, as an authoring decision. Mirrors portal.js TILT_PITCH /
+// TILT_ON_AT — a pitch is "tilted" when it is past the threshold, not only when it equals 60, so
+// a camera the author dragged to some other angle still reads as tilted here.
+const TILT_PITCH = 60
+const TILT_ON_AT = 5
+const startsTilted = computed(() =>
+  ((lastView.value?.pitch ?? savedView.value?.pitch) || 0) >= TILT_ON_AT)
+function setTilt(on) {
+  postToFrame({ type: 'tilt', value: on })
+  // Optimistic for the same reason as setGlobe, plus one of its own: the preview EASES over half a
+  // second, so waiting for moveend would leave the box visibly lagging the click.
+  if (lastView.value) lastView.value = { ...lastView.value, pitch: on ? TILT_PITCH : 0 }
 }
 
 function currentView() {

--- a/ui/src/views/README.md
+++ b/ui/src/views/README.md
@@ -63,6 +63,12 @@ Page-level route components. All except SetupWizard/Login render inside `Layout.
 - Raster layer `bbox` from the API is in source CRS (not lon/lat) — using it directly for `fitToBbox` can throw "Invalid LngLat" (see tasks/raster notes). Prefer zooming via vector bounds or TiTiler TileJSON.
 
 ## Last updated
+2026-08-07 (`PortalEditor`: **"Start tilted"** beside "Start in 3D globe" in the Layout panel.
+`initial_view` always carried `pitch`, but the only way to set it was right-dragging the preview —
+the same invisibility the globe toggle fixed. `setTilt` posts `{type:'tilt'}` to the preview iframe
+and optimistically updates `lastView.pitch`, because the iframe eases over 550 ms and the box would
+otherwise lag the click. `startsTilted` tests `pitch >= 5` (portal.js `TILT_ON_AT`), not `=== 60`, so
+a camera dragged to another angle still reads as tilted.)
 2026-08-06e (`DataManager`: page size 20 → 10, and a search with hits FORCE-OPENS a collapsed
 section — `sectionOpen` is the effective state (`!collapsed || search-with-hits`), display only, so
 the persisted preference survives and clearing the box collapses it again. A search that matches


### PR DESCRIPTION
Finishes v1.1's 3D work. The tag will be **moved** to this merge rather than a
new version being cut — v1.1 is hours old and the changelog scheme has no patch
level.

## The gap

The pinned start view has always carried a `pitch`, and the published portal has
always honoured it. But the only way to put a pitch in there was to right-drag
the preview, which nothing on the page advertises — the same invisibility that
"Start in 3D globe" was added to fix for `projection`. So a portal could offer
visitors the tilt button and still open flat, with no way for the author to say
otherwise.

## The change

A **Start tilted** checkbox beside *Start in 3D globe* in the editor's Layout
panel.

- `PortalEditor.vue` posts `{type:'tilt'}` to the preview iframe and updates
  `lastView.pitch` optimistically — the iframe eases over 550 ms, so the box
  would otherwise visibly lag the click.
- `portal.js::setupEditMode` eases between `0` and `TILT_PITCH` (60°), the
  on-map `TiltControl`'s two states, so the toggle and the button cannot
  disagree. No explicit camera report is needed (unlike `projection`): `easeTo`
  fires `moveend`, which already reports it, and `syncTilt` keeps the button lit.
- `startsTilted` tests `pitch >= TILT_ON_AT` rather than `=== 60`, so a camera
  dragged to some other angle still reads as tilted.

No server change: `initial_view.pitch` was already saved, baked and honoured on
load. An explicit `0` still beats the extruded-layer auto-tilt, which only fires
when the author never pinned a pitch.

Also carries the earlier `docs(roadmap)` commit from `docs/roadmap-v1.1-shipped`.