### PR TITLE
docs(changelog): v1.2 — from an upload to a map anyone can open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@ Notable changes, newest first. Versions are **major.minor** — `v1.0`, `v1.1`, 
 `v2.0`. The minor number moves for anything shipped, features or fixes; the major changes when an
 upgrade needs manual work.
 
+## v1.2 — 2026-08-07
+
+### From an upload to a map anyone can open
+
+Every raster failure fixed here was **silent**. The layer said `ready`, its TileJSON was valid, and
+the tiles did not work — so the only honest place to look was a tile server's log, which is not where
+anyone looks first.
+
+- **A 3 GB raster upload no longer dies writing overviews.** A classic TIFF cannot pass 4 GB (its
+  header offsets are 32-bit), and GDAL does not refuse the job up front — it fails part way through,
+  so the size limit surfaced as an overview error. Large rasters are written as BigTIFF now.
+- **Multispectral imagery renders.** A 4-band drone image asked the PNG encoder for five channels
+  (four bands plus the mask) and every tile failed, everywhere — the portal, the XYZ link, the STAC
+  asset, all of them build the same URL. A raster with more than three bands now gets an explicit
+  band selection.
+- **Hillshade works from the portal editor**, not only from the published legend. The layer's own
+  stretch was being applied *after* the algorithm, flattening a finished relief image to one colour.
+- **A world layer no longer breaks every tile.** Web Mercator is undefined at the poles, so a
+  countries dataset reaching Antarctica made PostGIS refuse the projection and Martin answer 500 for
+  every tile at every zoom. Geographic data is clipped to the Mercator band at import.
+- **One oversized tile no longer hangs a portal.** A drone plot 200 m across was still being
+  requested at zoom 3 — a single tile spanning 2,000 km — and the timeout left the map waiting, so a
+  catalog portal never finished loading and its filters never appeared.
+- **Clicking the map** no longer asks every raster on screen for a value it does not have.
+
+### Your data opens somewhere else
+
+- **WMTS for QGIS.** *Layer ▸ Add Layer ▸ Add WMS/WMTS Layer*, paste the link, and **Zoom to Layer**
+  goes to the data. An XYZ URL has nowhere to put an extent, which is why it could not.
+- **Tiles that miss a raster come back empty, not missing.** A tile server answering 404 for the
+  edges of a tile grid is correct for an API and wrong for a map — and a bare XYZ URL gives QGIS,
+  GeoLibre or Leaflet no way to avoid asking. They now get a transparent tile instead of a console
+  full of errors.
+- **Share links say which tool each one is for**, and the service-wide link says so plainly rather
+  than looking like the one dataset it was copied from.
+
+### Portals
+
+- **Start tilted** is an authoring choice, beside *Start in 3D globe*. The pinned view always
+  carried a pitch; the only way to set one was to right-drag the preview.
+- **Catalog portals on a phone**: filters sit beside the results instead of above them. The old
+  layout split the one scarce axis three ways and the result list — the point of the page — got the
+  smallest share.
+- **The "On map" list shows each layer's real symbology.** It is a catalog's only legend, and every
+  row used to be a dot coloured by type, so three point layers were three identical dots. Rasters
+  show their colour ramp.
+- **Custom logos can take the theme colour**, like the built-in ones always could — an SVG exported
+  dark on transparent was nearly invisible against a dark header. **SVG uploads** are accepted.
+- **A globe portal's thumbnail keeps the space behind the earth.**
+
+### Upgrading
+
+From the dashboard: **Settings ▸ Infrastructure ▸ Updates**, or on the server:
+
+```bash
+sudo bash installer/self-update.sh v1.2
+```
+
+**Re-publish your portals after updating.** The layer symbology in the catalog list, the logo
+tinting, the tilt state and the phone layout are baked into each portal when it is published.
+
+**One behaviour change worth knowing.** Geographic data is now clipped to the Web Mercator band
+(±85.05°) at import. Nothing outside that band can be shown on a web map anyway, but it means a
+world dataset downloaded back out of GeoDeploy has a truncated Antarctica rather than the polygon you
+uploaded. Existing layers are unaffected until re-imported.
+
+No manual migration is needed.
+
 ## v1.1 — 2026-08-07
 
 ### Data-driven symbology

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -14,7 +14,7 @@ Three surfaces, three jobs:
 |---|---|---|
 | **OGC API - Features** | reading features in any GIS (QGIS, ArcGIS, FME, GDAL) | `/api/ogc` |
 | **STAC** | discovering what an instance holds, and where each asset lives | `/api/stac` |
-| **Tiles** (XYZ · TileJSON · PMTiles · COG) | drawing big layers fast | per-layer, see below |
+| **Tiles** (WMTS · XYZ · TileJSON · PMTiles · COG) | drawing big layers fast | per-layer, see below |
 
 In the app, the **Share links** panel (link icon on any ready layer in *My Data*) hands you the
 right URL for each of these, labelled with the exact menu path in each tool.
@@ -118,10 +118,17 @@ filtering, no transactions, no OGC API - Tiles or Records — and `/api/ogc/conf
   `/vsicurl/https://YOUR-HOST/api/data/raster/{id}/cog`. Range requests fetch only the tiles
   and overviews you look at (this is the modern replacement for WCS).
 - **Download:** the same URL fetched normally returns the whole GeoTIFF.
-- **XYZ tiles (display only):** the item's `tiles` asset is a TiTiler tile template — paste it
-  into a QGIS *XYZ Tiles* connection or any web map.
-- **TileJSON (preferred over raw XYZ):** `…/api/data/raster/{id}/tilejson` wraps that template with
-  the layer's **bounds** and saved styling, so clients can *zoom to layer* — a bare XYZ URL cannot.
+- **WMTS — the one to use in QGIS:** `…/api/data/raster/{id}/wmts`, added under *Layer ▸ Add Layer ▸
+  Add WMS/WMTS Layer ▸ New*. It carries the layer's **extent**, so **Zoom to Layer** goes to the
+  data. QGIS does not read TileJSON for a raster, which is why an XYZ connection leaves it guessing
+  at the whole world.
+- **TileJSON — the one to use in MapLibre, deck.gl or GeoLibre:**
+  `…/api/data/raster/{id}/tilejson` wraps the tile template with the layer's **bounds** and saved
+  styling.
+- **XYZ tiles (display only, no extent):** the item's `tiles` asset is a TiTiler tile template —
+  paste it into a QGIS *XYZ Tiles* connection or any web map. Prefer WMTS or TileJSON above: a bare
+  `{z}/{x}/{y}` template has nowhere to carry an extent, so nothing that reads it can zoom to the
+  layer. Tiles outside the raster come back transparent rather than as errors.
 
 ### Vector layers served from PostGIS
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,10 +1,10 @@
 # Roadmap
 
-GeoDeploy is being cut as **v1.0** — the first tagged release. Everything under *In v1.0* is built
-and running in production; the groups after it are what comes next.
+GeoDeploy is at **v1.2**. Everything under *In v1.0* and in the releases after it is built and
+running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
-:material-check-circle:{ .gd-ok } **Shipped — in v1.0** ·
+:material-check-circle:{ .gd-ok } **Shipped** ·
 :material-progress-clock:{ .gd-wip } **Finishing** ·
 :material-circle-outline: **Planned**
 </div>
@@ -154,12 +154,38 @@ show <em>what they are</em> — and where choosing a version to run stops being 
 
 </div>
 
+<div class="gd-rel done" markdown>
+### v1.2 — from an upload to a map anyone can open
+<span class="gd-when">Shipped · 2026-08-07</span>
+
+<p class="gd-goal">Rasters that used to fail silently, and layers another tool can actually open.
+Every raster fault fixed here reported itself as healthy — the layer said <em>ready</em>, its
+TileJSON was valid, and only the tile server's log knew otherwise.</p>
+
+- [x] **Big and awkward rasters work** — a 3 GB upload no longer dies writing overviews (BigTIFF),
+      and a 4-band multispectral image renders instead of failing every tile at the PNG encoder
+- [x] **Hillshade works from the editor**, not only from the published legend
+- [x] **A world layer no longer breaks every tile** — geographic data is clipped to the Web Mercator
+      band at import, so a dataset reaching Antarctica stops making the projection refuse
+- [x] **One oversized tile no longer hangs a portal** — a 200 m drone plot was still being requested
+      at zoom 3, and the timeout left a catalog portal loading forever
+- [x] **WMTS for QGIS** — paste one URL and *Zoom to Layer* goes to the data, which an XYZ link can
+      never do because it has nowhere to carry an extent
+- [x] **Tiles that miss a raster come back empty, not missing** — no more 404 storms in someone
+      else's console
+- [x] **Share links say which tool each one is for**
+- [x] **Portals**: *Start tilted* as an authoring choice, real symbology in the catalog's on-map
+      list, a phone layout where the results are not a sliver, SVG logos that take the theme colour,
+      and a globe thumbnail that keeps the space behind the earth
+
+</div>
+
 <div class="gd-rel now tail" markdown>
-### v1.2 — the CLI, and getting data back out
+### v1.3 — the CLI, and getting data back out
 <span class="gd-when">Next</span>
 
-<p class="gd-goal">v1.1 made a portal say what the data means. This one is about reaching an instance
-without a browser, and about being able to take your data with you.</p>
+<p class="gd-goal">v1.2 made the data readable by other tools. This one is about reaching an instance
+without a browser, and about being able to take a copy with you.</p>
 
 - [ ] **A real CLI**, not an example script — every argument the API takes, the v1.1 symbology
       included, with its own section in the docs and tests so it is verified without anyone
@@ -172,6 +198,9 @@ without a browser, and about being able to take your data with you.</p>
 - [ ] Collapsible legend entries in the layer list, with a collapse-all ([#9](https://github.com/bravemaster3/GeoDeploy/issues/9))
 - [ ] Class count stops snapping back, and the 9-vs-12 ceiling agrees with the server ([#10](https://github.com/bravemaster3/GeoDeploy/issues/10))
 - [ ] **Invert a colour ramp** ([#11](https://github.com/bravemaster3/GeoDeploy/issues/11))
+- [ ] **A raster's zoom range read from the file, not guessed from its extent** — today a small
+      high-resolution layer stops drawing below a computed floor, with nothing saying why
+      ([#17](https://github.com/bravemaster3/GeoDeploy/issues/17))
 - [ ] **Size from a field**, and **labels** — the half of data-driven symbology v1.1 did not ship
 
 </div>


### PR DESCRIPTION
The v1.2 changelog section, ahead of tagging.

Grouped by what a reader is looking for rather than by commit:

- **Rasters that render** — every failure in this release was silent. The layer
  said `ready`, the TileJSON was valid, and the tiles did not work, so the only
  evidence was in a tile server's log.
- **Your data opens somewhere else** — WMTS for QGIS, empty tiles instead of 404
  storms, share links labelled by tool.
- **Portals** — tilt as an authoring state, the phone catalog layout, real
  symbology in the "On map" list, SVG logos and tinting, the globe thumbnail.

Two things called out under Upgrading rather than buried:

1. Portals need a **re-publish** — the catalog symbology, logo tinting, tilt
   state and phone layout all bake at publish.
2. The Mercator clip is **lossy**. A world dataset downloaded back out of
   GeoDeploy now has a truncated Antarctica. Harmless for display, but this
   release invites people to pull data out, so it belongs in the notes rather
   than in a commit message.