### PR TITLE
docs(readme): name the stack in the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ domain, and no per-seat pricing.
 
 ## What it is
 
-One command gives you a complete spatial stack on a single Linux server: a spatial database, object
-storage, vector and raster tile services, a web dashboard, and the portals you publish from it.
+One command gives you a complete spatial stack on a single Linux server: **PostGIS**, object
+storage, **Martin** for vector tiles and **TiTiler** for rasters, a web dashboard, and the portals
+you publish from it.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bravemaster3/geodeploy/main/installer/install.sh | bash


### PR DESCRIPTION
PostGIS, Martin and TiTiler are what a GIS reader is scanning for, and they were only in the architecture table 80 lines down. The intro said `a spatial database, object storage, vector and raster tile services` — true, and no more informative than the reader's own assumption.

Prose rather than badges: the two badge rows answer *is this alive* and *will my data get out*. A component row would age fastest and wrap on mobile, and someone who cares about internals is already scrolling to the table.