### PR TITLE
feat(cli): a packaged geodeploy client, the anonymous public index, and per-layer downloads

### DIFF
--- a/.github/CI-NOTES.md
+++ b/.github/CI-NOTES.md
@@ -12,11 +12,18 @@ GitHub Actions CI and the community-template validation pipeline.
 - `workflows/ci.yml` — runs on push/PR to `main`:
   - **api** job: Python 3.12, installs GDAL/PostgreSQL system libs + `requirements.txt` + pytest deps, runs `pytest tests/` with dev env vars.
   - **ui** job: Node 20, `npm install` + `npm run build`.
+  - **cli** job: `cli/` on a Python **3.9 and 3.12** matrix — `pip install -e ".[dev]"`, `pytest`,
+    then a smoke run of the console script. No services: the suite runs against a fake instance it
+    starts itself (`cli/tests/conftest.py`), so it finishes in seconds. **3.9 is in the matrix on
+    purpose**: the QGIS plugin vendors that package and QGIS 3.28 LTR ships Python 3.9, so this job
+    is what catches syntax or stdlib use that would break there. The install line is `.[dev]` and
+    nothing else — the package must stay dependency-free, and this job failing on a missing wheel
+    would mean one had crept in.
 - `workflows/validate-template.yml` — runs on PRs touching `templates/community/**`; installs `jsonschema`/`Pillow`/`maplibre-style-spec` and runs the validator script.
 - `scripts/validate_template.py` — checks each changed community template: required files present, `template.json` schema, `style.json` MapLibre validity, `preview.png` is 800×500, no external CDN URLs in `layout.html`.
 
 ## Dependencies / relationships
-- `ci.yml` exercises `api/` (pytest) and `ui/` (vite build) — keep build/test commands here in sync with those folders' tooling.
+- `ci.yml` exercises `api/` (pytest), `ui/` (vite build) and `cli/` (pytest + console script) — keep build/test commands here in sync with those folders' tooling.
 - `validate-template.yml` + `scripts/validate_template.py` enforce the contract documented in `templates/community/CONTRIBUTING.md`.
 
 ## Current status & known issues
@@ -24,4 +31,4 @@ GitHub Actions CI and the community-template validation pipeline.
 - The API test suite is minimal (`/health`, initial setup status).
 
 ## Last updated
-2026-06-01
+2026-08-12 (added the **cli** job for the packaged `geodeploy` client)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,42 @@ jobs:
           POSTGIS_USER: geodeploy
           POSTGIS_PASSWORD: test
 
+  cli:
+    name: CLI tests
+    runs-on: ubuntu-latest
+
+    # No services and no install of the API: the suite runs the client against a fake instance it
+    # starts itself (cli/tests/conftest.py), so it is seconds rather than minutes.
+    strategy:
+      matrix:
+        # 3.9 is the floor because the QGIS plugin vendors this package and QGIS 3.28 LTR ships
+        # 3.9; if a syntax or stdlib feature newer than that creeps in, this job is what catches it.
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install
+        working-directory: cli
+        # `.[dev]` and nothing else — the package has no runtime dependencies, and this job failing
+        # on a missing wheel would mean one had been added by accident.
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: cli
+        run: python -m pytest tests -q
+
+      - name: The console script runs
+        run: |
+          geodeploy --version
+          geodeploy --help > /dev/null
+
   ui:
     name: UI build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .venv/
 venv/
 dist/
+build/
 *.egg-info/
 .pytest_cache/
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Full documentation: **<https://docs-geodeploy.kndev.org/>**
 | [Portals and experiences](https://docs-geodeploy.kndev.org/portals/) | Web map, story map, catalog; layout and access |
 | [Users, roles and sharing](https://docs-geodeploy.kndev.org/users-and-sharing/) | Roles, visibility, tokens, audit log |
 | [Access from other tools](https://docs-geodeploy.kndev.org/data-access/) | QGIS, DuckDB, Python — which standard for which job |
+| [Command line](https://docs-geodeploy.kndev.org/cli/) | `pip install geodeploy` — upload, style, publish and administer from a shell |
 | [API reference](https://docs-geodeploy.kndev.org/api-reference/) | Tokens, scopes, and the live OpenAPI docs |
 | [Updating](https://docs-geodeploy.kndev.org/updating/) | Self-update, services, the Infrastructure panel |
 | [Backups and restore](https://docs-geodeploy.kndev.org/backups/) | Scheduled backups and in-app restore |

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -11,7 +11,7 @@ from starlette.responses import Response
 from .config import get_settings
 from . import database
 from .database import Base
-from .routers import (setup, auth, auth_oidc, portals, stac, templates, admin, basemaps, users,
+from .routers import (public, setup, auth, auth_oidc, portals, stac, templates, admin, basemaps, users,
                       tokens, audit, interop, ogcapi, backups)
 from .routers.data import vector, raster, sources, discover
 # The migration list lives in its own module because the Celery worker re-applies it after a
@@ -353,6 +353,7 @@ app.add_middleware(
 _PUBLIC_CORS = re.compile(
     r"^/api/(stac(/.*)?"
     r"|ogc(/.*)?"        # OGC API - Features: the whole tree is public, unauthenticated read
+    r"|public(/.*)?"     # the anonymous instance index: portals + public layers by kind
 
     # `[\w.-]+`, NOT `\d+`. Public URLs address a layer by its stable `uid` (hex, e.g.
     # 488c2c7f55d7) since 2026-07-29 — a digits-only pattern silently stopped matching them, so
@@ -360,6 +361,10 @@ _PUBLIC_CORS = re.compile(
     # the server had served perfectly (206 with no ACAO). Pinned by test_cors_public_surface.
     r"|data/vector/[\w.-]+/(pmtiles|features\.geojson|features\.arrow|tilejson|identify)"
     r"|data/vector/[\w.-]+/parquet/.*"     # duckdb-wasm / GDAL read partition files cross-origin
+    # Whole-layer / clipped downloads: same public terms as the artifacts above, and a browser
+    # client polls the status endpoint cross-origin while the export runs.
+    r"|data/(vector|raster)/[\w.-]+/export"
+    r"|data/(vector|raster)/[\w.-]+/export-(status|download)/[\w-]+"
     r"|data/raster/[\w.-]+/(cog|tilejson|statistics))$"
 )
 
@@ -433,7 +438,7 @@ async def _public_data_cors(request, call_next):
 for router in [setup.router, auth.router, auth_oidc.router, users.router, tokens.router,
                audit.router, portals.router, templates.router, admin.router, basemaps.router,
                vector.router, raster.router, sources.router, discover.router, stac.router,
-               ogcapi.router, interop.router, backups.router]:
+               ogcapi.router, interop.router, backups.router, public.router]:
     app.include_router(router, prefix="/api")
 
 # Serve published portals as static files

--- a/api/geodeploy/models.py
+++ b/api/geodeploy/models.py
@@ -12,14 +12,19 @@ from .database import Base
 def new_uid() -> str:
     """A layer's STABLE PUBLIC identifier.
 
-    Integer primary keys must never appear in shareable URLs. SQLite assigns them as rowid
-    aliases WITHOUT the AUTOINCREMENT keyword, so deleting the highest-id row frees that id for
-    the next insert: delete a shared layer, create another, and every saved link to
+    Integer primary keys must never appear in shareable URLs.
+
+    The original reason was SQLite, which assigns them as rowid aliases WITHOUT the AUTOINCREMENT
+    keyword: deleting the highest-id row freed that id for the next insert, so a saved link to
     `.../vector-3` — a STAC item, an OGC API - Features collection, a `/vsicurl/` COG pasted into
-    someone's QGIS project — silently resolves to a DIFFERENT dataset. No error, wrong data.
-    Postgres sequences would fix the reuse, but not the wider problem: integer keys are only
-    meaningful within one database, so a restore or an instance-to-instance move renumbers
-    everything and invalidates every published URL.
+    someone's QGIS project — could silently resolve to a DIFFERENT dataset. No error, wrong data.
+    State moved to Postgres on 2026-07-30 and its sequences never hand a number back, so that
+    particular failure is gone.
+
+    The reason the uid stays is the wider one: an integer key is meaningful only within ONE kind
+    (vector and raster are separate sequences, so "1" is routinely two layers) and ONE database, so
+    a restore or an instance-to-instance move renumbers everything and invalidates every published
+    URL. A published identifier has to outlive the row number that happens to back it today.
 
     12 hex chars from `secrets`: collision-free in practice, unguessable, and URL-safe.
     """

--- a/api/geodeploy/models.py
+++ b/api/geodeploy/models.py
@@ -92,6 +92,13 @@ class SetupConfig(Base):
     backup_include_objects: Mapped[bool] = mapped_column(Boolean, default=True)
     backup_include_state: Mapped[bool] = mapped_column(Boolean, default=True)
 
+    # Whether `GET /api/public` answers (2026-08-12) — the anonymous index of public portals and
+    # public layers that a QGIS plugin or any "browse this instance" client starts from. Default
+    # ON: publishing a portal as `public` already says it may be seen, and a geoportal nobody can
+    # browse is a filing cabinet. Off makes the endpoint 404, leaving every published portal
+    # reachable by link but unlisted.
+    public_index_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -201,9 +201,13 @@ deliberately NOT visibility-filtered (published portals depend on them).
   `is_public` for raster), so nothing new is exposed. **No bbox = no spatial predicate at all**, not
   a world envelope: transforming ±180 into a projected CRS is undefined near the poles and would
   silently drop rows. Whole-layer exports use `FULL_EXPORT_CAP` (1M, `EXPORT_FEATURE_CAP`) rather
-  than the 50k clip cap, and every zip carries a `MANIFEST.txt` naming the cap, because a truncated
-  export is indistinguishable from a complete one. A RASTER export requires a bbox — the whole file
-  is already `/cog`. Tests: `test_layer_export.py`.
+  than the 50k clip cap. **Truncation is reported, not merely warned about** (2026-08-13): the task
+  writes `{job_id}.json` beside the zip and `status()` returns `truncated: [{file, rows, cap}]`
+  from it, so a client knows before it hands the file on — `MANIFEST.txt` is only read by whoever
+  opens the archive, and a capped export is otherwise indistinguishable from a complete one. The
+  report is written BEFORE the zip is renamed into place, because readiness is the zip's existence.
+  A RASTER export requires a bbox — the whole file is already `/cog`. Tests:
+  `test_layer_export.py`.
 - `ogcapi.py` — **PUBLIC OGC API - Features (Part 1: Core)** at `/api/ogc` (2026-07-29). The
   **widest-reach read surface we have**: QGIS ("Add OGC API - Features Layer"), ArcGIS Pro, FME and
   anything on GDAL's `OAPIF` driver consume it natively — unlike TileJSON/PMTiles, which only the

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -178,6 +178,32 @@ deliberately NOT visibility-filtered (published portals depend on them).
   ids, OGC collection ids); authenticated/admin routes stay on the integer id. Contract pinned in
   `test_ogcapi.py` ("Stable public ids").
 
+- `public.py` — **PUBLIC instance index** at `/api/public` (+ `/public/portals`), 2026-08-12. The
+  one call that answers "what does this instance offer?" from a URL alone, which is the first screen
+  of the QGIS plugin and of any browse client: published portals whose `access_type == "public"`,
+  and `is_public` ready layers **grouped by storage kind** (`raster` / `postgis` / `geoparquet`),
+  each with `services/share_links.py`'s own URLs so this cannot drift from the Share links panel.
+  Portals are addressed by SLUG, never the integer id, and carry `style_url` — the published
+  bundle's `style.json`, which describes the whole portal in one anonymous fetch.
+  **Why it exists:** `GET /portals` is `portal:read`-scoped, so nothing let an anonymous client
+  discover portals; layers were already discoverable via STAC/OGC. **Exposure rule:** this turns
+  "reachable by link" into "findable", so `SetupConfig.public_index_enabled` (default **TRUE**,
+  admin-toggled at `GET/PUT /admin/public-index`, audited) can switch it off — and then it 404s
+  rather than returning an empty list, so a client can tell "no index here" from "nothing
+  published". `index_enabled()` treats NULL/absent as ON: an instance upgraded into the feature must
+  not silently unlist what it already published. Tests: `test_public_index.py`.
+- `data/exports.py` — **per-layer download** (2026-08-12): `POST /data/{vector,raster}/{ref}/export`
+  + `export-status/{job_id}` + `export-download/{job_id}`, wrapping the SAME `tasks/export.py`
+  machinery the portal area-export uses, with the **bbox made optional**. Closes the one real gap in
+  the public read surface: a raster (`/cog`) and a GeoParquet layer (`/parquet/…`) could always be
+  fetched whole, but a **PostGIS vector layer had no file** — `features.geojson` caps at 50k and
+  OAPIF pages. PUBLIC on the same terms as the other artifacts (`_publicly_readable` for vector,
+  `is_public` for raster), so nothing new is exposed. **No bbox = no spatial predicate at all**, not
+  a world envelope: transforming ±180 into a projected CRS is undefined near the poles and would
+  silently drop rows. Whole-layer exports use `FULL_EXPORT_CAP` (1M, `EXPORT_FEATURE_CAP`) rather
+  than the 50k clip cap, and every zip carries a `MANIFEST.txt` naming the cap, because a truncated
+  export is indistinguishable from a complete one. A RASTER export requires a bbox — the whole file
+  is already `/cog`. Tests: `test_layer_export.py`.
 - `ogcapi.py` — **PUBLIC OGC API - Features (Part 1: Core)** at `/api/ogc` (2026-07-29). The
   **widest-reach read surface we have**: QGIS ("Add OGC API - Features Layer"), ArcGIS Pro, FME and
   anything on GDAL's `OAPIF` driver consume it natively — unlike TileJSON/PMTiles, which only the
@@ -260,6 +286,8 @@ deliberately NOT visibility-filtered (published portals depend on them).
 - No rate limiting beyond nginx; no pagination on list endpoints (fine at current scale).
 
 ## Last updated
+2026-08-12 (`public.py` — the anonymous instance index, with the admin toggle; `data/exports.py` —
+whole-layer and clipped downloads for both layer kinds. Both added to `main.py`'s `_PUBLIC_CORS`.)
 2026-08-07b (`portals.py`: **SVG accepted for portal assets** — a raster logo goes soft on any retina
 display or larger header, and line art is what a logo IS. Added to `_ASSET_EXTENSIONS` and to the
 `portal_asset` filename allow-list. **Security:** an SVG is a document, not a picture — it can carry

--- a/api/geodeploy/routers/admin.py
+++ b/api/geodeploy/routers/admin.py
@@ -1074,6 +1074,36 @@ async def update_email_settings(body: EmailSettings,
     return _email_out(cfg)
 
 
+class PublicIndexSettings(BaseModel):
+    """Whether this instance answers `GET /api/public` — see routers/public.py."""
+
+    enabled: bool
+
+
+@router.get("/public-index")
+async def get_public_index(_: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    """Is the anonymous instance index published? (Default: yes.)"""
+    cfg = await _get_config(db)
+    return {"enabled": bool(getattr(cfg, "public_index_enabled", True))}
+
+
+@router.put("/public-index")
+async def set_public_index(body: PublicIndexSettings, user: User = Depends(require_admin),
+                           db: AsyncSession = Depends(get_db)):
+    """Turn the anonymous index on or off.
+
+    It changes DISCOVERABILITY, not access: a published public portal stays reachable by its link
+    either way. Audited, because "why did our datasets stop appearing in the plugin" should have an
+    answer that is not archaeology.
+    """
+    cfg = await _get_config(db)
+    cfg.public_index_enabled = bool(body.enabled)
+    await db.commit()
+    await record_audit(db, user, "admin.public_index", "instance", None,
+                       {"enabled": bool(body.enabled)})
+    return {"enabled": bool(body.enabled)}
+
+
 @router.post("/email-settings/test")
 async def test_email(user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
     """Send a test email to the calling admin. Raises the relay's actual error back to the UI —

--- a/api/geodeploy/routers/common.py
+++ b/api/geodeploy/routers/common.py
@@ -22,10 +22,11 @@ logger = logging.getLogger(__name__)
 def by_ref(model, ref):
     """Match a layer by its STABLE PUBLIC `uid` or its legacy integer id.
 
-    Public URLs now carry `uid` (`models.new_uid` — integer ids get reused after a delete and
-    would silently repoint saved links at another dataset). Old links must keep working, so every
-    public lookup accepts either form, and a `vector-`/`raster-` prefix is tolerated so a STAC item
-    id or an OGC API - Features collection id can be passed straight through.
+    Public URLs carry `uid` (`models.new_uid`). The integer is accepted only so links minted before
+    that column existed keep resolving — nothing emits one now (`share_links.public_ref`). Keep it
+    that way: an integer id is unique only within one kind and one database, so it says nothing
+    durable about *which* dataset a saved link meant. A `vector-`/`raster-` prefix is tolerated so a
+    STAC item id or an OGC API - Features collection id can be passed straight through.
 
     Returns a SQLAlchemy condition; combine it with `visible_to(...)` on authenticated routes.
     """

--- a/api/geodeploy/routers/data/exports.py
+++ b/api/geodeploy/routers/data/exports.py
@@ -23,6 +23,7 @@ range request; re-encoding it through a worker would spend minutes to produce a 
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 
@@ -109,17 +110,21 @@ def start(item: dict, bbox: str | None, target_crs: str) -> dict:
 
 
 def status(job_id: str) -> dict:
-    """queued | processing | ready | error — the portal export's contract, unchanged.
+    """queued | processing | ready | error — the portal export's contract, plus `truncated`.
 
     Readiness is the EXISTENCE of the finished file, not the task state: the task writes to a
     `.part` and renames atomically, so a file that is there is a file that is complete, and the
     answer survives a worker restart that loses the result backend entry.
+
+    A ready export also reports which files hit the row cap, read from the `{id}.json` the task
+    writes beside the zip. Same reason the state is read off the filesystem: the result backend may
+    be gone, and a caller that is told only "ready" cannot know it is holding a partial dataset.
     """
     from ...celery_app import celery_app
     _check_job_id(job_id)
     settings = get_settings()
     if os.path.exists("{0}/temp/exports/{1}.zip".format(settings.data_dir, job_id)):
-        return {"status": "ready"}
+        return {"status": "ready", "truncated": _report(job_id, settings)}
     state = celery_app.AsyncResult(job_id).state
     if state == "FAILURE":
         return {"status": "error"}
@@ -135,6 +140,20 @@ def download(job_id: str, filename: str) -> FileResponse:
     if not os.path.exists(path):
         raise HTTPException(404, "That export is not ready (or has been swept).")
     return FileResponse(path, media_type="application/zip", filename=filename)
+
+
+def _report(job_id: str, settings) -> list[dict]:
+    """The truncation report beside the zip: `[{file, rows, cap}]`, empty when nothing was cut.
+
+    An export produced before this existed has no report; that reads as "nothing truncated", which
+    is the same answer callers got then and is right for the overwhelming majority of exports.
+    """
+    path = "{0}/temp/exports/{1}.json".format(settings.data_dir, job_id)
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f).get("truncated") or []
+    except (OSError, ValueError):
+        return []
 
 
 def _check_job_id(job_id: str) -> None:

--- a/api/geodeploy/routers/data/exports.py
+++ b/api/geodeploy/routers/data/exports.py
@@ -1,0 +1,143 @@
+"""Per-layer downloads — "give me this dataset as a file".
+
+Until now the only server-side export was **draw a box on a portal**
+(`POST /portals/{slug}/export-bundle`): it needs a bbox, and it needs the layer to be on a portal.
+That left a real gap for anyone approaching an instance from outside — QGIS, a plugin, a script:
+a raster could be fetched whole (`/cog`), a GeoParquet layer could be fetched whole (`/parquet/…`),
+but a **PostGIS vector layer had no file**. `features.geojson` stops at 50k features and OGC API -
+Features pages, which GDAL handles but a person clicking "download" does not.
+
+So these three routes wrap the SAME Celery machinery the portal export uses, with the bbox made
+optional:
+
+    POST /api/data/{vector|raster}/{ref}/export            → {job_id}
+    GET  /api/data/{vector|raster}/{ref}/export-status/{job_id}
+    GET  /api/data/{vector|raster}/{ref}/export-download/{job_id}
+
+**Public, on the same terms as every other per-layer artifact**: a vector layer must be
+`_publicly_readable` (shared publicly, or shown by a published portal) and a raster must be
+`is_public`. Nothing new is exposed — this is a second shape of data that was already readable.
+
+A raster export REQUIRES a bbox. The whole raster is already one file and `/cog` streams it by
+range request; re-encoding it through a worker would spend minutes to produce a worse copy.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from ...config import get_settings
+
+#: What each backend can be asked for. GeoParquet is offered only where it costs nothing (the
+#: source is already parquet, so the clip stays inside DuckDB and never materialises GeoJSON).
+VECTOR_FORMATS = ("geojson", "gpkg", "csv", "geoparquet")
+RASTER_FORMATS = ("tif",)
+
+#: A celery task id. Validated before it is used as a filename — this is a path built from user
+#: input, and the portal export route learned the same lesson.
+_JOB_ID = re.compile(r"^[0-9a-fA-F-]{8,64}$")
+
+
+class LayerExportRequest(BaseModel):
+    """`bbox` omitted = the whole layer. `target_crs` 'native' keeps the layer's own CRS where the
+    format can carry it (GeoPackage, CSV, GeoParquet); GeoJSON is always EPSG:4326 (RFC 7946)."""
+
+    # No default here: the sensible one differs by layer kind (geojson for vector, tif for
+    # raster), and a shared default of "geojson" made every raster export fail the format check.
+    format: str | None = None
+    bbox: str | None = None            # "minx,miny,maxx,maxy" in EPSG:4326
+    target_crs: str = "4326"           # '4326' | 'native'
+
+
+def validate_bbox(bbox: str | None) -> str | None:
+    if bbox is None or bbox == "":
+        return None
+    try:
+        parts = [float(v) for v in bbox.split(",")]
+    except ValueError:
+        raise HTTPException(400, "bbox must be 'minx,miny,maxx,maxy' in EPSG:4326.")
+    if len(parts) != 4:
+        raise HTTPException(400, "bbox must be 'minx,miny,maxx,maxy' in EPSG:4326.")
+    if parts[0] >= parts[2] or parts[1] >= parts[3]:
+        raise HTTPException(400, "bbox is empty: min must be less than max on both axes.")
+    return bbox
+
+
+def vector_item(layer, fmt: str | None) -> dict:
+    """The export-task item for a vector layer, whichever backend it lives on."""
+    fmt = fmt or "geojson"
+    if fmt not in VECTOR_FORMATS:
+        raise HTTPException(400, "format must be one of {0}.".format(", ".join(VECTOR_FORMATS)))
+    if layer.storage_backend == "geoparquet":
+        if not layer.s3_key:
+            raise HTTPException(409, "This layer has no data file yet.")
+        return {"type": "geoparquet", "s3_key": layer.s3_key, "crs": layer.crs or "EPSG:4326",
+                "name": layer.name, "format": fmt}
+    if fmt == "geoparquet":
+        raise HTTPException(
+            400, "GeoParquet export is only available for file-backed layers; this one is in "
+                 "PostGIS. Ask for gpkg, geojson or csv.")
+    return {"type": "vector", "schema": layer.schema_name, "table": layer.table_name,
+            "name": layer.name, "format": fmt}
+
+
+def raster_item(layer, fmt: str | None, bbox: str | None) -> dict:
+    fmt = fmt or "tif"
+    if fmt not in RASTER_FORMATS:
+        raise HTTPException(400, "Raster export format must be tif.")
+    if bbox is None:
+        raise HTTPException(
+            400, "A raster export needs a bbox. The whole file is already one download: "
+                 "GET /api/data/raster/{0}/cog".format(layer.uid or layer.id))
+    return {"type": "raster", "s3_key": layer.s3_key, "name": layer.name}
+
+
+def start(item: dict, bbox: str | None, target_crs: str) -> dict:
+    """Queue the export and return the job id to poll."""
+    from ...routers.portals import _sweep_old_exports
+    from ...tasks.export import export_bundle
+
+    if target_crs not in ("4326", "native"):
+        raise HTTPException(400, "target_crs must be '4326' or 'native'.")
+    _sweep_old_exports(get_settings())
+    task = export_bundle.delay(bbox, [item], target_crs=target_crs)
+    return {"job_id": task.id}
+
+
+def status(job_id: str) -> dict:
+    """queued | processing | ready | error — the portal export's contract, unchanged.
+
+    Readiness is the EXISTENCE of the finished file, not the task state: the task writes to a
+    `.part` and renames atomically, so a file that is there is a file that is complete, and the
+    answer survives a worker restart that loses the result backend entry.
+    """
+    from ...celery_app import celery_app
+    _check_job_id(job_id)
+    settings = get_settings()
+    if os.path.exists("{0}/temp/exports/{1}.zip".format(settings.data_dir, job_id)):
+        return {"status": "ready"}
+    state = celery_app.AsyncResult(job_id).state
+    if state == "FAILURE":
+        return {"status": "error"}
+    if state == "STARTED":
+        return {"status": "processing"}
+    return {"status": "queued"}
+
+
+def download(job_id: str, filename: str) -> FileResponse:
+    _check_job_id(job_id)
+    settings = get_settings()
+    path = "{0}/temp/exports/{1}.zip".format(settings.data_dir, job_id)
+    if not os.path.exists(path):
+        raise HTTPException(404, "That export is not ready (or has been swept).")
+    return FileResponse(path, media_type="application/zip", filename=filename)
+
+
+def _check_job_id(job_id: str) -> None:
+    # The id becomes a path segment. A traversal here would serve any file the API can read.
+    if not _JOB_ID.match(job_id or ""):
+        raise HTTPException(400, "Invalid job id.")

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -14,6 +14,7 @@ from ...schemas import JobStatus, LayerRename, PortalRefOut, RasterDefaultStyle,
 from ...services import share_links
 from ...services.titiler import get_tile_url as raster_tile_url, COLORMAPS
 from ...tasks.raster_ingest import ingest_raster
+from . import exports
 from ..common import (apply_sharing, demo_upload_cap, busy_job_progress, by_ref, creator_names, portals_using,
                       prune_layer_from_portals, record_audit, visible_to)
 
@@ -306,6 +307,36 @@ async def rename_layer(
     await record_audit(db, user, "raster.rename", "raster", layer.id,
                        {"from": old_name, "to": layer.name})
     return RasterLayerOut.from_orm_json(layer)
+
+
+# ── Clipped download ──────────────────────────────────────────────────────────────────────────
+# A bbox is REQUIRED here: the whole raster is already a single file, streamed by range request
+# from /cog, so a "whole raster export" would spend worker minutes re-encoding a worse copy.
+
+@router.post("/{layer_ref}/export", status_code=202)
+async def start_raster_export(layer_ref: str, req: exports.LayerExportRequest,
+                              db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    if not layer or layer.status != "ready" or not layer.is_public or not layer.s3_key:
+        raise HTTPException(404, "No shared raster for this layer.")
+    bbox = exports.validate_bbox(req.bbox)
+    return exports.start(exports.raster_item(layer, req.format, bbox), bbox,
+                         req.target_crs)
+
+
+@router.get("/{layer_ref}/export-status/{job_id}")
+async def raster_export_status(layer_ref: str, job_id: str):
+    return exports.status(job_id)
+
+
+@router.get("/{layer_ref}/export-download/{job_id}")
+async def raster_export_download(layer_ref: str, job_id: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    from slugify import slugify
+    name = slugify(layer.name, separator="_") if layer else "export"
+    return exports.download(job_id, "{0}.zip".format(name or "export"))
 
 
 @router.get("/{layer_ref}/cog")

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -16,6 +16,7 @@ from ...models import Portal, UploadJob, User, VectorLayer
 from ...schemas import DefaultStyle, JobStatus, LayerRename, PortalRefOut, SharingUpdate, VectorLayerOut
 from ...services import martin as martin_svc
 from ...tasks.vector_ingest import ingest_vector
+from . import exports
 from ..common import (apply_sharing, demo_upload_cap, busy_job_progress, by_ref, creator_names, portals_using,
                       prune_layer_from_portals, record_audit, visible_to)
 
@@ -915,6 +916,36 @@ async def _pmtiles_key(layer_ref: str, db: AsyncSession) -> str | None:
         return None
     _PMTILES_KEY_CACHE[layer_ref] = layer.pmtiles_key
     return layer.pmtiles_key
+
+
+# ── Whole-layer / clipped download ────────────────────────────────────────────────────────────
+# PUBLIC on the same terms as the other per-layer artifacts (`_publicly_readable`): a layer that is
+# shared, or shown by a published portal. See routers/data/exports.py for why this exists at all —
+# a PostGIS vector layer was the one thing an outside client could not simply download.
+
+@router.post("/{layer_ref}/export", status_code=202)
+async def start_vector_export(layer_ref: str, req: exports.LayerExportRequest,
+                              db: AsyncSession = Depends(get_db)):
+    """Queue a download of this layer. No bbox = the whole layer; a bbox clips it."""
+    result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    if not layer or layer.status != "ready" or not await _publicly_readable(layer, db):
+        raise HTTPException(404, "Layer not found.")
+    bbox = exports.validate_bbox(req.bbox)
+    return exports.start(exports.vector_item(layer, req.format), bbox, req.target_crs)
+
+
+@router.get("/{layer_ref}/export-status/{job_id}")
+async def vector_export_status(layer_ref: str, job_id: str):
+    return exports.status(job_id)
+
+
+@router.get("/{layer_ref}/export-download/{job_id}")
+async def vector_export_download(layer_ref: str, job_id: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    name = slugify(layer.name, separator="_") if layer else "export"
+    return exports.download(job_id, "{0}.zip".format(name or "export"))
 
 
 @router.get("/{layer_ref}/pmtiles")

--- a/api/geodeploy/routers/ogcapi.py
+++ b/api/geodeploy/routers/ogcapi.py
@@ -63,8 +63,8 @@ def _root(base: str) -> str:
 
 def _cid(layer) -> str:
     """Collection id = `vector-<uid>`, mirroring the STAC item id. The layer's STABLE identifier,
-    never the integer PK — ids are reused after a delete and would silently repoint a saved
-    collection URL at a different dataset (models.new_uid)."""
+    never the integer PK — that renumbers on a restore or a move between instances, which would
+    silently repoint a saved collection URL at a different dataset (models.new_uid)."""
     return f"vector-{getattr(layer, 'uid', None) or layer.id}"
 
 

--- a/api/geodeploy/routers/public.py
+++ b/api/geodeploy/routers/public.py
@@ -1,0 +1,203 @@
+"""`GET /api/public` — what this instance offers to someone with no account.
+
+**The gap this closes.** Public layers were already discoverable (STAC, OGC API - Features) and
+public portals were already *reachable* — but only if you knew the slug. `GET /portals` requires the
+`portal:read` scope, so nothing let a client type an instance URL and see what is there. That is
+precisely the first screen of a QGIS plugin, and of any "browse this instance" surface.
+
+So this is one unauthenticated call that answers "what can I have?":
+
+* **portals** — published, `access_type == "public"`. Not password/organization/owner ones: those
+  are not public, and listing their titles would leak what an instance holds.
+* **layers**, grouped by the three kinds a GIS user actually distinguishes — `raster` (COG),
+  `postgis` (served as vector tiles) and `geoparquet` (files) — each with the URLs that suit it.
+  Only `is_public`, ready layers, exactly like STAC.
+
+**Discoverability is not the same as access**, which is why there is a switch. Every portal listed
+here is already reachable by anyone holding its link; an index makes it *findable*. For a geoportal
+that is the whole point, so `public_index_enabled` defaults to **on** — but an instance running one
+deliberately-unlisted public portal can turn it off, and then this endpoint 404s rather than
+returning an empty list (a client can tell "no index here" from "nothing published").
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..models import Portal, RasterLayer, SetupConfig, VectorLayer
+from ..services import share_links
+
+router = APIRouter(prefix="/public", tags=["public"])
+
+#: The layer kinds this endpoint groups by — storage, which is what decides how a client reads it.
+KINDS = ("raster", "postgis", "geoparquet")
+
+
+@router.get("")
+async def public_index(request: Request, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Everything anonymous: the portals, the layers by kind, and where the catalogs live."""
+    await _require_enabled(db)
+    base = _base_url(request)
+
+    portals = (await db.execute(
+        select(Portal).where(Portal.published.is_(True), Portal.access_type == "public")
+        .order_by(Portal.published_at.desc().nullslast(), Portal.created_at.desc())
+    )).scalars().all()
+
+    vectors = (await db.execute(
+        select(VectorLayer).where(VectorLayer.is_public.is_(True), VectorLayer.status == "ready")
+        .order_by(VectorLayer.name)
+    )).scalars().all()
+    rasters = (await db.execute(
+        select(RasterLayer).where(RasterLayer.is_public.is_(True), RasterLayer.status == "ready")
+        .order_by(RasterLayer.name)
+    )).scalars().all()
+
+    grouped: dict[str, list] = {kind: [] for kind in KINDS}
+    for layer in vectors:
+        kind = "geoparquet" if layer.storage_backend == "geoparquet" else "postgis"
+        grouped[kind].append(_vector_out(layer, base))
+    for layer in rasters:
+        grouped["raster"].append(_raster_out(layer, base))
+
+    return {
+        "geodeploy": {"api": base + "/api", "url": base},
+        "counts": {"portals": len(portals),
+                   **{kind: len(rows) for kind, rows in grouped.items()}},
+        "portals": [_portal_out(p, base) for p in portals],
+        "layers": grouped,
+        "catalogs": {
+            # The machine-readable surfaces, so a client can stop reading this endpoint and start
+            # reading a standard one as soon as it knows they exist.
+            "stac": base + "/api/stac",
+            "ogc_features": base + "/api/ogc",
+        },
+    }
+
+
+@router.get("/portals")
+async def public_portals(request: Request, db: AsyncSession = Depends(get_db)) -> list[dict]:
+    """Just the portals — the cheap call for a plugin's browse tree."""
+    await _require_enabled(db)
+    base = _base_url(request)
+    rows = (await db.execute(
+        select(Portal).where(Portal.published.is_(True), Portal.access_type == "public")
+        .order_by(Portal.published_at.desc().nullslast(), Portal.created_at.desc())
+    )).scalars().all()
+    return [_portal_out(p, base) for p in rows]
+
+
+# ── shaping ──────────────────────────────────────────────────────────────────────────────────────
+
+def _portal_out(portal: Portal, base: str) -> dict[str, Any]:
+    """A portal as the outside sees it: the slug, never the integer id.
+
+    The id is an internal key that the authenticated API addresses; handing it out here would
+    invite clients to build `/api/portals/{id}` URLs that 401, and it renumbers on a restore.
+    """
+    layout = json.loads(portal.layout_config) if portal.layout_config else {}
+    configs = json.loads(portal.layer_configs) if portal.layer_configs else []
+    return {
+        "slug": portal.slug,
+        "title": portal.title,
+        "description": (portal.description or "")[:500] or None,
+        "experience": (layout or {}).get("archetype") or "webmap",
+        "layer_count": len(configs),
+        "url": "{0}/portals/{1}/".format(base, portal.slug),
+        # The published bundle's own style — sources, layers, folder tree, bounds. A client can
+        # load the whole portal from this one file without a token, which is what makes "open this
+        # portal in QGIS" possible at all.
+        "style_url": "{0}/portals/{1}/style.json".format(base, portal.slug),
+        "thumbnail_url": portal.thumbnail_url,
+        "published_at": portal.published_at,
+    }
+
+
+def _vector_out(layer: VectorLayer, base: str) -> dict[str, Any]:
+    return {
+        "id": layer.uid or str(layer.id),
+        "name": layer.name,
+        "kind": "geoparquet" if layer.storage_backend == "geoparquet" else "postgis",
+        "geometry_type": layer.geometry_type,
+        "feature_count": layer.feature_count,
+        "crs": layer.crs,
+        "bbox": json.loads(layer.bbox) if layer.bbox else None,
+        "abstract": layer.abstract,
+        "keywords": _keywords(layer.keywords),
+        "license": layer.license,
+        "attribution": layer.attribution,
+        "links": _links(share_links.vector_links, layer, base),
+        "download": "{0}/api/data/vector/{1}/export".format(base, layer.uid or layer.id),
+    }
+
+
+def _raster_out(layer: RasterLayer, base: str) -> dict[str, Any]:
+    return {
+        "id": layer.uid or str(layer.id),
+        "name": layer.name,
+        "kind": "raster",
+        "band_count": layer.band_count,
+        "crs": layer.crs,
+        "bbox": json.loads(layer.bbox) if layer.bbox else None,
+        "abstract": layer.abstract,
+        "keywords": _keywords(layer.keywords),
+        "license": layer.license,
+        "attribution": layer.attribution,
+        "links": _links(share_links.raster_links, layer, base, _style(layer)),
+        "download": "{0}/api/data/raster/{1}/cog".format(base, layer.uid or layer.id),
+    }
+
+
+def _links(builder, layer, base: str, *args) -> list[dict[str, Any]]:
+    """Reuse `services/share_links.py` so this endpoint cannot drift from the Share links panel —
+    one place decides which artifact suits which tool.
+
+    Best-effort: a link builder that trips over one odd layer must not take the whole index down.
+    """
+    try:
+        return builder(layer, base, *args) or []
+    except Exception:  # noqa: BLE001 - the index is more useful incomplete than absent
+        return []
+
+
+def _keywords(raw: str | None) -> list[str]:
+    return [k.strip() for k in (raw or "").split(",") if k.strip()]
+
+
+def _style(layer: RasterLayer) -> dict:
+    """The raster's saved styling, so its tile URLs come back rendered the way the layer is meant
+    to look — an unstretched 16-bit raster tiles out black, which reads as broken."""
+    try:
+        return json.loads(layer.default_style) if layer.default_style else {}
+    except ValueError:
+        return {}
+
+
+# The origin as the CLIENT reached it (https-aware behind nginx). `share_links.request_base` is the
+# one implementation: every URL in this response is meant to be pasted somewhere else, and the
+# container's own address (`http://geodeploy-api:8000/…`) is useless to a QGIS user.
+_base_url = share_links.request_base
+
+
+def index_enabled(cfg) -> bool:
+    """Only an explicit False switches the index off.
+
+    Three ways this reads as ON, and all three are deliberate: no config row at all (a fresh
+    instance), the column NULL (an instance UPGRADED into this feature — the additive
+    `ALTER TABLE … DEFAULT TRUE` leaves the column nullable, so an older row can carry NULL), and
+    True. An upgrade must never silently unlist what an operator already published.
+    """
+    if cfg is None:
+        return True
+    return getattr(cfg, "public_index_enabled", True) is not False
+
+
+async def _require_enabled(db: AsyncSession) -> None:
+    cfg = (await db.execute(select(SetupConfig).limit(1))).scalar_one_or_none()
+    if not index_enabled(cfg):
+        raise HTTPException(404, "This instance does not publish a public index.")

--- a/api/geodeploy/routers/stac.py
+++ b/api/geodeploy/routers/stac.py
@@ -142,8 +142,9 @@ def _common_properties(layer) -> dict:
 
 
 def _ref(layer) -> str:
-    """The layer's STABLE public identifier for URLs and item ids (models.new_uid). Integer ids are
-    reused after a delete, which would silently repoint a bookmarked STAC item at another dataset."""
+    """The layer's STABLE public identifier for URLs and item ids (models.new_uid). Integer ids
+    renumber on a restore or a move between instances, which would silently repoint a bookmarked
+    STAC item at another dataset."""
     return getattr(layer, "uid", None) or str(layer.id)
 
 

--- a/api/geodeploy/schema_migrations.py
+++ b/api/geodeploy/schema_migrations.py
@@ -54,6 +54,8 @@ PG_MIGRATIONS = [
            ALTER TABLE raster_layers ALTER COLUMN file_size TYPE BIGINT;
          END IF;
        END $$""",
+    # The anonymous instance index (`GET /api/public`). Default TRUE: publishing a portal as
+    # 'public' already says it may be seen, and a geoportal that cannot be browsed is a filing
+    # cabinet. An operator who wants their public portal reachable-but-unlisted turns this off.
+    "ALTER TABLE setup_config ADD COLUMN public_index_enabled BOOLEAN DEFAULT TRUE",
 ]
-
-

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -30,7 +30,8 @@ def _link(id_, label, url, *, fmt, tools, hint, primary=False, download=False):
 def public_ref(layer) -> str:
     """The identifier a layer is addressed by in PUBLIC URLs: its stable `uid`, falling back to the
     integer id only for a row predating the uid migration. Never build a shareable URL from `id`
-    directly — ids get reused after a delete (models.new_uid)."""
+    directly: it is unique only within one layer kind and one database, so a restore or a move to
+    another instance renumbers it and every published link points somewhere else (models.new_uid)."""
     return getattr(layer, "uid", None) or str(layer.id)
 
 

--- a/api/geodeploy/tasks/export.py
+++ b/api/geodeploy/tasks/export.py
@@ -10,13 +10,17 @@ import os
 import subprocess
 import tempfile
 import zipfile
+from datetime import datetime, timezone
 
 from ..celery_app import celery_app
 from ..config import get_settings
 
 log = logging.getLogger(__name__)
 
-FEATURE_CAP = 50000          # max features per vector layer
+FEATURE_CAP = 50000          # max features per vector layer, for a BBOX clip
+# A whole-layer download is a different request: 50k would silently hand back a fraction of a
+# large layer and call it the layer. Env-tunable because the honest ceiling depends on the box.
+FULL_EXPORT_CAP = int(os.getenv("EXPORT_FEATURE_CAP", "1000000"))
 MAX_PIXELS = 16_000_000      # raster output cap (~4000x4000) — bigger selections are downsampled
 
 
@@ -31,6 +35,20 @@ def _env_sql(srid: int) -> str:
     even for a 4326 output, now that geometry may be stored natively."""
     return (f"ST_Transform(ST_MakeEnvelope(%s,%s,%s,%s,4326), {int(srid)})" if int(srid) != 4326
             else "ST_MakeEnvelope(%s,%s,%s,%s,4326)")
+
+
+def _filter(b, srid: int):
+    """`(WHERE clause, params, row cap)` for a clip — or for the whole layer when `b` is None.
+
+    A whole-layer export deliberately emits NO spatial predicate rather than a world envelope: a
+    world envelope transformed into a projected CRS is undefined near the poles, so it would drop
+    rows from exactly the datasets (national, polar) where nobody would notice.
+    """
+    if b is None:
+        return "", (), FULL_EXPORT_CAP
+    env = _env_sql(srid)
+    return (f"WHERE geom && {env} AND ST_Intersects(geom, {env})",
+            (b[0], b[1], b[2], b[3], b[0], b[1], b[2], b[3]), FEATURE_CAP)
 
 
 def _table_srid(cur, schema: str, table: str) -> int:
@@ -48,7 +66,7 @@ def _geom_out(srid: int, out_srid: int) -> str:
 
 
 def _vec_geojson(cur, schema: str, table: str, b, srid: int, out_srid: int) -> str:
-    env = _env_sql(srid)
+    where, params, cap = _filter(b, srid)
     sql = (
         "SELECT jsonb_build_object('type','FeatureCollection','features',"
         "COALESCE(jsonb_agg(f.feat), '[]'::jsonb))::text FROM ("
@@ -56,24 +74,24 @@ def _vec_geojson(cur, schema: str, table: str, b, srid: int, out_srid: int) -> s
         f"    'geometry', ST_AsGeoJSON({_geom_out(srid, out_srid)})::jsonb,"
         "    'properties', to_jsonb(t) - 'geom') AS feat"
         f'  FROM "{schema}"."{table}" t'
-        f"  WHERE geom && {env} AND ST_Intersects(geom, {env})"
-        f"  LIMIT {FEATURE_CAP}"
+        f"  {where}"
+        f"  LIMIT {cap}"
         ") f"
     )
-    cur.execute(sql, (b[0], b[1], b[2], b[3], b[0], b[1], b[2], b[3]))
+    cur.execute(sql, params)
     row = cur.fetchone()
     return row[0] if row and row[0] else '{"type":"FeatureCollection","features":[]}'
 
 
 def _vec_csv(cur, schema: str, table: str, b, srid: int, out_srid: int) -> str:
     import csv
-    env = _env_sql(srid)
+    where, params, cap = _filter(b, srid)
     sql = (
         f"SELECT (to_jsonb(t) - 'geom')::text AS props, ST_AsText({_geom_out(srid, out_srid)}) AS wkt "
         f'FROM "{schema}"."{table}" t '
-        f"WHERE geom && {env} AND ST_Intersects(geom, {env}) LIMIT {FEATURE_CAP}"
+        f"{where} LIMIT {cap}"
     )
-    cur.execute(sql, (b[0], b[1], b[2], b[3], b[0], b[1], b[2], b[3]))
+    cur.execute(sql, params)
     cols, recs = [], []
     for props_text, wkt in cur.fetchall():
         props = json.loads(props_text)
@@ -101,10 +119,12 @@ def _gpq_features(s3_key: str, b, settings, keep_native: bool = False) -> list[d
     from .raster_ingest import _get_storage_creds
     # Storage creds from SQLite (§0f) — celery env is unreliable.
     creds = _get_storage_creds()
-    fc = duckdb_engine.query_features_geojson(s3_key, list(b), FEATURE_CAP, creds, keep_native=keep_native)
+    cap = FEATURE_CAP if b is not None else FULL_EXPORT_CAP
+    fc = duckdb_engine.query_features_geojson(s3_key, list(b) if b else None, cap, creds,
+                                              keep_native=keep_native)
     feats = fc.get("features", [])
-    if keep_native:
-        return feats  # already pruned to the bbox in the file CRS; geometries are native
+    if keep_native or b is None:
+        return feats  # already pruned (or unfiltered, for a whole-layer download)
     sel = shp_box(b[0], b[1], b[2], b[3])
     kept = []
     for f in feats:
@@ -129,7 +149,9 @@ def _gpq_parquet(s3_key: str, b, settings) -> bytes:
     creds = _get_storage_creds()
     with tempfile.TemporaryDirectory() as td:
         out = os.path.join(td, "clip.parquet")
-        duckdb_engine.copy_features_parquet(s3_key, list(b), FEATURE_CAP, out, creds)
+        duckdb_engine.copy_features_parquet(s3_key, list(b) if b else None,
+                                            FEATURE_CAP if b is not None else FULL_EXPORT_CAP,
+                                            out, creds)
         with open(out, "rb") as f:
             return f.read()
 
@@ -232,15 +254,46 @@ def _clip_raster(s3_key: str, b, settings) -> bytes:
                 return memfile.read()
 
 
+def _manifest(items: list[dict], bbox: str | None, target_crs: str, files: list[str]) -> str:
+    """A plain-text note inside the zip: what was asked for, and the cap that applied.
+
+    An export that hit the row cap looks exactly like a complete one — same formats, same file
+    names, fewer rows. Saying so in the archive is the cheapest place to be honest, because the zip
+    outlives the HTTP response that produced it.
+    """
+    cap = FEATURE_CAP if bbox else FULL_EXPORT_CAP
+    lines = [
+        "GeoDeploy export",
+        "generated: {0}".format(datetime.now(timezone.utc).isoformat(timespec="seconds")),
+        "extent:    {0}".format("bbox " + bbox + " (EPSG:4326)" if bbox else "whole layer, no clip"),
+        "CRS:       {0}".format("native where the format allows" if target_crs == "native"
+                                else "EPSG:4326"),
+        "row cap:   {0} features per vector layer — a layer reaching exactly this number was "
+        "TRUNCATED".format(cap),
+        "",
+        "layers requested:",
+    ]
+    for it in items:
+        lines.append("  - {0} ({1}{2})".format(it.get("name"), it.get("type"),
+                                               ", " + it["format"] if it.get("format") else ""))
+    lines += ["", "files:"] + ["  - " + f for f in files]
+    return "\n".join(lines) + "\n"
+
+
 @celery_app.task(bind=True, name="geodeploy.tasks.export.export_bundle")
-def export_bundle(self, bbox: str, items: list[dict], target_crs: str = "4326") -> dict:
+def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "4326") -> dict:
     """items: [{type:'vector', schema, table, name, format} |
               {type:'geoparquet', s3_key, crs, name, format} | {type:'raster', s3_key, name}]
     target_crs: '4326' (default) or 'native' → GeoPackage/CSV carry the layer's native CRS (lossless);
-    GeoJSON is always EPSG:4326 (RFC 7946)."""
+    GeoJSON is always EPSG:4326 (RFC 7946).
+
+    `bbox` None = the WHOLE layer (the "download this dataset" path, added 2026-08-12) rather than a
+    map-view clip. Rasters still require one: a whole raster is already a single file and is served
+    as it stands from `GET /api/data/raster/{ref}/cog`, so re-encoding it through here would burn
+    worker time to produce a worse copy."""
     settings = get_settings()
     native = (target_crs == "native")
-    b = tuple(float(v) for v in bbox.split(","))
+    b = tuple(float(v) for v in bbox.split(",")) if bbox else None
     exports_dir = f"{settings.data_dir}/temp/exports"
     os.makedirs(exports_dir, exist_ok=True)
     out_path = os.path.join(exports_dir, f"{self.request.id}.zip")
@@ -319,6 +372,10 @@ def export_bundle(self, bbox: str, items: list[dict], target_crs: str = "4326") 
                     else:
                         z.writestr(fn(base, "geojson"), _gpq_geojson(feats))
                 else:  # raster
+                    if b is None:
+                        log.info("Whole-raster export skipped for %s — /cog serves the file itself.",
+                                 it.get("name"))
+                        continue
                     try:
                         data = _clip_raster(it["s3_key"], b, settings)
                     except ValueError:
@@ -328,6 +385,7 @@ def export_bundle(self, bbox: str, items: list[dict], target_crs: str = "4326") 
                         log.exception("Raster clip failed for %s", it.get("name"))
                         raise
                     z.writestr(fn(_safe(it.get("name")) + "_clip", "tif"), data)
+            z.writestr("MANIFEST.txt", _manifest(items, bbox, target_crs, sorted(used)))
             cur.close()
     except Exception:
         if os.path.exists(tmp_path):

--- a/api/geodeploy/tasks/export.py
+++ b/api/geodeploy/tasks/export.py
@@ -65,11 +65,14 @@ def _geom_out(srid: int, out_srid: int) -> str:
     return "geom" if int(srid) == int(out_srid) else f"ST_Transform(geom, {int(out_srid)})"
 
 
-def _vec_geojson(cur, schema: str, table: str, b, srid: int, out_srid: int) -> str:
+def _vec_geojson(cur, schema: str, table: str, b, srid: int, out_srid: int) -> tuple[str, int]:
+    """`(GeoJSON text, row count)`. The count comes back from the same query — `count(*)` over the
+    already-aggregated subquery is free, and without it a truncated export is indistinguishable
+    from a complete one."""
     where, params, cap = _filter(b, srid)
     sql = (
         "SELECT jsonb_build_object('type','FeatureCollection','features',"
-        "COALESCE(jsonb_agg(f.feat), '[]'::jsonb))::text FROM ("
+        "COALESCE(jsonb_agg(f.feat), '[]'::jsonb))::text, count(*) FROM ("
         "  SELECT jsonb_build_object('type','Feature',"
         f"    'geometry', ST_AsGeoJSON({_geom_out(srid, out_srid)})::jsonb,"
         "    'properties', to_jsonb(t) - 'geom') AS feat"
@@ -80,10 +83,12 @@ def _vec_geojson(cur, schema: str, table: str, b, srid: int, out_srid: int) -> s
     )
     cur.execute(sql, params)
     row = cur.fetchone()
-    return row[0] if row and row[0] else '{"type":"FeatureCollection","features":[]}'
+    if not (row and row[0]):
+        return '{"type":"FeatureCollection","features":[]}', 0
+    return row[0], int(row[1] or 0)
 
 
-def _vec_csv(cur, schema: str, table: str, b, srid: int, out_srid: int) -> str:
+def _vec_csv(cur, schema: str, table: str, b, srid: int, out_srid: int) -> tuple[str, int]:
     import csv
     where, params, cap = _filter(b, srid)
     sql = (
@@ -105,10 +110,10 @@ def _vec_csv(cur, schema: str, table: str, b, srid: int, out_srid: int) -> str:
     w.writeheader()
     for rec in recs:
         w.writerow(rec)
-    return buf.getvalue()
+    return buf.getvalue(), len(recs)
 
 
-def _gpq_features(s3_key: str, b, settings, keep_native: bool = False) -> list[dict]:
+def _gpq_features(s3_key: str, b, settings, keep_native: bool = False) -> tuple[list[dict], int]:
     """Clip a GeoParquet layer to the bbox via DuckDB (covering/partition-pruned viewport query).
     `keep_native=True` → geometries come back in the file's OWN CRS (lossless download); the exact
     4326-intersects refinement is then skipped (the covering prune, done in the file CRS, already
@@ -123,8 +128,12 @@ def _gpq_features(s3_key: str, b, settings, keep_native: bool = False) -> list[d
     fc = duckdb_engine.query_features_geojson(s3_key, list(b) if b else None, cap, creds,
                                               keep_native=keep_native)
     feats = fc.get("features", [])
+    # `read` is what DuckDB returned, BEFORE the refinement below. Truncation is a property of the
+    # read, not of what survived the intersects test — a clip that drops rows on purpose is not the
+    # same thing as a cap that dropped them silently.
+    read = len(feats)
     if keep_native or b is None:
-        return feats  # already pruned (or unfiltered, for a whole-layer download)
+        return feats, read  # already pruned (or unfiltered, for a whole-layer download)
     sel = shp_box(b[0], b[1], b[2], b[3])
     kept = []
     for f in feats:
@@ -133,11 +142,11 @@ def _gpq_features(s3_key: str, b, settings, keep_native: bool = False) -> list[d
                 kept.append(f)
         except Exception:  # noqa: BLE001 — a single bad geometry shouldn't kill the export
             continue
-    return kept
+    return kept, read
 
 
-def _gpq_parquet(s3_key: str, b, settings) -> bytes:
-    """Clip a GeoParquet layer to the bbox and return GeoParquet BYTES for the zip.
+def _gpq_parquet(s3_key: str, b, settings) -> tuple[bytes, int]:
+    """Clip a GeoParquet layer to the bbox and return `(GeoParquet bytes, row count)`.
 
     Written to a temp file because pyarrow writes parquet to a path, then read back — parquet is a
     random-access format with a footer, so it cannot be streamed into the archive as it is produced.
@@ -149,11 +158,11 @@ def _gpq_parquet(s3_key: str, b, settings) -> bytes:
     creds = _get_storage_creds()
     with tempfile.TemporaryDirectory() as td:
         out = os.path.join(td, "clip.parquet")
-        duckdb_engine.copy_features_parquet(s3_key, list(b) if b else None,
-                                            FEATURE_CAP if b is not None else FULL_EXPORT_CAP,
-                                            out, creds)
+        rows = duckdb_engine.copy_features_parquet(
+            s3_key, list(b) if b else None,
+            FEATURE_CAP if b is not None else FULL_EXPORT_CAP, out, creds)
         with open(out, "rb") as f:
-            return f.read()
+            return f.read(), int(rows or 0)
 
 
 def _gpq_geojson(feats: list[dict]) -> str:
@@ -254,29 +263,68 @@ def _clip_raster(s3_key: str, b, settings) -> bytes:
                 return memfile.read()
 
 
-def _manifest(items: list[dict], bbox: str | None, target_crs: str, files: list[str]) -> str:
-    """A plain-text note inside the zip: what was asked for, and the cap that applied.
+def _manifest(items: list[dict], bbox: str | None, target_crs: str, files: list[str],
+              rows: dict[str, int] | None = None,
+              truncated: list[dict] | None = None) -> str:
+    """A plain-text note inside the zip: what was asked for, what came out, and — when the cap bit —
+    how to get the data COMPLETE instead.
 
-    An export that hit the row cap looks exactly like a complete one — same formats, same file
-    names, fewer rows. Saying so in the archive is the cheapest place to be honest, because the zip
-    outlives the HTTP response that produced it.
+    An export that hit the row cap looks exactly like a complete one: same formats, same file
+    names, fewer rows. Stating the cap was never enough, because the reader still cannot tell
+    whether it applied to *them*; the per-file counts below are the part that answers that.
     """
     cap = FEATURE_CAP if bbox else FULL_EXPORT_CAP
+    rows = rows or {}
+    truncated = truncated or []
     lines = [
         "GeoDeploy export",
         "generated: {0}".format(datetime.now(timezone.utc).isoformat(timespec="seconds")),
         "extent:    {0}".format("bbox " + bbox + " (EPSG:4326)" if bbox else "whole layer, no clip"),
         "CRS:       {0}".format("native where the format allows" if target_crs == "native"
                                 else "EPSG:4326"),
-        "row cap:   {0} features per vector layer — a layer reaching exactly this number was "
-        "TRUNCATED".format(cap),
+        "row cap:   {0} features per vector layer".format(cap),
+        "complete:  {0}".format("NO — see the warning below" if truncated else "yes"),
         "",
         "layers requested:",
     ]
     for it in items:
         lines.append("  - {0} ({1}{2})".format(it.get("name"), it.get("type"),
                                                ", " + it["format"] if it.get("format") else ""))
-    lines += ["", "files:"] + ["  - " + f for f in files]
+    lines += ["", "files:"]
+    for f in files:
+        if f in rows:
+            mark = "  — TRUNCATED AT THE CAP" if any(t["file"] == f for t in truncated) else ""
+            lines.append("  - {0} — {1:,} rows{2}".format(f, rows[f], mark))
+        else:
+            lines.append("  - " + f)
+    if truncated:
+        lines += ["", "─" * 78, "WARNING — THIS EXPORT IS INCOMPLETE.", ""]
+        for t in truncated:
+            lines.append("  {0} stopped at the {1:,}-row cap.".format(t["file"], t["cap"]))
+        lines += [
+            "",
+            "The rows you have are the ones the scan reached first — not a sample, and not the",
+            "first N by any meaningful order. Do not treat this file as the dataset.",
+            "",
+            "Complete alternatives, none of which is capped:",
+            "",
+            "  1. OGC API - Features — paged, and GDAL follows the paging itself:",
+            "       ogr2ogr -f GPKG out.gpkg \"OAPIF:<instance>/api/ogc\" <layer>",
+            "     (the layer must have OGC sharing enabled)",
+            "",
+            "  2. GeoParquet layers — read the source files straight from storage:",
+            "       <instance>/api/data/vector/<uid>/parquet/manifest.json",
+            "       then each partition it lists, or in DuckDB:",
+            "       SELECT * FROM read_parquet('<instance>/api/data/vector/<uid>/parquet/*.parquet')",
+            "",
+            "  3. Ask for a smaller area: the same export with a bbox returns everything inside it",
+            "     (up to {0:,} features per layer).".format(FEATURE_CAP),
+            "",
+            "An administrator can also raise EXPORT_FEATURE_CAP, but the cap exists because the",
+            "archive is assembled in worker memory — raising it far trades a truncated download",
+            "for a failed one.",
+            "─" * 78,
+        ]
     return "\n".join(lines) + "\n"
 
 
@@ -302,6 +350,8 @@ def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "
     tmp_path = out_path + ".part"
 
     used: set[str] = set()
+    row_counts: dict[str, int] = {}
+    truncated: list[dict] = []
 
     def fn(base: str, ext: str) -> str:
         name = f"{base}.{ext}"
@@ -311,6 +361,18 @@ def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "
             i += 1
         used.add(name)
         return name
+
+    def put(z, name: str, payload, rows: int, cap: int) -> None:
+        """Write one layer's file and record what it actually contains.
+
+        `rows == cap` is the only signal available that the LIMIT bit: the query cannot report how
+        many rows it did NOT return. Equality is therefore treated as truncation, which over-warns
+        for a layer of exactly `cap` features — the harmless direction to be wrong in.
+        """
+        z.writestr(name, payload)
+        row_counts[name] = rows
+        if rows >= cap:
+            truncated.append({"file": name, "rows": rows, "cap": cap})
 
     import psycopg2
     # Build the DSN from the SQLite setup_config (authoritative) rather than env settings —
@@ -334,43 +396,50 @@ def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "
                     srid = _table_srid(cur, it["schema"], it["table"])
                     # GeoJSON is ALWAYS 4326 (RFC 7946). CSV/GPKG carry the native SRID when requested.
                     out_srid = srid if (native and fmt in ("csv", "gpkg")) else 4326
+                    cap = FEATURE_CAP if b is not None else FULL_EXPORT_CAP
                     if fmt == "csv":
-                        z.writestr(fn(base, "csv"), _vec_csv(cur, it["schema"], it["table"], b, srid, out_srid))
+                        csv_text, n = _vec_csv(cur, it["schema"], it["table"], b, srid, out_srid)
+                        put(z, fn(base, "csv"), csv_text, n, cap)
                     elif fmt == "gpkg":
-                        gj = _vec_geojson(cur, it["schema"], it["table"], b, srid, out_srid)
+                        gj, n = _vec_geojson(cur, it["schema"], it["table"], b, srid, out_srid)
                         try:
-                            z.writestr(fn(base, "gpkg"), _gj_to_gpkg(gj, base, f"EPSG:{out_srid}"))
+                            put(z, fn(base, "gpkg"), _gj_to_gpkg(gj, base, f"EPSG:{out_srid}"), n, cap)
                         except Exception as e:
                             log.warning("GeoPackage export failed for %s, falling back to GeoJSON: %s", base, e)
-                            z.writestr(fn(base, "geojson"), gj)
+                            put(z, fn(base, "geojson"), gj, n, cap)
                     else:
-                        z.writestr(fn(base, "geojson"), _vec_geojson(cur, it["schema"], it["table"], b, srid, 4326))
+                        gj, n = _vec_geojson(cur, it["schema"], it["table"], b, srid, 4326)
+                        put(z, fn(base, "geojson"), gj, n, cap)
                 elif it.get("type") == "geoparquet":
                     base = _safe(it.get("name"))
                     fmt = it.get("format", "geojson")
                     # native only for CSV/GPKG; GeoJSON must be 4326.
                     keep_native = native and fmt in ("csv", "gpkg")
+                    cap = FEATURE_CAP if b is not None else FULL_EXPORT_CAP
                     # The parquet path never needs decoded features — computing them would undo the
                     # entire point of it.
-                    feats = ([] if fmt == "geoparquet"
-                             else _gpq_features(it["s3_key"], b, settings, keep_native=keep_native))
+                    feats, n = (([], 0) if fmt == "geoparquet"
+                                else _gpq_features(it["s3_key"], b, settings,
+                                                   keep_native=keep_native))
                     out_crs = (it.get("crs") or "EPSG:4326") if keep_native else "EPSG:4326"
                     if fmt == "geoparquet":
                         # Parquet-to-parquet inside DuckDB: no GeoJSON materialisation, no shapely
                         # round-trip, geometry stays WKB in the file's own CRS. Lossless and the
                         # cheapest of the four, which is why it is offered only where it applies.
-                        z.writestr(fn(base, "parquet"), _gpq_parquet(it["s3_key"], b, settings))
+                        data, n = _gpq_parquet(it["s3_key"], b, settings)
+                        put(z, fn(base, "parquet"), data, n, cap)
                     elif fmt == "csv":
-                        z.writestr(fn(base, "csv"), _gpq_csv(feats))
+                        put(z, fn(base, "csv"), _gpq_csv(feats), n, cap)
                     elif fmt == "gpkg":
                         gj = _gpq_geojson(feats)
                         try:
-                            z.writestr(fn(base, "gpkg"), _gj_to_gpkg(gj, base, out_crs))
+                            put(z, fn(base, "gpkg"), _gj_to_gpkg(gj, base, out_crs), n, cap)
                         except Exception as e:
                             log.warning("GeoPackage export failed for %s, falling back to GeoJSON: %s", base, e)
-                            z.writestr(fn(base, "geojson"), _gpq_geojson(_gpq_features(it["s3_key"], b, settings)))
+                            again, n = _gpq_features(it["s3_key"], b, settings)
+                            put(z, fn(base, "geojson"), _gpq_geojson(again), n, cap)
                     else:
-                        z.writestr(fn(base, "geojson"), _gpq_geojson(feats))
+                        put(z, fn(base, "geojson"), _gpq_geojson(feats), n, cap)
                 else:  # raster
                     if b is None:
                         log.info("Whole-raster export skipped for %s — /cog serves the file itself.",
@@ -385,7 +454,8 @@ def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "
                         log.exception("Raster clip failed for %s", it.get("name"))
                         raise
                     z.writestr(fn(_safe(it.get("name")) + "_clip", "tif"), data)
-            z.writestr("MANIFEST.txt", _manifest(items, bbox, target_crs, sorted(used)))
+            z.writestr("MANIFEST.txt", _manifest(items, bbox, target_crs, sorted(used),
+                                                 row_counts, truncated))
             cur.close()
     except Exception:
         if os.path.exists(tmp_path):
@@ -394,5 +464,17 @@ def export_bundle(self, bbox: str | None, items: list[dict], target_crs: str = "
     finally:
         conn.close()
 
+    # The report goes down BEFORE the zip is published: readiness is the existence of {id}.zip, so
+    # writing it after would leave a window where a client can download a truncated export and be
+    # told nothing is wrong. Best-effort — a missing report must never fail an export that worked.
+    try:
+        with open(out_path[: -len(".zip")] + ".json", "w", encoding="utf-8") as f:
+            json.dump({"rows": row_counts, "truncated": truncated}, f)
+    except Exception:  # noqa: BLE001
+        log.warning("Could not write the export report for %s", self.request.id, exc_info=True)
+
     os.replace(tmp_path, out_path)  # atomic publish — only now does status flip to "ready"
-    return {"path": out_path}
+    if truncated:
+        log.warning("Export %s hit the row cap: %s", self.request.id,
+                    ", ".join(t["file"] for t in truncated))
+    return {"path": out_path, "truncated": truncated, "rows": row_counts}

--- a/api/tests/test_cors_public_surface.py
+++ b/api/tests/test_cors_public_surface.py
@@ -33,6 +33,15 @@ UID = "488c2c7f55d7"          # a real-shaped uid: hex, letters AND digits
     "/api/data/raster/12/cog",
     f"/api/data/raster/{UID}/cog",
     f"/api/data/raster/{UID}/tilejson",
+    # The anonymous instance index (2026-08-12) — a browse client reads it cross-origin.
+    "/api/public",
+    "/api/public/portals",
+    # Per-layer downloads: queued, polled and fetched from a browser like any other artifact.
+    f"/api/data/vector/{UID}/export",
+    f"/api/data/vector/{UID}/export-status/9f1c2b3a-4d5e-6f70-8192-a3b4c5d6e7f8",
+    f"/api/data/vector/{UID}/export-download/9f1c2b3a-4d5e-6f70-8192-a3b4c5d6e7f8",
+    f"/api/data/raster/{UID}/export",
+    "/api/data/raster/12/export-status/9f1c2b3a-4d5e-6f70-8192-a3b4c5d6e7f8",
     # Discovery + the standards surface.
     "/api/stac",
     "/api/stac/collections/vectors/items/vector-" + UID,
@@ -54,6 +63,8 @@ def test_public_surface_is_cors_matched(path):
     "/api/auth/login",
     "/api/backups/settings",
     "/api/ogcx",                          # must not leak past the `ogc` alternative
+    "/api/publicx",                       # nor past `public`
+    "/api/admin/public-index",            # the TOGGLE is admin-only, not part of the public surface
 ])
 def test_private_surface_is_not_wildcard_cors(path):
     """Wildcard CORS on an authenticated route would let any origin read a logged-in user's data.

--- a/api/tests/test_layer_export.py
+++ b/api/tests/test_layer_export.py
@@ -1,0 +1,185 @@
+"""Per-layer download — `POST /api/data/{kind}/{ref}/export`.
+
+Two things are being pinned. First the ACCESS rule: this serves the same data the other per-layer
+artifacts serve, so it must be readable on exactly the same terms and no wider — a private layer
+that becomes downloadable because a new route forgot the check is a data leak, not a bug report.
+
+Second the bbox rule: **omitting it means the whole layer**, and the task must then emit no spatial
+predicate at all. A world envelope would look equivalent and quietly drop rows, because
+transforming -180…180 into a projected CRS is undefined near the poles — precisely the national and
+polar datasets where nobody would notice the loss.
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from geodeploy.models import Portal, RasterLayer, User, VectorLayer
+from geodeploy.tasks import export as export_task
+
+
+class _Task:
+    id = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+async def layers(db):
+    db.add(User(id=1, email="k@e.org", name="K", role="owner", hashed_password="x", is_admin=True))
+    db.add_all([
+        VectorLayer(id=1, user_id=1, uid="aaaaaaaaaaaa", name="Roads", table_name="t1",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    is_public=True, visibility="public"),
+        VectorLayer(id=2, user_id=1, uid="bbbbbbbbbbbb", name="Parcels", table_name="t2",
+                    schema_name="gd", storage_backend="geoparquet", status="ready",
+                    is_public=True, visibility="public", s3_key="vectors/1/x/p.parquet"),
+        VectorLayer(id=3, user_id=1, uid="cccccccccccc", name="Private", table_name="t3",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    is_public=False, visibility="organization"),
+        VectorLayer(id=4, user_id=1, uid="dddddddddddd", name="Busy", table_name="t4",
+                    schema_name="gd", storage_backend="postgis", status="processing",
+                    is_public=True, visibility="public"),
+    ])
+    db.add_all([
+        RasterLayer(id=1, user_id=1, uid="eeeeeeeeeeee", name="DEM", s3_key="rasters/1/x/d.tif",
+                    status="ready", is_public=True, visibility="public"),
+        RasterLayer(id=2, user_id=1, uid="ffffffffffff", name="Secret", s3_key="rasters/1/y/s.tif",
+                    status="ready", is_public=False, visibility="organization"),
+    ])
+    await db.commit()
+    yield db
+
+
+def _queued():
+    """Patch the Celery dispatch: these tests are about the ROUTE, not the worker."""
+    return patch.object(export_task.export_bundle, "delay", return_value=_Task())
+
+
+class TestAccess:
+    async def test_a_public_layer_can_be_exported_without_a_token(self, client, layers):
+        with _queued():
+            r = await client.post("/api/data/vector/aaaaaaaaaaaa/export", json={"format": "gpkg"})
+        assert r.status_code == 202
+        assert r.json()["job_id"] == _Task.id
+
+    async def test_a_private_layer_is_not_found(self, client, layers):
+        r = await client.post("/api/data/vector/cccccccccccc/export", json={})
+        assert r.status_code == 404
+
+    async def test_a_layer_still_ingesting_is_not_exportable(self, client, layers):
+        r = await client.post("/api/data/vector/dddddddddddd/export", json={})
+        assert r.status_code == 404
+
+    async def test_a_layer_shown_by_a_published_portal_is_exportable(self, client, db, layers):
+        """Same rule as pmtiles/features: a published portal makes its layers readable."""
+        db.add(Portal(id=1, user_id=1, title="P", slug="p", published=True, access_type="public",
+                      template_id="minimal",
+                      layer_configs=json.dumps([{"layer_id": 3, "layer_type": "vector"}])))
+        await db.commit()
+        from geodeploy.routers.data import vector as vector_router
+        vector_router.invalidate_public_layers()
+        with _queued():
+            r = await client.post("/api/data/vector/cccccccccccc/export", json={})
+        assert r.status_code == 202
+
+    async def test_private_raster(self, client, layers):
+        assert (await client.post("/api/data/raster/ffffffffffff/export",
+                                  json={"bbox": "1,1,2,2"})).status_code == 404
+
+
+class TestWhatIsQueued:
+    async def test_no_bbox_means_the_whole_layer(self, client, layers):
+        with _queued() as delay:
+            await client.post("/api/data/vector/aaaaaaaaaaaa/export", json={"format": "gpkg"})
+        bbox, items = delay.call_args.args[0], delay.call_args.args[1]
+        assert bbox is None                       # NOT a world envelope — see the module docstring
+        assert items == [{"type": "vector", "schema": "gd", "table": "t1", "name": "Roads",
+                          "format": "gpkg"}]
+
+    async def test_a_bbox_is_passed_through(self, client, layers):
+        with _queued() as delay:
+            await client.post("/api/data/vector/aaaaaaaaaaaa/export",
+                              json={"format": "csv", "bbox": "11,55,12,56"})
+        assert delay.call_args.args[0] == "11,55,12,56"
+
+    async def test_a_geoparquet_layer_exports_from_its_file(self, client, layers):
+        with _queued() as delay:
+            await client.post("/api/data/vector/bbbbbbbbbbbb/export",
+                              json={"format": "geoparquet"})
+        item = delay.call_args.args[1][0]
+        assert item["type"] == "geoparquet" and item["s3_key"] == "vectors/1/x/p.parquet"
+
+    async def test_native_crs_is_offered(self, client, layers):
+        with _queued() as delay:
+            await client.post("/api/data/vector/bbbbbbbbbbbb/export",
+                              json={"format": "gpkg", "target_crs": "native"})
+        assert delay.call_args.kwargs["target_crs"] == "native"
+
+
+class TestArgumentChecking:
+    @pytest.mark.parametrize("bbox", ["1,2,3", "a,b,c,d", "5,5,1,1", "1,1,1,1"])
+    async def test_a_bad_bbox_is_refused_before_the_worker(self, client, layers, bbox):
+        r = await client.post("/api/data/vector/aaaaaaaaaaaa/export", json={"bbox": bbox})
+        assert r.status_code == 400
+
+    async def test_an_unknown_format(self, client, layers):
+        r = await client.post("/api/data/vector/aaaaaaaaaaaa/export", json={"format": "shp"})
+        assert r.status_code == 400
+        assert "gpkg" in r.json()["detail"]
+
+    async def test_geoparquet_is_refused_for_a_postgis_layer_with_a_reason(self, client, layers):
+        r = await client.post("/api/data/vector/aaaaaaaaaaaa/export",
+                              json={"format": "geoparquet"})
+        assert r.status_code == 400
+        assert "PostGIS" in r.json()["detail"]
+
+    async def test_a_raster_export_requires_a_bbox_and_names_the_alternative(self, client, layers):
+        """The whole raster is already one file; /cog streams it. Say so rather than burn a worker."""
+        r = await client.post("/api/data/raster/eeeeeeeeeeee/export", json={})
+        assert r.status_code == 400
+        assert "/cog" in r.json()["detail"]
+
+    async def test_a_raster_clip_is_accepted(self, client, layers):
+        with _queued() as delay:
+            r = await client.post("/api/data/raster/eeeeeeeeeeee/export",
+                                  json={"bbox": "11,55,12,56"})
+        assert r.status_code == 202
+        assert delay.call_args.args[1][0]["type"] == "raster"
+
+    async def test_an_invalid_job_id_cannot_traverse_the_filesystem(self, client, layers):
+        """The id becomes a path segment; a traversal here would serve any file the API can read."""
+        r = await client.get("/api/data/vector/aaaaaaaaaaaa/export-status/..%2F..%2Fetc%2Fpasswd")
+        assert r.status_code in (400, 404)
+
+    async def test_downloading_an_export_that_does_not_exist(self, client, layers):
+        r = await client.get(
+            "/api/data/vector/aaaaaaaaaaaa/export-download/" + _Task.id)
+        assert r.status_code == 404
+
+
+class TestTheTaskItself:
+    """The SQL the whole-layer path builds. Pinned here because it is the difference between
+    "downloaded the dataset" and "downloaded the first 50,000 rows of it"."""
+
+    def test_no_bbox_emits_no_spatial_filter_and_the_larger_cap(self):
+        where, params, cap = export_task._filter(None, 3006)
+        assert where == "" and params == ()
+        assert cap == export_task.FULL_EXPORT_CAP > export_task.FEATURE_CAP
+
+    def test_a_bbox_still_filters_in_the_table_srid_with_the_clip_cap(self):
+        where, params, cap = export_task._filter((11, 55, 12, 56), 3006)
+        assert "ST_Transform" in where and "geom &&" in where
+        assert len(params) == 8 and cap == export_task.FEATURE_CAP
+
+    def test_the_manifest_says_which_cap_applied(self):
+        text = export_task._manifest([{"name": "Roads", "type": "vector", "format": "gpkg"}],
+                                     None, "4326", ["roads.gpkg"])
+        assert "whole layer, no clip" in text
+        assert str(export_task.FULL_EXPORT_CAP) in text
+        assert "TRUNCATED" in text          # an export that hit the cap must say so in the zip
+        assert "roads.gpkg" in text
+
+    def test_the_manifest_records_a_clip(self):
+        text = export_task._manifest([{"name": "Roads", "type": "vector", "format": "csv"}],
+                                     "11,55,12,56", "native", ["roads.csv"])
+        assert "bbox 11,55,12,56" in text
+        assert "native" in text

--- a/api/tests/test_layer_export.py
+++ b/api/tests/test_layer_export.py
@@ -172,14 +172,87 @@ class TestTheTaskItself:
 
     def test_the_manifest_says_which_cap_applied(self):
         text = export_task._manifest([{"name": "Roads", "type": "vector", "format": "gpkg"}],
-                                     None, "4326", ["roads.gpkg"])
+                                     None, "4326", ["roads.gpkg"], {"roads.gpkg": 12480}, [])
         assert "whole layer, no clip" in text
         assert str(export_task.FULL_EXPORT_CAP) in text
-        assert "TRUNCATED" in text          # an export that hit the cap must say so in the zip
-        assert "roads.gpkg" in text
+        assert "complete:  yes" in text
+        assert "roads.gpkg — 12,480 rows" in text
+        assert "TRUNCATED" not in text       # nothing was cut: do not cry wolf
 
     def test_the_manifest_records_a_clip(self):
         text = export_task._manifest([{"name": "Roads", "type": "vector", "format": "csv"}],
                                      "11,55,12,56", "native", ["roads.csv"])
         assert "bbox 11,55,12,56" in text
         assert "native" in text
+
+
+class TestTruncationIsVisible:
+    """A capped export has the same file names and formats as a complete one, and fewer rows. The
+    ONLY thing separating "your data" from "some of your data" is being told."""
+
+    def _cut(self):
+        cap = export_task.FULL_EXPORT_CAP
+        return export_task._manifest(
+            [{"name": "Parcels", "type": "geoparquet", "format": "geoparquet"}],
+            None, "4326", ["parcels.parquet"], {"parcels.parquet": cap},
+            [{"file": "parcels.parquet", "rows": cap, "cap": cap}])
+
+    def test_the_manifest_says_the_export_is_incomplete(self):
+        text = self._cut()
+        assert "complete:  NO" in text
+        assert "WARNING — THIS EXPORT IS INCOMPLETE." in text
+        assert "parcels.parquet — 1,000,000 rows  — TRUNCATED AT THE CAP" in text
+
+    def test_it_names_the_uncapped_alternatives(self):
+        """A warning that leaves you stuck is only half of one."""
+        text = self._cut()
+        assert "ogr2ogr" in text and "OAPIF:" in text          # paged, any size
+        assert "parquet/manifest.json" in text                 # the stored files
+        assert "read_parquet" in text
+        assert "--bbox" in text or "bbox" in text
+        assert "EXPORT_FEATURE_CAP" in text                    # and the operator's lever
+
+    def test_a_complete_export_carries_none_of_that(self):
+        text = export_task._manifest([{"name": "Roads", "type": "vector", "format": "gpkg"}],
+                                     None, "4326", ["roads.gpkg"], {"roads.gpkg": 3}, [])
+        assert "INCOMPLETE" not in text and "ogr2ogr" not in text
+
+    @staticmethod
+    def _finished_export(tmp_path, monkeypatch, report=None):
+        """A ready export on disk, with the data dir pointed at tmp_path.
+
+        `data_dir` is a read-only property, so the settings OBJECT cannot be patched; the route's
+        own `get_settings` is the seam.
+        """
+        from types import SimpleNamespace
+
+        from geodeploy.routers.data import exports as exports_router
+        exports = tmp_path / "temp" / "exports"
+        exports.mkdir(parents=True)
+        (exports / (_Task.id + ".zip")).write_bytes(b"PK")
+        if report is not None:
+            (exports / (_Task.id + ".json")).write_text(json.dumps(report))
+        monkeypatch.setattr(exports_router, "get_settings",
+                            lambda: SimpleNamespace(data_dir=str(tmp_path)))
+
+    async def test_the_status_route_reports_it(self, client, layers, tmp_path, monkeypatch):
+        """So a client knows BEFORE it hands the file to someone — the zip's own manifest is only
+        read by whoever opens the zip."""
+        self._finished_export(tmp_path, monkeypatch, {
+            "rows": {"parcels.parquet": 1000000},
+            "truncated": [{"file": "parcels.parquet", "rows": 1000000, "cap": 1000000}]})
+
+        r = await client.get("/api/data/vector/aaaaaaaaaaaa/export-status/" + _Task.id)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ready"
+        assert body["truncated"][0]["file"] == "parcels.parquet"
+        assert body["truncated"][0]["cap"] == 1000000
+
+    async def test_an_export_with_no_report_reads_as_complete(self, client, layers, tmp_path,
+                                                              monkeypatch):
+        """Zips built before the report existed, and every export that was not truncated."""
+        self._finished_export(tmp_path, monkeypatch)
+
+        r = await client.get("/api/data/vector/aaaaaaaaaaaa/export-status/" + _Task.id)
+        assert r.json() == {"status": "ready", "truncated": []}

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -1,0 +1,212 @@
+"""`GET /api/public` — the anonymous index a plugin starts from.
+
+The thing worth pinning is not the shape of the JSON but the EXPOSURE RULE: this endpoint is the
+one place that turns "reachable by anyone holding the link" into "findable by anyone at all", so a
+portal or a layer appearing here that should not is a disclosure, not a cosmetic bug.
+"""
+import json
+
+import pytest
+from jose import jwt
+
+from geodeploy.config import get_settings
+from geodeploy.models import Portal, RasterLayer, SetupConfig, User, VectorLayer
+from geodeploy.routers.public import index_enabled
+
+
+def _as(user_id: int) -> dict:
+    """Session headers for a seeded user — admin routes reject API tokens by design."""
+    token = jwt.encode({"sub": str(user_id)}, get_settings().secret_key, algorithm="HS256")
+    return {"Authorization": "Bearer " + token}
+
+
+@pytest.fixture
+async def seeded(db):
+    """One of everything, public and not: what the index must include and what it must not."""
+    db.add(User(id=1, email="k@example.org", name="Koffi", role="owner",
+                hashed_password="x", is_admin=True))
+    db.add_all([
+        # Public portal — listed.
+        Portal(id=1, user_id=1, title="Open portal", slug="open-portal", published=True,
+               access_type="public", template_id="minimal", layer_configs=json.dumps(
+                   [{"layer_id": 1, "layer_type": "vector"}]),
+               layout_config=json.dumps({"archetype": "catalog"})),
+        # Published but NOT public — must never appear.
+        Portal(id=2, user_id=1, title="Members only", slug="members-only", published=True,
+               access_type="organization", template_id="minimal", layer_configs="[]"),
+        Portal(id=3, user_id=1, title="Password gated", slug="pw", published=True,
+               access_type="password", template_id="minimal", layer_configs="[]"),
+        Portal(id=4, user_id=1, title="Owner only", slug="owner-only", published=True,
+               access_type="owner", template_id="minimal", layer_configs="[]"),
+        # Public but UNPUBLISHED — a draft is not a portal anyone can open.
+        Portal(id=5, user_id=1, title="Draft", slug="draft", published=False,
+               access_type="public", template_id="minimal", layer_configs="[]"),
+    ])
+    db.add_all([
+        VectorLayer(id=1, user_id=1, uid="aaaaaaaaaaaa", name="Roads", table_name="t1",
+                    schema_name="gd", storage_backend="postgis", status="ready", is_public=True,
+                    visibility="public", geometry_type="linestring", feature_count=12,
+                    crs="EPSG:4326", bbox=json.dumps([11.0, 55.0, 24.0, 69.0]),
+                    keywords="transport, national", license="CC-BY-4.0"),
+        VectorLayer(id=2, user_id=1, uid="bbbbbbbbbbbb", name="Parcels", table_name="t2",
+                    schema_name="gd", storage_backend="geoparquet", status="ready", is_public=True,
+                    visibility="public", s3_key="vectors/1/x/parcels.parquet"),
+        # Not public, and not ready: neither may be listed.
+        VectorLayer(id=3, user_id=1, uid="cccccccccccc", name="Internal", table_name="t3",
+                    schema_name="gd", storage_backend="postgis", status="ready", is_public=False,
+                    visibility="organization"),
+        VectorLayer(id=4, user_id=1, uid="dddddddddddd", name="Still ingesting", table_name="t4",
+                    schema_name="gd", storage_backend="postgis", status="processing",
+                    is_public=True, visibility="public"),
+    ])
+    db.add(RasterLayer(id=1, user_id=1, uid="eeeeeeeeeeee", name="Elevation",
+                       s3_key="rasters/1/x/dem.tif", status="ready", is_public=True,
+                       visibility="public", band_count=1, crs="EPSG:3006"))
+    await db.commit()
+    yield db
+
+
+class TestExposure:
+    async def test_only_published_public_portals_are_listed(self, client, seeded):
+        body = (await client.get("/api/public")).json()
+        assert [p["slug"] for p in body["portals"]] == ["open-portal"]
+
+    async def test_only_public_ready_layers_are_listed(self, client, seeded):
+        body = (await client.get("/api/public")).json()
+        names = {l["name"] for group in body["layers"].values() for l in group}
+        assert names == {"Roads", "Parcels", "Elevation"}
+        assert "Internal" not in names          # organization-visibility layer
+        assert "Still ingesting" not in names   # not ready
+
+    async def test_no_credentials_are_needed(self, client, seeded):
+        response = await client.get("/api/public")
+        assert response.status_code == 200
+        assert "authorization" not in {k.lower() for k in response.request.headers}
+
+
+class TestGrouping:
+    async def test_layers_are_grouped_by_storage_kind(self, client, seeded):
+        body = (await client.get("/api/public")).json()
+        assert [l["name"] for l in body["layers"]["postgis"]] == ["Roads"]
+        assert [l["name"] for l in body["layers"]["geoparquet"]] == ["Parcels"]
+        assert [l["name"] for l in body["layers"]["raster"]] == ["Elevation"]
+
+    async def test_the_three_groups_always_exist_even_when_empty(self, client, db):
+        """A client renders three sections; a missing key would make it special-case emptiness."""
+        body = (await client.get("/api/public")).json()
+        assert set(body["layers"]) == {"raster", "postgis", "geoparquet"}
+        assert body["counts"] == {"portals": 0, "raster": 0, "postgis": 0, "geoparquet": 0}
+
+    async def test_layer_entries_carry_what_a_browser_needs(self, client, seeded):
+        body = (await client.get("/api/public")).json()
+        roads = body["layers"]["postgis"][0]
+        assert roads["id"] == "aaaaaaaaaaaa"          # the STABLE uid, never the row id
+        assert roads["bbox"] == [11.0, 55.0, 24.0, 69.0]
+        assert roads["keywords"] == ["transport", "national"]
+        assert roads["license"] == "CC-BY-4.0"
+        assert roads["links"], "share links should be reused, not rebuilt here"
+        assert roads["download"].endswith("/api/data/vector/aaaaaaaaaaaa/export")
+
+
+class TestPortalEntries:
+    async def test_a_portal_is_addressed_by_slug_not_id(self, client, seeded):
+        portal = (await client.get("/api/public")).json()["portals"][0]
+        assert "id" not in portal
+        assert portal["url"].endswith("/portals/open-portal/")
+
+    async def test_the_style_url_is_offered_so_a_client_can_load_the_whole_portal(self, client,
+                                                                                  seeded):
+        """`style.json` in the published bundle is the machine-readable portal — sources, layers,
+        folder tree, bounds. Without it a plugin can only open a portal in a browser."""
+        portal = (await client.get("/api/public")).json()["portals"][0]
+        assert portal["style_url"].endswith("/portals/open-portal/style.json")
+
+    async def test_the_experience_and_layer_count_come_through(self, client, seeded):
+        portal = (await client.get("/api/public")).json()["portals"][0]
+        assert portal["experience"] == "catalog"
+        assert portal["layer_count"] == 1
+
+    async def test_portals_only_endpoint_matches(self, client, seeded):
+        full = (await client.get("/api/public")).json()["portals"]
+        just = (await client.get("/api/public/portals")).json()
+        assert just == full
+
+
+class TestUrls:
+    async def test_urls_use_the_host_the_client_reached_not_the_container(self, client, seeded):
+        """Every URL here is meant to be pasted elsewhere, so it must carry the public origin."""
+        body = (await client.get("/api/public",
+                                 headers={"host": "geo.example.org",
+                                          "x-forwarded-proto": "https"})).json()
+        assert body["geodeploy"]["url"] == "https://geo.example.org"
+        assert body["portals"][0]["url"].startswith("https://geo.example.org/")
+        assert body["catalogs"]["stac"] == "https://geo.example.org/api/stac"
+        assert body["catalogs"]["ogc_features"] == "https://geo.example.org/api/ogc"
+
+
+class TestTheToggle:
+    async def test_it_is_on_by_default(self, client, db):
+        db.add(SetupConfig(id=1, completed=True))
+        await db.commit()
+        assert (await client.get("/api/public")).status_code == 200
+
+    async def test_off_means_404_not_an_empty_list(self, client, db, seeded):
+        """A client must be able to tell "this instance publishes no index" from "nothing is
+        published" — the first is a decision, the second is a state."""
+        db.add(SetupConfig(id=1, completed=True, public_index_enabled=False))
+        await db.commit()
+        response = await client.get("/api/public")
+        assert response.status_code == 404
+        assert (await client.get("/api/public/portals")).status_code == 404
+
+    async def test_turning_it_off_does_not_hide_the_portal_itself(self, client, db, seeded):
+        """Discoverability, not access: the gate still says a public portal may be served."""
+        db.add(SetupConfig(id=1, completed=True, public_index_enabled=False))
+        await db.commit()
+        gate = await client.get("/api/portals/open-portal/gate")
+        assert gate.status_code == 200
+
+    def test_only_an_explicit_false_switches_it_off(self):
+        """An UPGRADED instance carries NULL here — the additive ALTER leaves the column nullable —
+        and must stay listed. Nothing an operator already published may go dark on an update."""
+        class Cfg:
+            public_index_enabled = None
+
+        class Older:               # a row from before the column existed at all
+            pass
+
+        assert index_enabled(None) is True          # no config row: fresh instance
+        assert index_enabled(Cfg()) is True         # NULL from the migration
+        assert index_enabled(Older()) is True       # attribute absent
+        Cfg.public_index_enabled = True
+        assert index_enabled(Cfg()) is True
+        Cfg.public_index_enabled = False
+        assert index_enabled(Cfg()) is False
+
+
+class TestAdminToggleEndpoint:
+    async def test_it_is_admin_only(self, client, seeded):
+        assert (await client.get("/api/admin/public-index")).status_code in (401, 403)
+        assert (await client.put("/api/admin/public-index",
+                                 json={"enabled": False})).status_code in (401, 403)
+
+    async def test_round_trip(self, client, db, seeded):
+        headers = _as(1)
+        assert (await client.get("/api/admin/public-index",
+                                 headers=headers)).json() == {"enabled": True}
+
+        await client.put("/api/admin/public-index", json={"enabled": False}, headers=headers)
+        assert (await client.get("/api/admin/public-index",
+                                 headers=headers)).json() == {"enabled": False}
+        assert (await client.get("/api/public")).status_code == 404
+
+        await client.put("/api/admin/public-index", json={"enabled": True}, headers=headers)
+        assert (await client.get("/api/public")).status_code == 200
+
+    async def test_the_change_is_audited(self, client, db, seeded):
+        headers = _as(1)
+        await client.put("/api/admin/public-index", json={"enabled": False}, headers=headers)
+        rows = (await client.get("/api/audit?action=admin.public_index",
+                                 headers=headers)).json()
+        assert rows["total"] >= 1
+        assert rows["items"][0]["detail"] == {"enabled": False}

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Koffi Dodji Noumonvi
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cli/MANIFEST.in
+++ b/cli/MANIFEST.in
@@ -1,0 +1,6 @@
+# The sdist should be enough to run the tests from, so a packager or a distro can verify the
+# release rather than take the wheel on trust. LICENSE, NOTICE and PYPI.md come in automatically
+# from the metadata; the tests do not.
+recursive-include tests *.py
+include README.md
+global-exclude __pycache__/* *.py[cod]

--- a/cli/NOTICE
+++ b/cli/NOTICE
@@ -1,0 +1,11 @@
+GeoDeploy
+Copyright 2026 Koffi Dodji Noumonvi
+
+This product includes software developed for the GeoDeploy project
+(https://github.com/bravemaster3/GeoDeploy).
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+
+GeoDeploy runs alongside third-party services (PostGIS, MinIO, Martin, TiTiler,
+Redis, nginx) and bundles third-party libraries, each under its own licence.
+Those services run as separate processes; their licences are unaffected by this one.

--- a/cli/PYPI.md
+++ b/cli/PYPI.md
@@ -1,0 +1,64 @@
+# geodeploy
+
+**Command-line client and Python API for [GeoDeploy](https://github.com/bravemaster3/GeoDeploy)** —
+the self-hosted spatial data platform and geoportal builder.
+
+Upload data, style it, build a portal and publish it, without opening a browser:
+
+```bash
+pip install geodeploy
+
+geodeploy login https://geodeploy.example.org --token gdp_…
+geodeploy upload roads.gpkg sites.csv dem.tif --wait
+geodeploy portals create "Field sites 2026" --publish
+```
+
+**No dependencies. Python 3.9+.** Every request goes through the standard library, so installing
+this pulls in nothing else — and a QGIS plugin can vendor the same client without asking anyone to
+pip-install into QGIS.
+
+## What it covers
+
+- **Uploads** — shapefile, GeoPackage, GeoJSON, CSV (X/Y or WKT), GeoParquet, GeoTIFF. Many files
+  in one command; the route is chosen per file, and anything over 48 MB goes direct to object
+  storage in parallel presigned parts, so a multi-gigabyte upload survives a proxy that caps
+  request bodies.
+- **Layers** — list, inspect, rename, share (STAC / OGC API - Features opt-in), share links per
+  tool, download, delete, restart a stalled ingest.
+- **Symbology** — colour, opacity, outlines, dashes, markers, raster colormaps and stretches, plus
+  data-driven styling: `--color-field pop --classify jenks --classes 6 --ramp magma`, proportional
+  size, and attribute-driven 3D. Classification is computed by the instance, with the same code the
+  portal editor uses, so the CLI and the editor can never disagree about a class.
+- **Portals** — create (web map, story map or catalog), arrange and style layers, folders, About
+  page, assets, access tiers, publish, and a whole-configuration JSON round trip for version
+  control.
+- **Everything else** — external WMS/XYZ/WFS services, registering data already in PostGIS or the
+  bucket, the public STAC and OGC API - Features catalog, ingest jobs, users, and instance
+  administration (health, services, updates, backups, activity log).
+
+Every command takes `--json`, where stdout is exactly one JSON document, and exit codes distinguish
+authentication (3) from network (4) from server (5) so a scheduled job can alert on the right thing.
+
+## As a library
+
+```python
+from geodeploy import Client
+
+gd = Client("https://geodeploy.example.org", token="gdp_…")
+result = gd.uploads.upload("roads.gpkg", wait=True)
+portal = gd.portals.create("Roads")
+gd.portals.add_layer(portal["id"], result.layer_id, "vector", {"color": "#e11d48"})
+gd.portals.publish(portal["id"])
+```
+
+Typed exceptions (`AuthError`, `PermissionError_`, `NotFoundError`, `ValidationError`,
+`ServerError`, `TransportError`, `JobFailed`), progress callbacks and cancellation on uploads, and a
+swappable transport so a desktop application can route requests through its own network stack.
+
+## Documentation
+
+Full guide: **<https://docs-geodeploy.kndev.org/cli/>**
+
+Source and issues: **<https://github.com/bravemaster3/GeoDeploy>**
+
+Licensed under the Apache License 2.0.

--- a/cli/PYPI.md
+++ b/cli/PYPI.md
@@ -17,6 +17,10 @@ geodeploy portals create "Field sites 2026" --publish
 this pulls in nothing else — and a QGIS plugin can vendor the same client without asking anyone to
 pip-install into QGIS.
 
+If your shell cannot find `geodeploy` after installing, pip's scripts directory is not on your
+`PATH` — `python -m geodeploy` works regardless, and `pipx install geodeploy` or a virtual
+environment avoids it.
+
 ## What it covers
 
 - **Uploads** — shapefile, GeoPackage, GeoJSON, CSV (X/Y or WKT), GeoParquet, GeoTIFF. Many files

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,7 +29,11 @@ User documentation is `docs/cli.md`; this file is the technical note.
 - `uploads.py` — the routing table (below) plus both transports: multipart-through-the-API, and
   presign/chunked direct-to-storage with per-part retry and abort-on-failure.
 - `layers.py` — the two layer kinds, and `Layers.resolve` (id | uid | `vector-3` | name; ambiguity
-  raises rather than guessing).
+  raises rather than guessing — including a **bare integer that exists in both kinds**, since
+  vector and raster ids are separate sequences and "1" is routinely two different layers).
+  `download_dataset()` pulls a prepared GeoParquet layer's manifest + every partition straight from
+  storage: complete, lossless and **not subject to the export row cap**, which is why
+  `layers download` prefers it over queueing an export for those layers.
 - `portals.py` — portal CRUD and `layer_configs` surgery. `layer_configs[0]` = top of the list =
   drawn on top. `editable_config()` drops server-owned fields before a round-trip PUT.
 - `styles.py` — the style vocabulary of `api/geodeploy/services/symbology.py`, assembled from plain
@@ -54,7 +58,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 284 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 297 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships
@@ -103,6 +107,24 @@ python -m twine upload dist/*
 
 `dist/` and `build/` are git-ignored. The sdist carries the tests, so the release can be verified
 from source rather than trusted.
+
+## The row cap, and the two ways around it
+
+A **built** export (`gpkg`/`csv`/`geojson`, or anything clipped) stops at `FULL_EXPORT_CAP`
+(1,000,000 features, env-tunable) for a whole layer and `FEATURE_CAP` (50,000) for a bbox clip,
+because the worker assembles the archive in memory. The failure mode this creates is not the cap —
+it is that a truncated export has the same names and formats as a complete one. So:
+
+- the task records the row count of every file it writes, marks the ones that reached the cap in
+  `MANIFEST.txt` (with the uncapped alternatives spelled out), and writes `{job_id}.json` beside
+  the zip;
+- `GET …/export-status/{job_id}` reports `truncated: [{file, rows, cap}]` from that file;
+- `layers download` prints `INCOMPLETE`, names the alternative, and **exits non-zero**.
+
+The uncapped paths, which the CLI prefers automatically where it can: a prepared **GeoParquet**
+layer's own partition files (`download_dataset`, no worker involved), and **OGC API - Features**
+paging for PostGIS (`ogr2ogr -f GPKG out.gpkg "OAPIF:<instance>/api/ogc" <layer>` — not wrapped by
+the CLI yet; see below).
 
 ## Current status & known issues
 - `geodeploy browse` and `layers download` depend on API endpoints added in the same branch

--- a/cli/README.md
+++ b/cli/README.md
@@ -54,7 +54,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 281 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 284 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,7 +58,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 297 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 298 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/README.md
+++ b/cli/README.md
@@ -95,7 +95,8 @@ both. The version is single-sourced from `geodeploy/__init__.py` (`dynamic = ["v
 repo convention in CLAUDE.md), which is not what someone landing on PyPI wants to read; `PYPI.md` is
 the user-facing front page. Keep both current.
 
-The name `geodeploy` was unregistered on PyPI as of 2026-08-12. To cut a release:
+The name `geodeploy` was unregistered on PyPI as of 2026-08-13 (re-check immediately before the
+first upload — anyone can claim it). To cut a release:
 
 ```bash
 cd cli
@@ -107,6 +108,12 @@ python -m twine upload dist/*
 
 `dist/` and `build/` are git-ignored. The sdist carries the tests, so the release can be verified
 from source rather than trusted.
+
+**Versioning.** The CLI's number tracks the GeoDeploy release it ships with, so it must not claim a
+release that has not happened: the first upload is `1.3.0b1`, and `1.3.0` follows when v1.3 tags. A
+version on PyPI can never be re-uploaded — deleting it does not free the number — so a pre-release
+is the only way to test the real index without spending the one that matters. `pip install
+geodeploy` skips pre-releases unless asked with `--pre`.
 
 ## The row cap, and the two ways around it
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -33,7 +33,13 @@ User documentation is `docs/cli.md`; this file is the technical note.
   arguments. **Classification maths is NOT reimplemented**: `classify()` reads
   `GET /data/vector/{ref}/field-stats`, so the CLI cannot disagree with the editor about which class
   a feature is in.
-- `jobs.py`, `sources.py`, `imports.py`, `admin.py`, `catalog.py`, `errors.py`.
+- `catalog.py` — the public surfaces, including `public()` (the instance index behind
+  `geodeploy browse`) and `portal_style()`, which reads a published portal's own `style.json`.
+- `jobs.py`, `sources.py`, `imports.py`, `admin.py`, `errors.py`.
+
+`Layers.resolve_public()` is the anonymous twin of `resolve()`: with no credential a layer is looked
+up in the public index, so `geodeploy --url … layers download roads` works by NAME for someone with
+no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a built export.
 
 **The CLI** (`geodeploy/cli/`) — the only part allowed to print:
 - `main.py` — argparse root, `Context` (formatter + lazy client), and the single place exceptions
@@ -41,10 +47,11 @@ User documentation is `docs/cli.md`; this file is the technical note.
 - `output.py` — `Formatter` (stdout = the answer, stderr = commentary, `--json` = one document),
   tables, progress bar, `EXIT_*` constants.
 - `commands/` — one module per group (`auth`, `upload`, `layers`, `portals`, `sources`, `imports`,
-  `jobs`, `catalog`, `admin`), each with `register(subparsers)`. `_common.py` holds the styling
-  flags, shared by the three commands that take them.
+  `jobs`, `catalog`, `admin`, `browse`), each with `register(subparsers)`. `_common.py` holds the
+  styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
+  which decides between the authenticated list and the public index.
 
-`tests/` — 243 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 259 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships
@@ -95,6 +102,9 @@ python -m twine upload dist/*
 from source rather than trusted.
 
 ## Current status & known issues
+- `geodeploy browse` and `layers download` depend on API endpoints added in the same branch
+  (`/api/public`, `/data/{kind}/{ref}/export`). An older instance answers 404 for both; the browse
+  command says so, but `layers download` for a built format will simply fail against one.
 - Built 2026-08-12 on branch `feat/cli`; **not yet exercised against a live instance** — every test
   runs against the in-repo fake. First real run should be `upload --dry-run`, then a small upload,
   then a portal round trip.
@@ -109,4 +119,5 @@ from source rather than trusted.
   `cancel`, typed errors, no printing) are in place and tested.
 
 ## Last updated
-2026-08-12 (created — packaged CLI + Python client, replacing `examples/geodeploy_cli.py`)
+2026-08-12 (created — packaged CLI + Python client, replacing `examples/geodeploy_cli.py`; then
+`browse` + anonymous layer download on top of the new `/api/public` and per-layer export endpoints)

--- a/cli/README.md
+++ b/cli/README.md
@@ -51,7 +51,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 259 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 263 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,112 @@
+# cli/
+
+## Purpose
+The packaged **`geodeploy`** command-line client **and** the Python API client it is built on — the
+headless half of the product (roadmap v1.3). Two audiences, one package: a person or CI job at a
+shell, and the **QGIS plugin** (`E-05`), which imports `geodeploy.client` directly rather than
+re-implementing HTTP against the same endpoints.
+
+User documentation is `docs/cli.md`; this file is the technical note.
+
+## Contents
+
+**The library** (`geodeploy/`) — never prints, never exits, raises typed errors:
+- `client.py` — `Client`: URL/auth resolution, request plumbing, error mapping, and the namespaces
+  (`gd.vector`, `gd.raster`, `gd.layers`, `gd.portals`, `gd.sources`, `gd.imports`, `gd.jobs`,
+  `gd.uploads`, `gd.admin`, `gd.users`, `gd.catalog`). `absolute()` resolves the **relative
+  `/s3/…` presigned URLs** a managed MinIO returns.
+- `transport.py` — stdlib HTTP. `UrllibTransport` (retries only connection failures and 502/503/504,
+  and **never** a streamed body — the file object is already partly consumed), `MultipartBody`
+  (form-data streamed from disk with a real Content-Length), `ProgressReader`. Anything with
+  `send(Request) -> Response` can replace it; that seam is for QGIS's `QgsNetworkAccessManager`.
+- `config.py` — profiles + credentials. **Tokens never enter `config.json`**: OS keyring when there
+  is one, else `credentials.json` at 0600 in a 0700 directory, written atomically. `normalize_url`
+  collapses `…/api`, trailing slashes and a bare host to one origin, so a credential saved under one
+  spelling is found under another. `resolve()` = flag → env → profile, for URL and token separately.
+- `uploads.py` — the routing table (below) plus both transports: multipart-through-the-API, and
+  presign/chunked direct-to-storage with per-part retry and abort-on-failure.
+- `layers.py` — the two layer kinds, and `Layers.resolve` (id | uid | `vector-3` | name; ambiguity
+  raises rather than guessing).
+- `portals.py` — portal CRUD and `layer_configs` surgery. `layer_configs[0]` = top of the list =
+  drawn on top. `editable_config()` drops server-owned fields before a round-trip PUT.
+- `styles.py` — the style vocabulary of `api/geodeploy/services/symbology.py`, assembled from plain
+  arguments. **Classification maths is NOT reimplemented**: `classify()` reads
+  `GET /data/vector/{ref}/field-stats`, so the CLI cannot disagree with the editor about which class
+  a feature is in.
+- `jobs.py`, `sources.py`, `imports.py`, `admin.py`, `catalog.py`, `errors.py`.
+
+**The CLI** (`geodeploy/cli/`) — the only part allowed to print:
+- `main.py` — argparse root, `Context` (formatter + lazy client), and the single place exceptions
+  become exit codes.
+- `output.py` — `Formatter` (stdout = the answer, stderr = commentary, `--json` = one document),
+  tables, progress bar, `EXIT_*` constants.
+- `commands/` — one module per group (`auth`, `upload`, `layers`, `portals`, `sources`, `imports`,
+  `jobs`, `catalog`, `admin`), each with `register(subparsers)`. `_common.py` holds the styling
+  flags, shared by the three commands that take them.
+
+`tests/` — 243 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
+
+## Dependencies / relationships
+- **Zero runtime dependencies, Python 3.9+.** Both constraints exist for the QGIS plugin, which
+  vendors this package and cannot pip-install anything (QGIS 3.28 LTR ships Python 3.9). Do not add
+  a dependency here without moving it into an extra.
+- Consumes `api/geodeploy/routers/` — see that folder's README for the permission model. Nothing in
+  the API imports this.
+- **GeoLibre does not use this package**: its plugin is browser TypeScript
+  (`integrations/geolibre-plugin/`) hitting `/api/interop/geolibre/*`. What the two share is the
+  HTTP contract and the style vocabulary, not code.
+- Parity to keep: the upload routing mirrors `ui/src/composables/useUpload.js`, and the style keys
+  mirror `services/symbology.py` + `ui/src/lib/symbology.js`.
+
+## The upload routing table (and why 48 MB)
+`.gpkg/.geojson/.json/.zip` < 48 MB → `POST /data/vector/upload`; `.csv` < 48 MB → `/upload-csv`
+(PostGIS); either at/over 48 MB → presigned direct-to-storage → `/large/complete` (converted to
+GeoParquet); `.parquet` at any size → `/geoparquet/{presign,complete}`; `.tif` small/large →
+`/data/raster/upload` or chunked → `/data/raster/large/complete`. Over 48 MB the upload is chunked
+into 48 MB presigned parts, four in parallel.
+
+**48 MB is not the API's 2 GB cap.** The binding limit is the request-body cap of whatever proxy
+sits in front of the instance (Cloudflare's free tier: 100 MB), and exceeding it produces *no server
+log at all* — the request never arrives. `LARGE_UPLOAD_THRESHOLD` must stay equal to the UI's.
+
+## Packaging and release
+
+`pyproject.toml` follows PEP 639: `license = "Apache-2.0"` as an SPDX expression plus
+`license-files`, and **no `License ::` classifier** — setuptools ≥ 77 refuses a build that declares
+both. The version is single-sourced from `geodeploy/__init__.py` (`dynamic = ["version"]`), so
+`--version`, the user agent and the package metadata cannot disagree.
+
+**`PYPI.md`, not `README.md`, is the project page.** This file is the folder's technical note (the
+repo convention in CLAUDE.md), which is not what someone landing on PyPI wants to read; `PYPI.md` is
+the user-facing front page. Keep both current.
+
+The name `geodeploy` was unregistered on PyPI as of 2026-08-12. To cut a release:
+
+```bash
+cd cli
+python -m build                     # sdist + wheel into dist/
+python -m twine check dist/*        # must pass before anything is uploaded
+python -m twine upload --repository testpypi dist/*    # rehearse
+python -m twine upload dist/*
+```
+
+`dist/` and `build/` are git-ignored. The sdist carries the tests, so the release can be verified
+from source rather than trusted.
+
+## Current status & known issues
+- Built 2026-08-12 on branch `feat/cli`; **not yet exercised against a live instance** — every test
+  runs against the in-repo fake. First real run should be `upload --dry-run`, then a small upload,
+  then a portal round trip.
+- Not published to PyPI yet. `pip install -e cli/` is the current install.
+- `geodeploy admin update --watch` polls through the API restart the update itself causes; a failed
+  poll is treated as progress, which is right but means a genuinely dead instance looks like a slow
+  update until the poll loop is interrupted.
+- No declarative `apply` (a manifest describing layers + portal, applied idempotently). The
+  `portals export/import` round trip is the seam it would build on. Deliberately deferred.
+- No shell completion.
+- The QGIS plugin does not exist yet; the seams it needs (pluggable transport, progress callbacks,
+  `cancel`, typed errors, no printing) are in place and tested.
+
+## Last updated
+2026-08-12 (created — packaged CLI + Python client, replacing `examples/geodeploy_cli.py`)

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,7 +22,10 @@ User documentation is `docs/cli.md`; this file is the technical note.
 - `config.py` — profiles + credentials. **Tokens never enter `config.json`**: OS keyring when there
   is one, else `credentials.json` at 0600 in a 0700 directory, written atomically. `normalize_url`
   collapses `…/api`, trailing slashes and a bare host to one origin, so a credential saved under one
-  spelling is found under another. `resolve()` = flag → env → profile, for URL and token separately.
+  spelling is found under another. `split_portal_url` does the same job for a published portal's
+  URL → `(origin, slug)`, so a link copied out of the address bar is a valid portal reference
+  anywhere a slug is (`browse --portal`, and `Portals.get`, which every portal command goes
+  through). `resolve()` = flag → env → profile, for URL and token separately.
 - `uploads.py` — the routing table (below) plus both transports: multipart-through-the-API, and
   presign/chunked direct-to-storage with per-part retry and abort-on-failure.
 - `layers.py` — the two layer kinds, and `Layers.resolve` (id | uid | `vector-3` | name; ambiguity
@@ -51,7 +54,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 263 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 281 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/geodeploy/__init__.py
+++ b/cli/geodeploy/__init__.py
@@ -1,0 +1,46 @@
+"""GeoDeploy — command-line client and Python API.
+
+    from geodeploy import Client
+    gd = Client("https://geodeploy.example.org", token="gdp_…")
+    layer = gd.uploads.upload("roads.gpkg", wait=True)
+    portal = gd.portals.create("Roads")
+    gd.portals.add_layer(portal["id"], layer.layer_id, "vector", {"color": "#e11d48"})
+    gd.portals.publish(portal["id"])
+
+Zero runtime dependencies, Python 3.9+, so the QGIS plugin can vendor this package as-is.
+"""
+from __future__ import annotations
+
+__version__ = "1.3.0"
+
+from .client import Client  # noqa: E402  (after __version__ — the user agent reads it)
+from .errors import (  # noqa: E402
+    APIError,
+    AuthError,
+    ConfigError,
+    ConflictError,
+    GeoDeployError,
+    NotFoundError,
+    PermissionError_,
+    ServerError,
+    TransportError,
+    ValidationError,
+)
+from .jobs import JobFailed, JobTimeout  # noqa: E402
+
+__all__ = [
+    "Client",
+    "GeoDeployError",
+    "APIError",
+    "AuthError",
+    "ConfigError",
+    "ConflictError",
+    "NotFoundError",
+    "PermissionError_",
+    "ServerError",
+    "TransportError",
+    "ValidationError",
+    "JobFailed",
+    "JobTimeout",
+    "__version__",
+]

--- a/cli/geodeploy/__init__.py
+++ b/cli/geodeploy/__init__.py
@@ -11,7 +11,11 @@ Zero runtime dependencies, Python 3.9+, so the QGIS plugin can vendor this packa
 """
 from __future__ import annotations
 
-__version__ = "1.3.0"
+# A PyPI version can never be re-uploaded, so the FIRST upload is a pre-release: it proves the
+# packaging against the real index without spending the number this ships under. `pip install
+# geodeploy` ignores it (pre-releases need --pre), so nobody gets it by accident. Becomes 1.3.0
+# when GeoDeploy v1.3 tags — the CLI's version tracks the release it belongs to.
+__version__ = "1.3.0b1"
 
 from .client import Client  # noqa: E402  (after __version__ — the user agent reads it)
 from .errors import (  # noqa: E402

--- a/cli/geodeploy/__main__.py
+++ b/cli/geodeploy/__main__.py
@@ -1,0 +1,13 @@
+"""`python -m geodeploy` — the same entry point as the `geodeploy` console script.
+
+Worth having: inside QGIS's bundled Python, or a virtualenv whose `Scripts/` is not on PATH, the
+module form is the one that works.
+"""
+from __future__ import annotations
+
+import sys
+
+from .cli.main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/geodeploy/admin.py
+++ b/cli/geodeploy/admin.py
@@ -101,6 +101,23 @@ class Admin(object):
         """Connection details for the managed PostGIS/MinIO. Owner-only, and audited."""
         return self._get("/admin/credentials")
 
+    # ── the public listing ──────────────────────────────────────────────────────────────────────
+
+    def public_index(self) -> Dict[str, Any]:
+        """Whether this instance publishes `GET /api/public` — its anonymous index."""
+        return self._get("/admin/public-index")
+
+    def set_public_index(self, enabled: bool) -> Dict[str, Any]:
+        """List, or stop listing, what this instance publishes.
+
+        Discoverability, not access: a published public portal stays reachable by its link either
+        way. Audited, because "why did our datasets stop appearing" deserves an answer.
+        """
+        try:
+            return self._c.put("/admin/public-index", {"enabled": bool(enabled)})
+        except PermissionError_ as exc:
+            raise _session_only(exc)
+
     # ── audit ───────────────────────────────────────────────────────────────────────────────────
 
     def audit(self, limit: int = 20, offset: int = 0, action: Optional[str] = None,

--- a/cli/geodeploy/admin.py
+++ b/cli/geodeploy/admin.py
@@ -1,0 +1,174 @@
+"""Operating an instance: health, services, updates, backups, the audit log, and users.
+
+**These routes refuse API tokens.** `deps.require_role`/`require_admin` reject a token-authenticated
+request outright, so a leaked `gdp_…` cannot restart your database, read your storage credentials,
+or mint more tokens. That is a deliberate security property, not an oversight — so everything in
+this module needs a *session*: `geodeploy login --password`, or `Client(url, jwt=…)`.
+
+`Users` is the exception: `/users/*` is scope-gated (`users:admin`), so a token with that scope can
+manage members.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .errors import PermissionError_, ValidationError
+
+#: Services the health endpoint reports on. `api` is deliberately not controllable — it is the
+#: process serving the request that would stop it.
+SERVICES = ("postgres", "minio", "redis", "martin", "titiler", "nginx", "celery", "ui", "api")
+ACTIONS = ("start", "stop", "restart")
+
+
+def _session_only(exc: PermissionError_) -> PermissionError_:
+    """Turn the API's bare 403 into the actionable version of the same fact."""
+    if exc.status == 403 and "token" in (exc.detail or "").lower():
+        return PermissionError_(
+            exc.status,
+            "{0} — administration is session-only by design, so a leaked API token cannot "
+            "reconfigure the instance. Run `geodeploy login --password` first.".format(exc.detail),
+            exc.url, exc.payload)
+    return exc
+
+
+class Admin(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        try:
+            return self._c.get(path, params)
+        except PermissionError_ as exc:
+            raise _session_only(exc)
+
+    def _post(self, path: str, json: Any = None) -> Any:
+        try:
+            return self._c.post(path, json)
+        except PermissionError_ as exc:
+            raise _session_only(exc)
+
+    # ── health & services ───────────────────────────────────────────────────────────────────────
+
+    def health(self) -> List[Dict[str, Any]]:
+        return self._get("/admin/health")
+
+    def service(self, name: str, action: str) -> Any:
+        if action not in ACTIONS:
+            raise ValidationError(400, "Action must be one of {0}.".format(", ".join(ACTIONS)))
+        return self._post("/admin/services/{0}/{1}".format(name, action))
+
+    def logs(self, name: str, tail: int = 200, timestamps: bool = True) -> Any:
+        return self._get("/admin/services/{0}/logs".format(name),
+                         {"tail": tail, "timestamps": timestamps})
+
+    def reload_martin(self) -> Any:
+        """Regenerate Martin's config from every ready PostGIS layer — the manual recovery hook
+        for a tile server that has ended up with a stale or empty config."""
+        return self._post("/admin/reload-martin")
+
+    def storage_stats(self) -> Dict[str, Any]:
+        """Per-store usage. A store that could not be measured is `null`, NOT 0 — the difference
+        between "the database is unreachable" and "the database is empty"."""
+        return self._get("/admin/storage-stats")
+
+    # ── updates ─────────────────────────────────────────────────────────────────────────────────
+
+    def updates(self, refresh: bool = False) -> Dict[str, Any]:
+        """What this instance could move to: `main`, the latest release, every release, branches.
+
+        `refresh=True` bypasses the 10-minute cache. That cache protects GitHub's unauthenticated
+        rate limit against page loads; a deliberate check must not answer from it, or a commit
+        pushed a minute ago looks like it never landed.
+        """
+        return self._get("/admin/updates", {"refresh": refresh} if refresh else None)
+
+    def preflight(self) -> Dict[str, Any]:
+        """Whether an update is safe to start right now (it refuses over work in progress)."""
+        return self._get("/admin/update/preflight")
+
+    def update(self, target: Optional[str] = None) -> Dict[str, Any]:
+        """Start an update. The API container restarts as part of it, so the call that STARTS an
+        update is not the one that reports its outcome — poll `update_status`."""
+        return self._post("/admin/update", {"target": target} if target else None)
+
+    def update_status(self) -> Dict[str, Any]:
+        return self._get("/admin/update/status")
+
+    def deployments(self, limit: int = 20) -> Any:
+        return self._get("/admin/deployments", {"limit": limit})
+
+    def credentials(self) -> Dict[str, Any]:
+        """Connection details for the managed PostGIS/MinIO. Owner-only, and audited."""
+        return self._get("/admin/credentials")
+
+    # ── audit ───────────────────────────────────────────────────────────────────────────────────
+
+    def audit(self, limit: int = 20, offset: int = 0, action: Optional[str] = None,
+              resource_type: Optional[str] = None, resource_id: Optional[str] = None,
+              actor_id: Optional[int] = None, query: Optional[str] = None,
+              since: Optional[str] = None, until: Optional[str] = None) -> Dict[str, Any]:
+        """A PAGE of the activity log. Every filter is applied server-side before the page is cut —
+        never fetch the log and filter locally, that searches only the slice you downloaded."""
+        return self._get("/audit", {"limit": limit, "offset": offset, "action": action,
+                                    "resource_type": resource_type, "resource_id": resource_id,
+                                    "actor_id": actor_id, "q": query, "since": since,
+                                    "until": until})
+
+    def audit_actions(self) -> List[str]:
+        return self._get("/audit/actions")
+
+    # ── backups ─────────────────────────────────────────────────────────────────────────────────
+
+    def backup_settings(self) -> Dict[str, Any]:
+        return self._get("/backups/settings")
+
+    def backup_runs(self, limit: int = 20) -> Any:
+        return self._get("/backups/runs", {"limit": limit})
+
+    def backup_stored(self) -> Any:
+        """The destination's own manifests — the only trustworthy inventory, since our run table
+        lives in the state database that is itself part of what gets backed up."""
+        return self._get("/backups/stored")
+
+    def backup_run(self) -> Any:
+        return self._post("/backups/run")
+
+    def backup_test(self) -> Any:
+        return self._post("/backups/settings/test")
+
+
+class Users(object):
+    """Members, roles and invitations — `users:admin` scope, so a token can do this."""
+
+    def __init__(self, client: Any):
+        self._c = client
+
+    def list(self) -> List[Dict[str, Any]]:
+        return self._c.get("/users")
+
+    def invite(self, email: str, role: str = "viewer") -> Dict[str, Any]:
+        """Create an invitation. The raw token is returned ONCE — regenerate is the only way to get
+        a link again. It is emailed too when SMTP is configured, but the link always works."""
+        if role not in ("viewer", "editor", "admin"):
+            raise ValidationError(400, "Role must be viewer, editor or admin (owner is transferred).")
+        return self._c.post("/users/invitations", {"email": email, "role": role})
+
+    def invitations(self) -> List[Dict[str, Any]]:
+        return self._c.get("/users/invitations")
+
+    def revoke_invitation(self, invitation_id: int) -> Any:
+        return self._c.delete("/users/invitations/{0}".format(int(invitation_id)))
+
+    def regenerate_invitation(self, invitation_id: int) -> Any:
+        return self._c.post("/users/invitations/{0}/regenerate".format(int(invitation_id)))
+
+    def set_role(self, user_id: int, role: str) -> Dict[str, Any]:
+        return self._c.put("/users/{0}/role".format(int(user_id)), {"role": role})
+
+    def delete(self, user_id: int) -> Any:
+        """Delete a member. Their layers, portals and sources are REASSIGNED to the owner —
+        nothing of theirs is destroyed."""
+        return self._c.delete("/users/{0}".format(int(user_id)))
+
+    def reset_link(self, user_id: int) -> Dict[str, Any]:
+        return self._c.post("/users/{0}/reset-password-link".format(int(user_id)))

--- a/cli/geodeploy/catalog.py
+++ b/cli/geodeploy/catalog.py
@@ -14,6 +14,34 @@ class Catalog(object):
     def __init__(self, client: Any):
         self._c = client
 
+    # ── the instance index ──────────────────────────────────────────────────────────────────────
+
+    def public(self) -> Dict[str, Any]:
+        """Everything this instance offers anonymously: public portals, and public layers grouped
+        by storage kind (`raster`, `postgis`, `geoparquet`).
+
+        This is the "paste a URL and see what is there" call — the first screen of a plugin. An
+        instance may switch its index off, in which case this raises `NotFoundError`: that is a
+        decision ("no index here"), distinct from an empty one ("nothing published").
+        """
+        return self._c.get("/public", auth=False)
+
+    def public_portals(self) -> List[Dict[str, Any]]:
+        return self._c.get("/public/portals", auth=False) or []
+
+    def portal_style(self, style_url: str) -> Dict[str, Any]:
+        """A published portal's own `style.json` — sources, layers, folder tree, bounds.
+
+        The whole portal in one anonymous fetch, which is what makes "open this portal in QGIS"
+        possible without a token. The URL comes from `public()`; it is a static file in the
+        published bundle, not an API route.
+        """
+        response = self._c.send_absolute("GET", style_url)
+        if response.status >= 400:
+            from .errors import from_status
+            raise from_status(response.status, "Could not read the portal style.", response.url)
+        return response.json()
+
     # ── OGC API - Features ──────────────────────────────────────────────────────────────────────
 
     def collections(self) -> List[Dict[str, Any]]:

--- a/cli/geodeploy/catalog.py
+++ b/cli/geodeploy/catalog.py
@@ -1,0 +1,68 @@
+"""The public read surfaces: STAC, OGC API - Features, templates and basemaps.
+
+These need no credentials — they are what an instance offers the rest of the world, and what QGIS,
+ArcGIS, FME and GDAL connect to. Only layers explicitly shared as **public** appear here; the CLI
+reaching them anonymously is therefore also the honest way to check what you have actually exposed:
+if `geodeploy catalog collections` does not list it, nor can anyone else.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class Catalog(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    # ── OGC API - Features ──────────────────────────────────────────────────────────────────────
+
+    def collections(self) -> List[Dict[str, Any]]:
+        """One collection per public, ready vector layer. Ids mirror the STAC item ids."""
+        data = self._c.get("/ogc/collections", auth=False) or {}
+        return data.get("collections") or []
+
+    def collection(self, cid: str) -> Dict[str, Any]:
+        return self._c.get("/ogc/collections/{0}".format(cid), auth=False)
+
+    def items(self, cid: str, bbox: Optional[str] = None, limit: int = 10,
+              offset: int = 0) -> Dict[str, Any]:
+        return self._c.get("/ogc/collections/{0}/items".format(cid),
+                           {"bbox": bbox, "limit": limit, "offset": offset}, auth=False)
+
+    def item(self, cid: str, fid: str) -> Dict[str, Any]:
+        return self._c.get("/ogc/collections/{0}/items/{1}".format(cid, fid), auth=False)
+
+    def conformance(self) -> Dict[str, Any]:
+        """What the OGC endpoint claims to support — Core + GeoJSON, and nothing it does not do."""
+        return self._c.get("/ogc/conformance", auth=False)
+
+    # ── STAC ────────────────────────────────────────────────────────────────────────────────────
+
+    def stac(self) -> Dict[str, Any]:
+        return self._c.get("/stac", auth=False)
+
+    def stac_collections(self) -> List[Dict[str, Any]]:
+        data = self._c.get("/stac/collections", auth=False) or {}
+        return data.get("collections") or []
+
+    def stac_items(self, cid: str, bbox: Optional[str] = None, datetime: Optional[str] = None,
+                   limit: int = 100, offset: int = 0) -> Dict[str, Any]:
+        return self._c.get("/stac/collections/{0}/items".format(cid),
+                           {"bbox": bbox, "datetime": datetime, "limit": limit, "offset": offset},
+                           auth=False)
+
+    def search(self, bbox: Optional[str] = None, collections: Optional[str] = None,
+               datetime: Optional[str] = None, ids: Optional[str] = None,
+               limit: int = 100) -> Dict[str, Any]:
+        return self._c.get("/stac/search", {"bbox": bbox, "collections": collections,
+                                            "datetime": datetime, "ids": ids, "limit": limit},
+                           auth=False)
+
+    # ── portal building blocks ──────────────────────────────────────────────────────────────────
+
+    def templates(self) -> List[Dict[str, Any]]:
+        """Portal templates, each declaring the experiences (`archetypes`) it may be used for."""
+        return self._c.get("/templates", auth=False)
+
+    def basemaps(self) -> List[Dict[str, Any]]:
+        return self._c.get("/basemaps", auth=False)

--- a/cli/geodeploy/cli/__init__.py
+++ b/cli/geodeploy/cli/__init__.py
@@ -1,0 +1,7 @@
+"""The `geodeploy` command-line interface.
+
+Everything user-facing lives under here — argument parsing, tables, progress bars, exit codes. The
+package above it (`geodeploy.client` and friends) is a library and never prints or exits, which is
+what lets the QGIS plugin import it without dragging a CLI along.
+"""
+from __future__ import annotations

--- a/cli/geodeploy/cli/commands/__init__.py
+++ b/cli/geodeploy/cli/commands/__init__.py
@@ -1,0 +1,2 @@
+"""One module per command group. Each exposes `register(subparsers)`."""
+from __future__ import annotations

--- a/cli/geodeploy/cli/commands/_common.py
+++ b/cli/geodeploy/cli/commands/_common.py
@@ -208,9 +208,20 @@ def layer_ref_arg(parser, name: str = "layer", help_text: Optional[str] = None) 
                         help="disambiguate when a vector and a raster share a name")
 
 
-def resolve_layer(ctx, args, ref_attr: str = "layer") -> Dict[str, Any]:
+def resolve_layer(ctx, args, ref_attr: str = "layer", public_ok: bool = False) -> Dict[str, Any]:
+    """Find the layer a command was pointed at, by id, uid or name.
+
+    `public_ok` marks a command that works on public data alone (downloads, links to shared
+    artifacts). With no credential those resolve through the instance's PUBLIC INDEX instead of the
+    authenticated layer list, so `geodeploy --url … layers download roads` works for someone who
+    has no account — which is the whole point of a public layer.
+    """
     ref = getattr(args, ref_attr)
-    return ctx.client().layers.resolve(ref, getattr(args, "layer_type", None))
+    kind = getattr(args, "layer_type", None)
+    info = ctx.resolved
+    if public_ok and not (info.token or info.jwt):
+        return ctx.client(auth_required=False).layers.resolve_public(ref, kind)
+    return ctx.client().layers.resolve(ref, kind)
 
 
 def parse_fields(value: Optional[str]) -> Optional[List[str]]:

--- a/cli/geodeploy/cli/commands/_common.py
+++ b/cli/geodeploy/cli/commands/_common.py
@@ -1,0 +1,219 @@
+"""Argument groups and helpers shared by several command modules.
+
+The styling flags live here because THREE commands take the same set — `portals add-layer`,
+`portals style` and `layers style` (a layer's own default). Defining them once is not only less
+code: it is the only way the three stay consistent, and inconsistency between them is exactly the
+kind of thing nobody notices until someone's map is wrong.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+from ...errors import ValidationError
+from ...styles import (CLASSIFY_METHODS, COLOR_MODES, LINE_TYPES, MARKERS, RAMPS, build_style,
+                       parse_categories, parse_classes)
+
+
+def add_style_args(parser, raster: bool = True) -> None:
+    """Every styling flag the API accepts, including the v1.1 data-driven symbology."""
+    single = parser.add_argument_group(
+        "symbology (single symbol)",
+        "Only the flags you pass are changed; everything else keeps its current value.")
+    single.add_argument("--color", help="main colour: polygon fill, line, or point (hex or name)")
+    single.add_argument("--fill-opacity", type=float, help="polygon fill opacity, 0-1")
+    single.add_argument("--outline-color",
+                        help="outline colour, or 'none' for no outline at all")
+    single.add_argument("--outline-width", type=float,
+                        help="point outline width as a FRACTION of the radius (0-1, default 0.28) "
+                             "— a wide one on a small marker is how a ring is drawn")
+    single.add_argument("--line-width", type=float, help="line width in px")
+    single.add_argument("--radius", type=float, help="point radius in px")
+    single.add_argument("--marker", choices=MARKERS, help="point marker shape")
+    single.add_argument("--line-type", choices=LINE_TYPES, help="line dash pattern")
+    single.add_argument("--opacity", type=float, help="layer opacity, 0-1")
+
+    driven = parser.add_argument_group(
+        "symbology (data-driven, v1.1)",
+        "Colour or size from a feature property. --classify asks the instance to compute the "
+        "breaks with the same code the editor and the published portal use.")
+    driven.add_argument("--color-field", help="property to colour by")
+    driven.add_argument("--color-mode", choices=COLOR_MODES,
+                        help="single | graduated (numeric classes) | categorized (text values)")
+    driven.add_argument("--classify", nargs="?", const="quantile", choices=CLASSIFY_METHODS,
+                        help="compute classes from the data: quantile (default), equal, jenks")
+    driven.add_argument("--classes", type=int, default=None,
+                        help="how many classes to compute (2-12, default 5)")
+    driven.add_argument("--ramp", choices=RAMPS, help="colour ramp for computed classes")
+    driven.add_argument("--class-breaks",
+                        help="explicit classes instead of computing them: '0-10:#fee,10-50:#f00' "
+                             "(* is an open edge)")
+    driven.add_argument("--categories",
+                        help="explicit categories: 'forest:#2c7,water:#39f'")
+    driven.add_argument("--other-color", help="colour for values in no category")
+    driven.add_argument("--size-field", help="property to size points/lines by")
+    driven.add_argument("--size-stops", help="proportional size: 'value:size,value:size' "
+                                             "(at least two, ascending)")
+    driven.add_argument("--no-classification", action="store_true",
+                        help="drop data-driven colouring and go back to a single symbol")
+
+    three_d = parser.add_argument_group("3D")
+    three_d.add_argument("--extrude", action="store_true", default=None,
+                         help="extrude by a numeric field (polygons) or draw points as bars")
+    three_d.add_argument("--no-extrude", action="store_true", help="turn 3D off")
+    three_d.add_argument("--extrude-field", help="numeric property giving the height")
+    three_d.add_argument("--extrude-scale", type=float, help="multiply the height by this")
+    three_d.add_argument("--extrude-base", help="base height: a number, or a property name")
+    three_d.add_argument("--extrude-color", help="override the extrusion colour")
+    three_d.add_argument("--extrude-opacity", type=float, help="extrusion opacity, 0-1")
+    three_d.add_argument("--extrude-radius", type=float,
+                         help="POINT bar footprint radius in metres (default: derived from the "
+                              "layer's own extent, because a fixed one is invisible on a world map)")
+
+    if raster:
+        rast = parser.add_argument_group("raster")
+        rast.add_argument("--colormap", help="TiTiler colormap, e.g. viridis (see `layers colormaps`)")
+        rast.add_argument("--rescale", help="stretch as 'min,max' (see `layers stats` for a suggestion)")
+        rast.add_argument("--algorithm", help="e.g. hillshade (single-band)")
+        rast.add_argument("--zfactor", type=float, help="hillshade vertical exaggeration")
+        rast.add_argument("--bidx", help="band selection: '1' or '3,2,1' for an RGB composite")
+
+    parser.add_argument("--style-json",
+                        help="a JSON object (or @file.json) merged in last — the escape hatch for "
+                             "anything these flags do not cover")
+
+
+def style_from_args(args, client=None, layer_ref: Optional[Any] = None,
+                    base: Optional[Dict[str, Any]] = None, out=None) -> Dict[str, Any]:
+    """Turn the parsed styling flags into a style dict, classifying against the layer if asked."""
+    style = dict(base or {})
+
+    if getattr(args, "classify", None):
+        if not getattr(args, "color_field", None):
+            raise ValidationError(400, "--classify needs --color-field.")
+        if client is None or layer_ref is None:  # pragma: no cover - guarded by the callers
+            raise ValidationError(400, "Classification needs a layer to read.")
+        from ... import styles as styles_mod
+        style, stats = styles_mod.classify(
+            client, layer_ref, args.color_field, mode=getattr(args, "color_mode", None),
+            classes=getattr(args, "classes", None) or 5, method=args.classify,
+            ramp=getattr(args, "ramp", None) or "viridis", base=style)
+        if out is not None:
+            count = len(style.get("classes") or style.get("categories") or [])
+            out.info("Classified {0} on {1}: {2} {3} from {4} values.".format(
+                args.color_field, args.classify, count,
+                "classes" if style.get("color_mode") == "graduated" else "categories",
+                (stats or {}).get("count") or (stats or {}).get("total") or "the"))
+
+    kwargs = {}  # type: Dict[str, Any]
+    for name in ("color", "fill_opacity", "outline_color", "outline_width", "line_width",
+                 "radius", "marker", "line_type", "colormap", "rescale", "algorithm", "zfactor",
+                 "color_field", "color_mode", "size_field", "other_color", "size_stops",
+                 "extrude_field", "extrude_scale", "extrude_base", "extrude_color",
+                 "extrude_opacity", "extrude_radius"):
+        kwargs[name] = getattr(args, name, None)
+    if getattr(args, "bidx", None):
+        kwargs["bidx"] = [int(b) for b in str(args.bidx).replace(" ", "").split(",") if b]
+    if getattr(args, "extrude", None):
+        kwargs["extrude"] = True
+    if getattr(args, "no_extrude", False):
+        kwargs["extrude"] = False
+    if getattr(args, "class_breaks", None):
+        kwargs["classes"] = parse_classes(args.class_breaks)
+    if getattr(args, "categories", None):
+        kwargs["categories"] = parse_categories(args.categories)
+    if getattr(args, "no_classification", False):
+        kwargs["clear_classification"] = True
+
+    style = build_style(style, **kwargs)
+
+    extra = getattr(args, "style_json", None)
+    if extra:
+        style.update(read_json_arg(extra, "--style-json"))
+    return style
+
+
+def read_json_arg(value: str, label: str) -> Dict[str, Any]:
+    """A JSON object given inline, or `@path` to read it from a file (or `@-` for stdin).
+
+    `utf-8-sig` on the file: PowerShell's `>` writes UTF-16 or a BOM, which is how the reference
+    script's `portal-set` used to fail on Windows with an unreadable JSON error.
+    """
+    text = value
+    if value.startswith("@"):
+        path = value[1:]
+        if path == "-":
+            text = sys.stdin.read()
+        else:
+            with open(path, "r", encoding="utf-8-sig") as fh:
+                text = fh.read()
+    try:
+        data = json.loads(text)
+    except ValueError as exc:
+        raise ValidationError(400, "{0} is not valid JSON: {1}".format(label, exc))
+    if not isinstance(data, dict):
+        raise ValidationError(400, "{0} must be a JSON object.".format(label))
+    return data
+
+
+def read_text_arg(value: str) -> str:
+    """Text, or `@file` to read it from disk (Markdown for an About page, typically)."""
+    if value.startswith("@"):
+        path = value[1:]
+        if path == "-":
+            return sys.stdin.read()
+        with open(path, "r", encoding="utf-8-sig") as fh:
+            return fh.read()
+    return value
+
+
+def write_json_file(path: str, payload: Any) -> None:
+    """Write JSON as UTF-8 ourselves rather than letting the shell redirect it.
+
+    PowerShell's `>` writes UTF-16 with a BOM, which then cannot be read back — the reference CLI
+    grew an explicit output-file argument for exactly this reason, and so does this one.
+    """
+    directory = os.path.dirname(os.path.abspath(path))
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False, default=str)
+        fh.write("\n")
+
+
+def confirm(out, question: str, assume_yes: bool = False, expect: Optional[str] = None) -> bool:
+    """Ask before something irreversible. `--yes` skips it; a non-interactive shell refuses.
+
+    Refusing rather than assuming yes is deliberate: a script piping into this has not consented to
+    a delete, and `--yes` is one character to add when it has.
+    """
+    if assume_yes:
+        return True
+    if not sys.stdin.isatty():
+        out.error("Refusing to {0} without --yes when not attached to a terminal.".format(question))
+        return False
+    if expect:
+        answer = input("{0}\nType {1!r} to confirm: ".format(question, expect)).strip()
+        return answer == expect
+    answer = input("{0} [y/N] ".format(question)).strip().lower()
+    return answer in ("y", "yes")
+
+
+def layer_ref_arg(parser, name: str = "layer", help_text: Optional[str] = None) -> None:
+    parser.add_argument(name, help=help_text or
+                        "layer id, uid, or name (a unique part of the name is enough)")
+    parser.add_argument("--type", dest="layer_type", choices=["vector", "raster"],
+                        help="disambiguate when a vector and a raster share a name")
+
+
+def resolve_layer(ctx, args, ref_attr: str = "layer") -> Dict[str, Any]:
+    ref = getattr(args, ref_attr)
+    return ctx.client().layers.resolve(ref, getattr(args, "layer_type", None))
+
+
+def parse_fields(value: Optional[str]) -> Optional[List[str]]:
+    if value is None:
+        return None
+    return [f.strip() for f in value.split(",") if f.strip()]

--- a/cli/geodeploy/cli/commands/admin.py
+++ b/cli/geodeploy/cli/commands/admin.py
@@ -62,6 +62,21 @@ def register(subparsers) -> None:
     backups.add_argument("--run", action="store_true", help="start a backup now")
     backups.add_argument("-n", "--limit", type=int, default=10)
 
+    listing = add_command(group, "public-index", cmd_public_index,
+                          "show or change whether this instance is publicly browsable",
+                          epilog="""examples:
+  geodeploy admin public-index            is it listed?
+  geodeploy admin public-index --off      stop listing (links keep working)
+  geodeploy admin public-index --on
+
+Listing controls whether anyone can DISCOVER your published public portals and public layers from
+the instance URL — what `geodeploy browse` and the QGIS plugin read. It does not change who may
+open them: a public portal stays reachable by its link either way.
+""")
+    state = listing.add_mutually_exclusive_group()
+    state.add_argument("--on", dest="enabled", action="store_true", default=None)
+    state.add_argument("--off", dest="enabled", action="store_false", default=None)
+
     add_command(group, "credentials", cmd_credentials,
                 "connection details for the managed PostGIS and MinIO (owner only, audited)")
 
@@ -237,6 +252,23 @@ def cmd_backups(ctx, args) -> int:
     ctx.out.render(client.admin.backup_runs(limit=args.limit),
                    ["id", "started_at", "status", "trigger", "size_bytes", "error_message"],
                    empty="No backup runs recorded.")
+    return EXIT_OK
+
+
+def cmd_public_index(ctx, args) -> int:
+    client = _admin(ctx)
+    if args.enabled is None:
+        state = client.admin.public_index()
+    else:
+        state = client.admin.set_public_index(args.enabled)
+    ctx.out.render(state, ["enabled"])
+    if not ctx.out.json_mode:
+        if state.get("enabled"):
+            ctx.out.success("This instance is listed — `geodeploy browse {0}` shows what anyone "
+                            "can see.".format(ctx.resolved.url))
+        else:
+            ctx.out.success("Not listed. Published public portals stay reachable by their links; "
+                            "they are simply not enumerated.")
     return EXIT_OK
 
 

--- a/cli/geodeploy/cli/commands/admin.py
+++ b/cli/geodeploy/cli/commands/admin.py
@@ -1,0 +1,285 @@
+"""`geodeploy admin …` and `geodeploy users …` — operating an instance.
+
+Everything under `admin` needs a **password session** (`geodeploy login --password`), because the
+API rejects API tokens on those routes so that a leaked token cannot restart your database or read
+your storage credentials. `users` is different: it is scope-gated, so a token with `users:admin`
+works.
+"""
+from __future__ import annotations
+
+from ...errors import GeoDeployError
+from ..main import add_command, group_parser
+from ..output import EXIT_GENERIC, EXIT_OK, human_size
+from ._common import confirm
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "admin", "health, services, updates, backups, activity log")
+
+    add_command(group, "health", cmd_health, "status of every service in the stack")
+
+    services = add_command(group, "service", cmd_service, "start, stop or restart a service")
+    services.add_argument("name", help="postgres | minio | redis | martin | titiler | nginx | "
+                                       "celery | ui")
+    services.add_argument("action", choices=["start", "stop", "restart"])
+    services.add_argument("--yes", action="store_true")
+
+    logs = add_command(group, "logs", cmd_logs, "recent log lines from one service")
+    logs.add_argument("name")
+    logs.add_argument("-n", "--tail", type=int, default=200)
+    logs.add_argument("--no-timestamps", action="store_true")
+
+    add_command(group, "storage", cmd_storage, "how much space each store is using")
+
+    updates = add_command(group, "updates", cmd_updates,
+                          "what this instance could update to (main, releases, branches)")
+    updates.add_argument("--refresh", action="store_true",
+                         help="bypass the 10-minute cache and ask GitHub now")
+
+    update = add_command(group, "update", cmd_update, "update the instance")
+    update.add_argument("target", nargs="?", help="main, a release tag, or a branch "
+                                                  "(default: whatever the instance follows)")
+    update.add_argument("--yes", action="store_true")
+    update.add_argument("--watch", action="store_true", help="follow the update to completion")
+
+    add_command(group, "reload-martin", cmd_reload_martin,
+                "regenerate the vector tile server's config from the ready PostGIS layers")
+
+    audit = add_command(group, "audit", cmd_audit, "the activity log (paginated, filtered server-side)")
+    audit.add_argument("-n", "--limit", type=int, default=20)
+    audit.add_argument("--offset", type=int, default=0)
+    audit.add_argument("--action", help="exact action, or a family prefix like 'portal'")
+    audit.add_argument("--resource-type")
+    audit.add_argument("--resource-id")
+    audit.add_argument("--actor", type=int, dest="actor_id")
+    audit.add_argument("--query", dest="search")
+    audit.add_argument("--since", help="ISO instant, e.g. 2026-08-01T00:00:00Z")
+    audit.add_argument("--until")
+
+    backups = add_command(group, "backups", cmd_backups, "backup history and destination status")
+    backups.add_argument("--stored", action="store_true",
+                         help="list what is actually AT the destination, not our own log")
+    backups.add_argument("--run", action="store_true", help="start a backup now")
+    backups.add_argument("-n", "--limit", type=int, default=10)
+
+    add_command(group, "credentials", cmd_credentials,
+                "connection details for the managed PostGIS and MinIO (owner only, audited)")
+
+    # ── users ───────────────────────────────────────────────────────────────────────────────────
+    users = group_parser(subparsers, "users", "members, roles and invitations")
+    add_command(users, "list", cmd_users_list, "list members", aliases=["ls"])
+    invite = add_command(users, "invite", cmd_users_invite, "invite someone (returns a link once)")
+    invite.add_argument("email")
+    invite.add_argument("--role", choices=["viewer", "editor", "admin"], default="viewer")
+    add_command(users, "invitations", cmd_users_invitations, "pending invitations")
+    role = add_command(users, "role", cmd_users_role, "change a member's role")
+    role.add_argument("user_id", type=int)
+    role.add_argument("role", choices=["viewer", "editor", "admin"])
+    remove = add_command(users, "remove", cmd_users_remove,
+                         "remove a member (their data is reassigned to the owner)", aliases=["rm"])
+    remove.add_argument("user_id", type=int)
+    remove.add_argument("--yes", action="store_true")
+
+
+def _admin(ctx):
+    return ctx.client(session=True)
+
+
+# ── health & services ────────────────────────────────────────────────────────────────────────────
+
+def cmd_health(ctx, args) -> int:
+    rows = _admin(ctx).admin.health()
+    ctx.out.render(rows, ["name", "status", "controllable", "message"])
+    if not ctx.out.json_mode:
+        bad = [r for r in rows if (r.get("status") or "") not in ("healthy", "running")]
+        if bad:
+            ctx.out.warn("{0} service(s) not healthy: {1}".format(
+                len(bad), ", ".join(r.get("name") for r in bad)))
+    return EXIT_OK
+
+
+def cmd_service(ctx, args) -> int:
+    if args.action in ("stop", "restart") and not confirm(
+            ctx.out, "{0} the {1} service?".format(args.action.capitalize(), args.name), args.yes):
+        return EXIT_GENERIC
+    ctx.out.render(_admin(ctx).admin.service(args.name, args.action))
+    if not ctx.out.json_mode:
+        ctx.out.success("{0} {1}ed.".format(args.name, args.action.rstrip("e")))
+    return EXIT_OK
+
+
+def cmd_logs(ctx, args) -> int:
+    data = _admin(ctx).admin.logs(args.name, tail=args.tail, timestamps=not args.no_timestamps)
+    if ctx.out.json_mode:
+        ctx.out.json(data)
+        return EXIT_OK
+    text = data.get("logs") if isinstance(data, dict) else data
+    ctx.out.out(text if isinstance(text, str) else str(text))
+    return EXIT_OK
+
+
+def cmd_storage(ctx, args) -> int:
+    stats = _admin(ctx).admin.storage_stats()
+    if ctx.out.json_mode:
+        ctx.out.json(stats)
+        return EXIT_OK
+    rows = []
+    for key, label in (("postgis_bytes", "PostGIS tables"), ("raster_bytes", "Raster COGs"),
+                       ("geoparquet_bytes", "GeoParquet + PMTiles"),
+                       ("portal_bundle_bytes", "Published portals"), ("used_bytes", "Total")):
+        value = stats.get(key)
+        # None means "could not be measured", which is NOT zero — saying 0 for an unreachable
+        # database would read as "empty" and send someone looking for missing data.
+        rows.append({"store": label,
+                     "size": human_size(value) if value is not None else "not measured"})
+    ctx.out.table(rows, ["store", "size"])
+    ctx.out.info("{0} vector layers, {1} rasters, {2} portals.".format(
+        stats.get("vector_layers"), stats.get("raster_layers"), stats.get("portals")))
+    return EXIT_OK
+
+
+# ── updates ──────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_updates(ctx, args) -> int:
+    data = _admin(ctx).admin.updates(refresh=args.refresh)
+    if ctx.out.json_mode:
+        ctx.out.json(data)
+        return EXIT_OK
+    main = data.get("main") or {}
+    ctx.out.record({"channel": data.get("channel"), "current": data.get("current_ref"),
+                    "main": main.get("status"), "commits behind": main.get("commits"),
+                    "latest release": (data.get("latest_release") or {}).get("tag")},
+                   ["channel", "current", "main", "commits behind", "latest release"])
+    releases = data.get("releases") or []
+    if releases:
+        ctx.out.out("")
+        ctx.out.table([{"tag": r.get("tag"), "published": r.get("published_at"),
+                        "title": r.get("name")} for r in releases[:10]],
+                      ["tag", "published", "title"])
+    return EXIT_OK
+
+
+def cmd_update(ctx, args) -> int:
+    client = _admin(ctx)
+    preflight = client.admin.preflight()
+    if not ctx.out.json_mode and preflight:
+        ctx.out.record(preflight)
+    if preflight.get("blocked") or preflight.get("ok") is False:
+        ctx.out.error(preflight.get("reason") or "The instance refused: work is in progress.")
+        return EXIT_GENERIC
+    if not confirm(ctx.out, "Update this instance to {0}?".format(args.target or "its channel"),
+                   args.yes):
+        return EXIT_GENERIC
+    started = client.admin.update(args.target)
+    ctx.out.render(started)
+    if args.watch:
+        import time
+        while True:
+            time.sleep(4)
+            try:
+                status = client.admin.update_status()
+            except GeoDeployError as exc:
+                # Expected: the API container is recreated BY the update, so the poll that hits
+                # that moment fails. That is progress, not an error.
+                ctx.out.info("  (instance restarting: {0})".format(exc))
+                continue
+            phase = status.get("phase") or status.get("status")
+            ctx.out.info("  {0}".format(phase))
+            if phase in ("done", "complete", "completed", "error", "failed"):
+                ctx.out.render(status)
+                return EXIT_OK if phase.startswith(("done", "complete")) else EXIT_GENERIC
+    if not ctx.out.json_mode:
+        ctx.out.success("Update started. `geodeploy admin updates` will show the new version once "
+                        "the API comes back.")
+    return EXIT_OK
+
+
+def cmd_reload_martin(ctx, args) -> int:
+    ctx.out.render(_admin(ctx).admin.reload_martin())
+    return EXIT_OK
+
+
+# ── audit & backups ──────────────────────────────────────────────────────────────────────────────
+
+def cmd_audit(ctx, args) -> int:
+    page = _admin(ctx).admin.audit(limit=args.limit, offset=args.offset, action=args.action,
+                                   resource_type=args.resource_type, resource_id=args.resource_id,
+                                   actor_id=args.actor_id, query=args.search, since=args.since,
+                                   until=args.until)
+    if ctx.out.json_mode:
+        ctx.out.json(page)
+        return EXIT_OK
+    ctx.out.table(page.get("items") or [],
+                  ["created_at", "actor_name", "action", "resource_type", "resource_id"])
+    ctx.out.info("{0}-{1} of {2}".format(page.get("offset", 0) + 1,
+                                         page.get("offset", 0) + len(page.get("items") or []),
+                                         page.get("total")))
+    return EXIT_OK
+
+
+def cmd_backups(ctx, args) -> int:
+    client = _admin(ctx)
+    if args.run:
+        ctx.out.render(client.admin.backup_run())
+        if not ctx.out.json_mode:
+            ctx.out.success("Backup started — it runs in the worker, so this returns immediately.")
+        return EXIT_OK
+    if args.stored:
+        ctx.out.render(client.admin.backup_stored(), ["key", "size", "created_at"],
+                       empty="Nothing at the destination.")
+        return EXIT_OK
+    settings = client.admin.backup_settings()
+    if not ctx.out.json_mode:
+        ctx.out.record(settings, ["enabled", "schedule", "hour", "keep", "bucket", "prefix",
+                                  "endpoint", "include_postgis", "include_objects",
+                                  "include_state"])
+        ctx.out.out("")
+    ctx.out.render(client.admin.backup_runs(limit=args.limit),
+                   ["id", "started_at", "status", "trigger", "size_bytes", "error_message"],
+                   empty="No backup runs recorded.")
+    return EXIT_OK
+
+
+def cmd_credentials(ctx, args) -> int:
+    ctx.out.render(_admin(ctx).admin.credentials())
+    return EXIT_OK
+
+
+# ── users ────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_users_list(ctx, args) -> int:
+    ctx.out.render(ctx.client().users.list(),
+                   ["id", "name", "email", "role", "vector_count", "raster_count", "portal_count",
+                    "created_at"])
+    return EXIT_OK
+
+
+def cmd_users_invite(ctx, args) -> int:
+    invite = ctx.client().users.invite(args.email, args.role)
+    ctx.out.render(invite, ["id", "email", "role", "expires_at", "invite_url", "token",
+                            "email_sent"])
+    if not ctx.out.json_mode:
+        ctx.out.warn("The invitation link is shown once — regenerating is the only way to get it "
+                     "again.")
+    return EXIT_OK
+
+
+def cmd_users_invitations(ctx, args) -> int:
+    ctx.out.render(ctx.client().users.invitations(),
+                   ["id", "email", "role", "purpose", "expires_at", "created_at"],
+                   empty="No pending invitations.")
+    return EXIT_OK
+
+
+def cmd_users_role(ctx, args) -> int:
+    ctx.out.render(ctx.client().users.set_role(args.user_id, args.role), ["id", "email", "role"])
+    return EXIT_OK
+
+
+def cmd_users_remove(ctx, args) -> int:
+    if not confirm(ctx.out, "Remove user {0}? Their layers and portals move to the owner.".format(
+            args.user_id), args.yes):
+        return EXIT_GENERIC
+    ctx.client().users.delete(args.user_id)
+    ctx.out.render({"ok": True, "removed": args.user_id})
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/auth.py
+++ b/cli/geodeploy/cli/commands/auth.py
@@ -1,0 +1,280 @@
+"""login / logout / whoami / profile / token — who you are, and against which instance.
+
+**An API token is the normal credential.** `geodeploy login <url> --token gdp_…` (or the
+`GEODEPLOY_TOKEN` environment variable) is what scripts, CI and the QGIS plugin use, and it is all
+the CLI needs for data, portals and publishing.
+
+`login --password` exists for one reason: the API rejects API tokens on `/admin/*`, `/backups/*`,
+`/tokens` and ownership transfer, so that a leaked token cannot reconfigure an instance or mint
+more tokens. Those commands therefore need a *session*. The password is never stored and never
+accepted as a flag value — it is prompted for (or read from stdin, for CI), exchanged once for the
+same 7-day JWT the browser gets, and only that is kept.
+"""
+from __future__ import annotations
+
+import getpass
+import sys
+from typing import Any
+
+from ... import config as cfg
+from ...errors import AuthError, ConfigError
+from ..main import add_command, group_parser
+from ..output import EXIT_AUTH, EXIT_GENERIC, EXIT_OK, EXIT_USAGE
+
+
+def register(subparsers) -> None:
+    login = add_command(
+        subparsers, "login", cmd_login, "log in to an instance and remember it",
+        epilog="""\
+examples:
+  geodeploy login https://gd.example.org --token gdp_xxx   # normal: a scoped API token
+  geodeploy login https://gd.example.org                   # prompts for the token
+  geodeploy login https://gd.example.org --password        # a session too, for admin commands
+  echo "$PW" | geodeploy login https://gd.example.org --email me@x.org --password-stdin
+""")
+    login.add_argument("url", help="instance URL, e.g. https://geodeploy.example.org")
+    # NOTE: the API token comes from the GLOBAL --token flag, so `geodeploy login <url> --token
+    # gdp_…` reads the same as every other command and there is only one spelling to remember.
+    login.add_argument("--token-stdin", action="store_true", help="read the API token from stdin")
+    login.add_argument("--password", action="store_true",
+                       help="ALSO start a password session, for the admin commands that refuse "
+                            "API tokens (prompts; the password is never stored)")
+    login.add_argument("--password-stdin", action="store_true",
+                       help="read the password from stdin instead of prompting (for CI)")
+    login.add_argument("--email", help="account email for the password session")
+    login.add_argument("--name", help="profile name (default: the instance host)")
+    login.add_argument("--no-keyring", action="store_true",
+                       help="store credentials in the 0600 file rather than the OS keyring")
+
+    logout = add_command(subparsers, "logout", cmd_logout,
+                         "forget the credentials stored for an instance")
+    logout.add_argument("--all", action="store_true", help="every instance, not just the active one")
+    logout.add_argument("--session-only", action="store_true",
+                        help="drop the password session but keep the API token")
+
+    add_command(subparsers, "whoami", cmd_whoami, "show the authenticated account and its role")
+
+    profile = group_parser(subparsers, "profile", "manage saved instances", aliases=["profiles"])
+    add_command(profile, "list", cmd_profile_list, "list saved profiles")
+    use = add_command(profile, "use", cmd_profile_use, "make a profile the active one")
+    use.add_argument("name")
+    add_command(profile, "show", cmd_profile_show,
+                "show the active profile and where each setting came from")
+    remove = add_command(profile, "remove", cmd_profile_remove, "delete a saved profile")
+    remove.add_argument("name")
+
+    token = group_parser(subparsers, "token", "manage API tokens (needs a password session)")
+    add_command(token, "list", cmd_token_list, "list your API tokens")
+    create = add_command(token, "create", cmd_token_create, "mint an API token (shown once)")
+    create.add_argument("name", help="what this token is for — it appears in Settings")
+    create.add_argument("--scopes", default="data:read,data:write,portal:read,portal:write,portal:publish",
+                        help="comma-separated: data:read, data:write, portal:read, portal:write, "
+                             "portal:publish, users:admin")
+    create.add_argument("--expires", type=int, default=90, choices=[30, 90, 365],
+                        help="days until it expires (default 90)")
+    create.add_argument("--save", action="store_true",
+                        help="store the new token as this instance's credential")
+    revoke = add_command(token, "revoke", cmd_token_revoke, "revoke an API token")
+    revoke.add_argument("id", type=int)
+
+
+# ── login ────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_login(ctx, args) -> int:
+    from ...client import Client
+
+    url = cfg.normalize_url(args.url)
+    out = ctx.out
+
+    token = getattr(args, "token", None)
+    if args.token_stdin:
+        token = sys.stdin.readline().strip()
+    if not token and not args.password and not args.password_stdin:
+        if not sys.stdin.isatty():
+            raise ConfigError("Pass --token, --token-stdin, or --password-stdin with --email.")
+        out.info("Create a token in {0} → Settings → API tokens. It is shown once.".format(url))
+        token = getpass.getpass("API token (input hidden): ").strip()
+
+    client = Client(url, token=token or None,
+                    verify_tls=not getattr(args, "insecure", False))
+
+    jwt = None
+    if args.password or args.password_stdin:
+        email = args.email
+        if not email:
+            if not sys.stdin.isatty():
+                raise ConfigError("--password-stdin needs --email.")
+            email = input("Email: ").strip()
+        if args.password_stdin:
+            password = sys.stdin.readline().rstrip("\n")
+        else:
+            password = getpass.getpass("Password for {0} (input hidden): ".format(email))
+        jwt = client.login(email, password)
+        del password  # nothing keeps it: not the config, not this process any longer than needed
+        client.token = token or None   # restore the token; login() cleared it on the client
+        client.jwt = jwt
+
+    identity = client.whoami()
+
+    name = args.name or _profile_name(url)
+    ctx.config.set_profile(name, url, email=identity.get("email"))
+    ctx.config.save()
+    where = cfg.save_credential(url, token=token or None, jwt=jwt,
+                                email=identity.get("email"),
+                                use_keyring=not getattr(args, "no_keyring", False))
+
+    if ctx.out.json_mode:
+        ctx.out.json({"ok": True, "instance": url, "profile": name, "stored": where,
+                      "user": identity, "session": bool(jwt)})
+        return EXIT_OK
+    out.success("Logged in to {0} as {1} ({2}).".format(url, identity.get("email"),
+                                                        identity.get("role")))
+    out.info("Profile {0!r} is now active; credentials stored in {1}.".format(name, where))
+    if jwt:
+        out.info("A password session was stored too — that is what the admin commands use. "
+                 "It expires in 7 days, and a password change revokes it immediately.")
+    elif token:
+        out.info("Administration commands (`geodeploy admin …`) need `--password`, because the "
+                 "API refuses API tokens on those routes by design.")
+    return EXIT_OK
+
+
+def _profile_name(url: str) -> str:
+    host = url.split("://", 1)[-1].split("/", 1)[0]
+    return host.split(":")[0] or "default"
+
+
+def cmd_logout(ctx, args) -> int:
+    kind = "jwt" if args.session_only else None
+    if args.all:
+        removed = []
+        for name, entry in list(ctx.config.profiles.items()):
+            if entry.get("url") and cfg.delete_token(entry["url"], kind):
+                removed.append(entry["url"])
+        ctx.out.render({"ok": True, "forgotten": removed})
+        if not ctx.out.json_mode:
+            ctx.out.success("Forgot credentials for {0} instance(s).".format(len(removed)))
+        return EXIT_OK
+
+    info = ctx.resolved
+    if not info.url:
+        ctx.out.error("No instance to log out of.")
+        return EXIT_USAGE
+    removed = cfg.delete_token(info.url, kind)
+    if ctx.out.json_mode:
+        ctx.out.json({"ok": True, "instance": info.url, "forgotten": removed})
+        return EXIT_OK
+    if removed:
+        ctx.out.success("Forgot {0} for {1}.".format(
+            "the password session" if args.session_only else "the stored credentials", info.url))
+    else:
+        ctx.out.info("Nothing was stored for {0}.".format(info.url))
+    return EXIT_OK
+
+
+# ── whoami / profiles ────────────────────────────────────────────────────────────────────────────
+
+def cmd_whoami(ctx, args) -> int:
+    info = ctx.resolved
+    if not info.url:
+        ctx.out.error("Not logged in to any instance.",
+                      hint="Run `geodeploy login <url>`, or set GEODEPLOY_URL and GEODEPLOY_TOKEN.")
+        return EXIT_AUTH
+    identity = ctx.client().whoami()
+    payload = dict(identity)
+    payload.update({"instance": info.url, "profile": info.profile,
+                    "credential": _credential_kind(info)})
+    ctx.out.render(payload, ["instance", "profile", "credential", "email", "name", "role", "id"])
+    return EXIT_OK
+
+
+def _credential_kind(info) -> str:
+    if info.token:
+        return "API token ({0})".format(info.source_token)
+    if info.jwt:
+        return "password session (stored)"
+    return "none"
+
+
+def cmd_profile_list(ctx, args) -> int:
+    rows = []
+    for name, entry in sorted(ctx.config.profiles.items()):
+        stored = cfg.load_credential(entry.get("url") or "") if entry.get("url") else {}
+        rows.append({"active": name == ctx.config.current, "name": name,
+                     "url": entry.get("url"), "email": entry.get("email"),
+                     "token": bool(stored.get("token")), "session": bool(stored.get("jwt"))})
+    ctx.out.render(rows, ["active", "name", "url", "email", "token", "session"],
+                   empty="No profiles yet — run `geodeploy login <url>`.")
+    return EXIT_OK
+
+
+def cmd_profile_use(ctx, args) -> int:
+    if args.name not in ctx.config.profiles:
+        ctx.out.error("No profile named {0!r}.".format(args.name),
+                      hint="`geodeploy profile list` shows what there is.")
+        return EXIT_GENERIC
+    ctx.config.current = args.name
+    ctx.config.save()
+    ctx.out.render({"ok": True, "current": args.name,
+                    "url": ctx.config.profiles[args.name].get("url")})
+    if not ctx.out.json_mode:
+        ctx.out.success("Now using {0} ({1}).".format(
+            args.name, ctx.config.profiles[args.name].get("url")))
+    return EXIT_OK
+
+
+def cmd_profile_show(ctx, args) -> int:
+    info = ctx.resolved
+    ctx.out.render({"profile": info.profile, "instance": info.url,
+                    "instance_from": info.source_url, "credential": _credential_kind(info),
+                    "credential_from": info.source_token, "email": info.email,
+                    "config_file": cfg.config_path(),
+                    "credentials_file": cfg.credentials_path()},
+                   ["profile", "instance", "instance_from", "credential", "credential_from",
+                    "email", "config_file", "credentials_file"])
+    return EXIT_OK
+
+
+def cmd_profile_remove(ctx, args) -> int:
+    entry = ctx.config.profiles.get(args.name)
+    if not ctx.config.remove_profile(args.name):
+        ctx.out.error("No profile named {0!r}.".format(args.name))
+        return EXIT_GENERIC
+    ctx.config.save()
+    if entry and entry.get("url"):
+        cfg.delete_token(entry["url"])
+    ctx.out.render({"ok": True, "removed": args.name})
+    if not ctx.out.json_mode:
+        ctx.out.success("Removed profile {0!r} and its stored credentials.".format(args.name))
+    return EXIT_OK
+
+
+# ── API tokens ───────────────────────────────────────────────────────────────────────────────────
+
+def cmd_token_list(ctx, args) -> int:
+    rows = ctx.client(session=True).tokens()
+    ctx.out.render(rows, ["id", "name", "prefix", "scopes", "expires_at", "last_used_at"],
+                   empty="No API tokens.")
+    return EXIT_OK
+
+
+def cmd_token_create(ctx, args) -> int:
+    scopes = [s.strip() for s in args.scopes.split(",") if s.strip()]
+    created = ctx.client(session=True).create_token(args.name, scopes, args.expires)
+    if ctx.out.json_mode:
+        ctx.out.json(created)
+    else:
+        ctx.out.render(created, ["id", "name", "prefix", "scopes", "expires_at", "token"])
+        ctx.out.warn("Copy the token now — it is stored hashed and cannot be shown again.")
+    if args.save and created.get("token"):
+        where = cfg.save_credential(ctx.resolved.url, token=created["token"])
+        ctx.out.info("Saved as this instance's credential ({0}).".format(where))
+    return EXIT_OK
+
+
+def cmd_token_revoke(ctx, args) -> int:
+    ctx.client(session=True).revoke_token(args.id)
+    ctx.out.render({"ok": True, "revoked": args.id})
+    if not ctx.out.json_mode:
+        ctx.out.success("Token {0} revoked.".format(args.id))
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/browse.py
+++ b/cli/geodeploy/cli/commands/browse.py
@@ -7,6 +7,7 @@ plugin needs, and the reason this exists in the client rather than only in a plu
 """
 from __future__ import annotations
 
+from ...config import split_portal_url
 from ...errors import GeoDeployError, NotFoundError
 from ..main import add_command
 from ..output import EXIT_GENERIC, EXIT_OK
@@ -24,14 +25,17 @@ examples:
   geodeploy browse https://geodeploy.example.org      anyone can run this
   geodeploy browse                                    the instance you are logged in to
   geodeploy browse --portal field-sites-2026          what one portal contains
+  geodeploy browse https://gd.example.org/portals/5b5c627cfd/    a portal URL, pasted whole
   geodeploy browse --json | jq '.layers.raster'       machine-readable
 
 With a token stored (or --token), it also reports what that token can see beyond the public
 surface, which is usually the point of having one.
 """)
     parser.add_argument("instance", nargs="?",
-                        help="instance URL (default: the active profile)")
-    parser.add_argument("--portal", help="show one portal's layers, read from its published style")
+                        help="instance URL, or a published portal's URL "
+                             "(default: the active profile)")
+    parser.add_argument("--portal", metavar="SLUG_OR_URL",
+                        help="show one portal's layers, read from its published style")
     parser.add_argument("--kind", choices=["raster", "postgis", "geoparquet"],
                         help="only this kind of layer")
     parser.add_argument("--links", action="store_true",
@@ -39,8 +43,16 @@ surface, which is usually the point of having one.
 
 
 def cmd_browse(ctx, args) -> int:
-    if args.instance:
-        args.url = args.instance          # the positional is just a friendlier --url
+    instance = args.instance
+    if instance and not args.portal and "/portals/" in instance:
+        # A portal's own URL, pasted whole. It names both the instance and the portal, so it does
+        # not need --portal and must not be read as an instance URL.
+        instance, args.portal = split_portal_url(instance)
+    elif args.portal:
+        origin, args.portal = split_portal_url(args.portal)
+        instance = instance or origin     # a full portal URL brings its instance with it
+    if instance:
+        args.url = instance               # the positional is just a friendlier --url
         ctx._resolved = None              # re-resolve against it
     client = ctx.client(auth_required=False)
     out = ctx.out

--- a/cli/geodeploy/cli/commands/browse.py
+++ b/cli/geodeploy/cli/commands/browse.py
@@ -1,0 +1,162 @@
+"""`geodeploy browse` — point at an instance and see what it offers.
+
+The one command that needs no account: give it a URL and it prints the public portals and the
+public layers, grouped by how they are stored, with the URL each one is best consumed by. With a
+token it also shows what that token can see — which is the same two-mode behaviour a desktop
+plugin needs, and the reason this exists in the client rather than only in a plugin.
+"""
+from __future__ import annotations
+
+from ...errors import GeoDeployError, NotFoundError
+from ..main import add_command
+from ..output import EXIT_GENERIC, EXIT_OK
+
+KIND_LABEL = {"postgis": "Vector (PostGIS)", "geoparquet": "Vector (GeoParquet)",
+              "raster": "Raster (COG)"}
+
+
+def register(subparsers) -> None:
+    parser = add_command(
+        subparsers, "browse", cmd_browse,
+        "see what an instance publishes — no account needed",
+        epilog="""\
+examples:
+  geodeploy browse https://geodeploy.example.org      anyone can run this
+  geodeploy browse                                    the instance you are logged in to
+  geodeploy browse --portal field-sites-2026          what one portal contains
+  geodeploy browse --json | jq '.layers.raster'       machine-readable
+
+With a token stored (or --token), it also reports what that token can see beyond the public
+surface, which is usually the point of having one.
+""")
+    parser.add_argument("instance", nargs="?",
+                        help="instance URL (default: the active profile)")
+    parser.add_argument("--portal", help="show one portal's layers, read from its published style")
+    parser.add_argument("--kind", choices=["raster", "postgis", "geoparquet"],
+                        help="only this kind of layer")
+    parser.add_argument("--links", action="store_true",
+                        help="print every access URL for each layer, not just a summary")
+
+
+def cmd_browse(ctx, args) -> int:
+    if args.instance:
+        args.url = args.instance          # the positional is just a friendlier --url
+        ctx._resolved = None              # re-resolve against it
+    client = ctx.client(auth_required=False)
+    out = ctx.out
+
+    if args.portal:
+        return _one_portal(ctx, client, args)
+
+    try:
+        index = client.catalog.public()
+    except NotFoundError:
+        out.error("{0} does not publish a public index.".format(client.url),
+                  hint="An admin can turn it on in Settings, or you can list what your token can "
+                       "see with `geodeploy layers list` and `geodeploy portals list`.")
+        return EXIT_GENERIC
+
+    if out.json_mode:
+        payload = dict(index)
+        private = _private_view(ctx)
+        if private:
+            payload["with_your_token"] = private
+        out.json(payload)
+        return EXIT_OK
+
+    counts = index.get("counts") or {}
+    out.out(out.bold("{0}".format(client.url)))
+    out.out(out.dim("{0} public portal(s), {1} public layer(s)".format(
+        counts.get("portals", 0),
+        sum(v for k, v in counts.items() if k != "portals"))))
+
+    portals = index.get("portals") or []
+    if portals:
+        out.out("")
+        out.out(out.bold("Portals"))
+        out.table([{"slug": p.get("slug"), "title": p.get("title"),
+                    "experience": p.get("experience"), "layers": p.get("layer_count"),
+                    "url": p.get("url")} for p in portals],
+                  ["slug", "title", "experience", "layers", "url"])
+
+    layers = index.get("layers") or {}
+    for kind in ("postgis", "geoparquet", "raster"):
+        rows = layers.get(kind) or []
+        if not rows or (args.kind and args.kind != kind):
+            continue
+        out.out("")
+        out.out(out.bold("{0} — {1}".format(KIND_LABEL[kind], len(rows))))
+        out.table([{"id": r.get("id"), "name": r.get("name"),
+                    "geometry": r.get("geometry_type") or ("{0} band(s)".format(r.get("band_count"))
+                                                           if r.get("band_count") else None),
+                    "features": r.get("feature_count"), "crs": r.get("crs"),
+                    "licence": r.get("license")} for r in rows],
+                  ["id", "name", "geometry", "features", "crs", "licence"])
+        if args.links:
+            for row in rows:
+                out.out("")
+                out.out("  " + out.bold(row.get("name") or "?"))
+                for link in row.get("links") or []:
+                    out.out("    {0}  {1}".format(link.get("label"), link.get("url")))
+
+    catalogs = index.get("catalogs") or {}
+    out.out("")
+    out.info("Standards: OGC API - Features {0} · STAC {1}".format(
+        catalogs.get("ogc_features"), catalogs.get("stac")))
+
+    private = _private_view(ctx)
+    if private:
+        out.info("With your token: {0} layer(s) and {1} portal(s) in total — "
+                 "`geodeploy layers list` shows them.".format(private["layers"], private["portals"]))
+    elif not ctx.resolved.token:
+        out.info("No token in use: this is the anonymous view. `geodeploy login <url> --token …` "
+                 "to see everything you have access to.")
+    return EXIT_OK
+
+
+def _private_view(ctx):
+    """What the caller's own credential can see, when there is one. Best-effort by design:
+    browsing must not fail because a token expired."""
+    if not (ctx.resolved.token or ctx.resolved.jwt):
+        return None
+    try:
+        client = ctx.client(auth_required=False)
+        return {"layers": len(client.layers.list()), "portals": len(client.portals.list())}
+    except GeoDeployError:
+        return None
+
+
+def _one_portal(ctx, client, args) -> int:
+    """Read a published portal's own style.json — the whole portal, anonymously."""
+    out = ctx.out
+    slug = args.portal
+    style_url = "{0}/portals/{1}/style.json".format(client.url, slug)
+    try:
+        style = client.catalog.portal_style(style_url)
+    except GeoDeployError as exc:
+        out.error("Could not read portal {0!r}: {1}".format(slug, exc),
+                  hint="Public portals only — a password or members-only portal will not open "
+                       "without a session.")
+        return EXIT_GENERIC
+
+    meta = style.get("geodeploy") or {}
+    if out.json_mode:
+        out.json(style)
+        return EXIT_OK
+
+    out.out(out.bold(meta.get("title") or slug))
+    out.out(out.dim("{0}/portals/{1}/".format(client.url, slug)))
+    out.out("")
+    rows = []
+    for layer in style.get("layers") or []:
+        source = layer.get("source")
+        if not source or source in ("basemap", "composite"):
+            continue        # the basemap the template ships, not the author's data
+        rows.append({"id": layer.get("id"), "type": layer.get("type"), "source": source})
+    for deck in meta.get("deckLayers") or []:
+        rows.append({"id": deck.get("id") or deck.get("name"), "type": "deck.gl (GeoParquet)",
+                     "source": deck.get("url") or deck.get("manifest")})
+    out.table(rows, ["id", "type", "source"], )
+    if meta.get("bounds"):
+        out.info("Extent: {0}".format(meta["bounds"]))
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/browse.py
+++ b/cli/geodeploy/cli/commands/browse.py
@@ -159,16 +159,66 @@ def _one_portal(ctx, client, args) -> int:
     out.out(out.bold(meta.get("title") or slug))
     out.out(out.dim("{0}/portals/{1}/".format(client.url, slug)))
     out.out("")
-    rows = []
-    for layer in style.get("layers") or []:
+
+    sources = style.get("sources") or {}
+    rows, urls = [], {}
+    for layer in _data_layers(style):
+        lmeta = layer.get("metadata") or {}
         source = layer.get("source")
-        if not source or source in ("basemap", "composite"):
-            continue        # the basemap the template ships, not the author's data
-        rows.append({"id": layer.get("id"), "type": layer.get("type"), "source": source})
+        row = {"name": lmeta.get("geodeploy:name") or layer.get("id"),
+               "kind": lmeta.get("geodeploy:geometry") or layer.get("type"),
+               "id": layer.get("id"),
+               "visible": "no" if _hidden(layer) else "yes"}
+        rows.append(row)
+        urls[row["id"]] = _source_url(sources.get(source) or {})
     for deck in meta.get("deckLayers") or []:
-        rows.append({"id": deck.get("id") or deck.get("name"), "type": "deck.gl (GeoParquet)",
-                     "source": deck.get("url") or deck.get("manifest")})
-    out.table(rows, ["id", "type", "source"], )
+        ident = deck.get("id") or deck.get("name")
+        rows.append({"name": deck.get("name") or ident, "kind": "GeoParquet (deck.gl)",
+                     "id": ident, "visible": "no" if deck.get("visible") is False else "yes"})
+        urls[ident] = deck.get("url") or deck.get("manifest") or ""
+
+    columns = ["name", "kind", "id"]
+    if any(r["visible"] == "no" for r in rows):
+        columns.append("visible")       # only worth a column when something is actually off
+    out.table(rows, columns)
+
+    if args.links:
+        out.out("")
+        for row in rows:
+            if urls.get(row["id"]):
+                out.out("  {0}  {1}".format(out.bold(row["name"]), urls[row["id"]]))
     if meta.get("bounds"):
         out.info("Extent: {0}".format(meta["bounds"]))
+    if not args.links:
+        out.info("`--links` adds the data URL behind each layer.")
     return EXIT_OK
+
+
+def _data_layers(style):
+    """The author's layers, without the basemap's and without counting one layer twice.
+
+    A layer can be drawn by several MapLibre layers (a fill plus its outline, a polygon plus its
+    3D pillars); the generator flags the extras `geodeploy:part` and puts the metadata on the
+    first, which is exactly the rule the portal's own layer switcher follows.
+    """
+    layers = style.get("layers") or []
+    tagged = [l for l in layers
+              if (l.get("metadata") or {}).get("geodeploy:layer_id") is not None
+              and not (l.get("metadata") or {}).get("geodeploy:part")]
+    if tagged:
+        return tagged
+    # An older bundle, published before the metadata existed: fall back to "not the basemap".
+    return [l for l in layers
+            if l.get("source") and l.get("source") not in ("basemap", "composite")]
+
+
+def _hidden(layer):
+    return ((layer.get("layout") or {}).get("visibility")) == "none"
+
+
+def _source_url(source):
+    """Where a MapLibre source actually reads from — a tile template, a TileJSON or inline data."""
+    tiles = source.get("tiles")
+    if tiles:
+        return tiles[0]
+    return source.get("url") or (source.get("data") if isinstance(source.get("data"), str) else "")

--- a/cli/geodeploy/cli/commands/catalog.py
+++ b/cli/geodeploy/cli/commands/catalog.py
@@ -1,0 +1,107 @@
+"""`geodeploy catalog …` — the public surfaces: OGC API - Features, STAC, templates, basemaps.
+
+These need no credentials, which makes this group the honest way to check what you have actually
+published: if a layer is not listed here, nobody outside your organisation can see it either.
+"""
+from __future__ import annotations
+
+import json
+
+from ..main import add_command, group_parser
+from ..output import EXIT_OK
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "catalog",
+                         "what this instance publishes: OGC API - Features, STAC, templates")
+
+    add_command(group, "collections", cmd_collections,
+                "OGC API - Features collections (one per public vector layer)")
+
+    items = add_command(group, "items", cmd_items, "features from a collection")
+    items.add_argument("collection", help="collection id, e.g. vector-a1b2c3d4e5f6")
+    items.add_argument("--bbox", help="minx,miny,maxx,maxy")
+    items.add_argument("--limit", type=int, default=10)
+    items.add_argument("--offset", type=int, default=0)
+
+    add_command(group, "conformance", cmd_conformance,
+                "what the OGC endpoint claims to support")
+
+    stac = add_command(group, "stac", cmd_stac, "the STAC catalog root and its collections")
+    stac.add_argument("--collection", help="list items in this collection (vectors | rasters)")
+    stac.add_argument("--limit", type=int, default=20)
+
+    search = add_command(group, "search", cmd_search, "STAC search across public layers")
+    search.add_argument("--bbox")
+    search.add_argument("--collections")
+    search.add_argument("--datetime", dest="datetime_", help="instant or start/end (.. is open)")
+    search.add_argument("--ids")
+    search.add_argument("--limit", type=int, default=20)
+
+    add_command(group, "templates", cmd_templates, "portal templates and the experiences they suit")
+    add_command(group, "basemaps", cmd_basemaps, "basemaps available to portals")
+
+
+def _client(ctx):
+    # Public endpoints: a URL is enough, no credential required.
+    return ctx.client(auth_required=False)
+
+
+def cmd_collections(ctx, args) -> int:
+    rows = _client(ctx).catalog.collections()
+    ctx.out.render([{"id": c.get("id"), "title": c.get("title"),
+                     "extent": ((c.get("extent") or {}).get("spatial") or {}).get("bbox")}
+                    for c in rows], ["id", "title", "extent"],
+                   empty="No public collections — share a vector layer publicly to add one.")
+    return EXIT_OK
+
+
+def cmd_items(ctx, args) -> int:
+    data = _client(ctx).catalog.items(args.collection, bbox=args.bbox, limit=args.limit,
+                                      offset=args.offset)
+    if ctx.out.json_mode:
+        ctx.out.json(data)
+        return EXIT_OK
+    ctx.out.info("{0} returned, {1} matched.".format(data.get("numberReturned"),
+                                                     data.get("numberMatched", "unknown")))
+    ctx.out.out(json.dumps(data, indent=2, ensure_ascii=False)[:20000])
+    return EXIT_OK
+
+
+def cmd_conformance(ctx, args) -> int:
+    ctx.out.render((_client(ctx).catalog.conformance() or {}).get("conformsTo") or [])
+    return EXIT_OK
+
+
+def cmd_stac(ctx, args) -> int:
+    catalog = _client(ctx).catalog
+    if args.collection:
+        ctx.out.render(catalog.stac_items(args.collection, limit=args.limit))
+        return EXIT_OK
+    ctx.out.render([{"id": c.get("id"), "title": c.get("title"), "description": c.get("description")}
+                    for c in catalog.stac_collections()], ["id", "title", "description"])
+    return EXIT_OK
+
+
+def cmd_search(ctx, args) -> int:
+    data = _client(ctx).catalog.search(bbox=args.bbox, collections=args.collections,
+                                       datetime=args.datetime_, ids=args.ids, limit=args.limit)
+    if ctx.out.json_mode:
+        ctx.out.json(data)
+        return EXIT_OK
+    features = data.get("features") or []
+    ctx.out.table([{"id": f.get("id"), "collection": f.get("collection"),
+                    "assets": ", ".join(sorted((f.get("assets") or {}).keys()))}
+                   for f in features], ["id", "collection", "assets"])
+    return EXIT_OK
+
+
+def cmd_templates(ctx, args) -> int:
+    ctx.out.render(_client(ctx).catalog.templates(),
+                   ["id", "name", "archetypes", "archetype", "tags", "is_official", "version"])
+    return EXIT_OK
+
+
+def cmd_basemaps(ctx, args) -> int:
+    ctx.out.render(_client(ctx).catalog.basemaps(), ["id", "name", "type", "attribution"])
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/imports.py
+++ b/cli/geodeploy/cli/commands/imports.py
@@ -1,0 +1,125 @@
+"""`geodeploy import …` — register data that is already in the database or the bucket.
+
+Nothing is copied and nothing is moved: a PostGIS table is introspected and registered where it
+stands, and an object in storage is attached by key. This is how you point a fresh instance at
+data that is already on the server, without a round trip through your laptop.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..main import add_command, group_parser
+from ..output import EXIT_GENERIC, EXIT_OK
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "import", "register existing PostGIS tables or storage objects",
+                         aliases=["discover"])
+
+    db_list = add_command(group, "db-list", cmd_db_list,
+                          "spatial tables in the database, and whether they are registered")
+    db_list.add_argument("--all", action="store_true", help="include already-imported tables")
+
+    db_add = add_command(group, "db-add", cmd_db_add, "register PostGIS tables as layers",
+                         epilog="examples:\n  geodeploy import db-add public.roads public.sites\n")
+    db_add.add_argument("tables", nargs="+", help="schema.table (as listed by db-list)")
+    db_add.add_argument("--name", help="display name (single table only)")
+
+    st_list = add_command(group, "storage-list", cmd_storage_list,
+                          "GeoTIFF / GeoParquet / CSV objects in the bucket")
+    st_list.add_argument("--kind", choices=["raster", "geoparquet", "csv"])
+
+    st_add = add_command(group, "storage-add", cmd_storage_add,
+                         "attach storage objects as layers (GeoParquet is inspected + prepared)")
+    st_add.add_argument("keys", nargs="+", help="object keys as listed by storage-list")
+    st_add.add_argument("--name", help="display name (single object only)")
+    st_add.add_argument("--wait", action="store_true", help="wait for any queued jobs")
+
+    csv_cols = add_command(group, "csv-columns", cmd_csv_columns, "header of a CSV in the bucket")
+    csv_cols.add_argument("key")
+    csv_cols.add_argument("--delimiter", default="comma",
+                          choices=["comma", "semicolon", "tab", "pipe", "space"])
+
+    csv_add = add_command(group, "csv", cmd_csv, "build a PostGIS layer from a CSV in the bucket")
+    csv_add.add_argument("key")
+    csv_add.add_argument("--name")
+    csv_add.add_argument("--x", dest="x_column")
+    csv_add.add_argument("--y", dest="y_column")
+    csv_add.add_argument("--wkt", dest="wkt_column")
+    csv_add.add_argument("--srid", type=int, default=4326)
+    csv_add.add_argument("--delimiter", default="comma",
+                         choices=["comma", "semicolon", "tab", "pipe", "space"])
+    csv_add.add_argument("--wait", action="store_true")
+
+
+def cmd_db_list(ctx, args) -> int:
+    rows = ctx.client().imports.database_tables()
+    if not args.all:
+        rows = [r for r in rows if not r.get("imported")]
+    ctx.out.render(rows, ["schema_name", "table_name", "geometry_column", "geometry_type", "srid",
+                          "imported"],
+                   empty="No spatial tables found (or all of them are already registered).")
+    return EXIT_OK
+
+
+def cmd_db_add(ctx, args) -> int:
+    available = {"{0}.{1}".format(r.get("schema_name"), r.get("table_name")): r
+                 for r in ctx.client().imports.database_tables()}
+    tables = []  # type: List[Dict[str, Any]]
+    for ref in args.tables:
+        found = available.get(ref)
+        if not found:
+            ctx.out.error("No spatial table {0!r}. `geodeploy import db-list` shows what there is."
+                          .format(ref))
+            return EXIT_GENERIC
+        entry = {"schema_name": found["schema_name"], "table_name": found["table_name"],
+                 "geometry_column": found.get("geometry_column"),
+                 "srid": found.get("srid") or 0,
+                 "geometry_type": found.get("geometry_type")}
+        if args.name and len(args.tables) == 1:
+            entry["name"] = args.name
+        tables.append(entry)
+    result = ctx.client().imports.database(tables)
+    ctx.out.render(result)
+    if not ctx.out.json_mode:
+        ctx.out.success("Registered {0} table(s).".format(len(tables)))
+    return EXIT_OK
+
+
+def cmd_storage_list(ctx, args) -> int:
+    ctx.out.render(ctx.client().imports.storage_objects(args.kind),
+                   ["key", "kind", "size", "imported"], empty="Nothing importable in the bucket.")
+    return EXIT_OK
+
+
+def cmd_storage_add(ctx, args) -> int:
+    items = [{"key": key} for key in args.keys]
+    if args.name and len(items) == 1:
+        items[0]["name"] = args.name
+    result = ctx.client().imports.storage(items)
+    jobs = (result or {}).get("jobs") or []
+    ctx.out.render(result)
+    if args.wait and jobs:
+        for job in jobs:
+            ctx.client().jobs.wait(job.get("id"), "vector",
+                                   on_progress=lambda st: ctx.out.info("  {0:3d}%  {1}".format(
+                                       st.get("progress") or 0, st.get("current_step") or "")))
+        ctx.out.success("All queued imports finished.")
+    return EXIT_OK
+
+
+def cmd_csv_columns(ctx, args) -> int:
+    ctx.out.render(ctx.client().imports.csv_columns(args.key, args.delimiter))
+    return EXIT_OK
+
+
+def cmd_csv(ctx, args) -> int:
+    job = ctx.client().imports.csv(args.key, name=args.name, x_column=args.x_column,
+                                   y_column=args.y_column, wkt_column=args.wkt_column,
+                                   srid=args.srid, delimiter=args.delimiter)
+    if args.wait and job.get("id"):
+        job = ctx.client().jobs.wait(job["id"], "vector",
+                                     on_progress=lambda st: ctx.out.info("  {0:3d}%  {1}".format(
+                                         st.get("progress") or 0, st.get("current_step") or "")))
+    ctx.out.render(job)
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/jobs.py
+++ b/cli/geodeploy/cli/commands/jobs.py
@@ -1,0 +1,38 @@
+"""`geodeploy jobs …` — ingest jobs, and waiting for one."""
+from __future__ import annotations
+
+from ..main import add_command, group_parser
+from ..output import EXIT_OK
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "jobs", "ingest job status")
+
+    show = add_command(group, "show", cmd_show, "the current state of a job")
+    show.add_argument("job_id")
+    show.add_argument("--type", dest="layer_type", choices=["vector", "raster"], default="vector")
+
+    watch = add_command(group, "watch", cmd_watch, "follow a job until it finishes")
+    watch.add_argument("job_id")
+    watch.add_argument("--type", dest="layer_type", choices=["vector", "raster"], default="vector")
+    watch.add_argument("--interval", type=float, default=2.0)
+    watch.add_argument("--max-wait", dest="max_wait", type=float, default=3600.0,
+                       help="give up after this many seconds (the job keeps running server-side)")
+
+
+def cmd_show(ctx, args) -> int:
+    ctx.out.render(ctx.client().jobs.get(args.job_id, args.layer_type),
+                   ["id", "layer_id", "layer_type", "status", "progress", "current_step",
+                    "error_message"])
+    return EXIT_OK
+
+
+def cmd_watch(ctx, args) -> int:
+    final = ctx.client().jobs.wait(
+        args.job_id, args.layer_type, interval=args.interval, timeout=args.max_wait,
+        on_progress=lambda st: ctx.out.info("  {0:3d}%  {1}".format(
+            st.get("progress") or 0, st.get("current_step") or st.get("status") or "")))
+    ctx.out.render(final, ["id", "layer_id", "layer_type", "status", "progress", "current_step"])
+    if not ctx.out.json_mode:
+        ctx.out.success("Job {0} finished.".format(args.job_id))
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -1,0 +1,388 @@
+"""`geodeploy layers …` — the data on an instance.
+
+A layer can be named by id, uid or name everywhere, because typing `roads` is what a person does
+and looking up `7` is what a machine does.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+from ...errors import GeoDeployError, ValidationError
+from ..main import add_command, group_parser
+from ..output import EXIT_GENERIC, EXIT_OK, human_size
+from ._common import (add_style_args, confirm, layer_ref_arg, parse_fields, resolve_layer,
+                      style_from_args, write_json_file)
+
+LIST_COLUMNS = ["layer_type", "id", "name", "status", "geometry_type", "feature_count",
+                "storage_backend", "visibility", "created_by"]
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "layers", "list, inspect, style, share and delete data layers",
+                         aliases=["data"])
+
+    listing = add_command(group, "list", cmd_list, "list layers", aliases=["ls"])
+    listing.add_argument("--type", dest="kind", choices=["vector", "raster", "all"], default="all")
+    listing.add_argument("--status", help="only layers in this state (ready, processing, error)")
+    listing.add_argument("--visibility", choices=["private", "organization", "public"])
+    listing.add_argument("--query", dest="search",
+                         help="match name, abstract or keywords")
+
+    show = add_command(group, "show", cmd_show, "everything known about one layer")
+    layer_ref_arg(show)
+
+    rename = add_command(group, "rename", cmd_rename, "change a layer's display name")
+    layer_ref_arg(rename)
+    rename.add_argument("name")
+
+    share = add_command(group, "share", cmd_share,
+                        "set visibility and catalog metadata (public = STAC + OGC + raw asset)")
+    layer_ref_arg(share)
+    share.add_argument("--visibility", choices=["private", "organization", "public"])
+    share.add_argument("--abstract")
+    share.add_argument("--license")
+    share.add_argument("--attribution")
+    share.add_argument("--keywords", help="comma-separated")
+
+    style = add_command(group, "style", cmd_style,
+                        "set a layer's DEFAULT styling — what a portal starts from",
+                        epilog="""\
+examples:
+  geodeploy layers style roads --color '#e11d48' --line-width 2
+  geodeploy layers style sites --marker star --radius 6 --outline-color none
+  geodeploy layers style parcels --color-field pop --classify jenks --classes 6 --ramp magma
+  geodeploy layers style dem --colormap terrain --rescale 0,2400
+""")
+    layer_ref_arg(style)
+    style.add_argument("--popup-fields", help="comma-separated attribute names for popups")
+    style.add_argument("--replace", action="store_true",
+                       help="replace the whole style instead of merging into it")
+    add_style_args(style)
+
+    fields = add_command(group, "fields", cmd_fields, "the attribute columns of a vector layer")
+    layer_ref_arg(fields)
+
+    stats = add_command(group, "stats", cmd_stats,
+                        "distribution of one attribute (vector) or band statistics (raster)")
+    layer_ref_arg(stats)
+    stats.add_argument("--field", help="attribute to summarise (vector layers)")
+    stats.add_argument("--classes", type=int, default=5)
+    stats.add_argument("--method", choices=["quantile", "equal", "jenks"], default="quantile")
+    stats.add_argument("--ramp", default="viridis")
+
+    links = add_command(group, "links", cmd_links,
+                        "share URLs for this layer, labelled by the tool each one suits")
+    layer_ref_arg(links)
+
+    usage = add_command(group, "usage", cmd_usage, "which portals include this layer")
+    layer_ref_arg(usage)
+
+    features = add_command(group, "features", cmd_features, "GeoJSON features from a vector layer")
+    layer_ref_arg(features)
+    features.add_argument("--bbox", help="minx,miny,maxx,maxy in EPSG:4326")
+    features.add_argument("--limit", type=int, default=1000)
+    features.add_argument("-o", "--output", help="write to a file (UTF-8) instead of stdout")
+
+    identify = add_command(group, "identify", cmd_identify,
+                           "attributes of the features under a point")
+    layer_ref_arg(identify)
+    identify.add_argument("lng", type=float)
+    identify.add_argument("lat", type=float)
+    identify.add_argument("--tolerance", type=float, default=1e-4)
+    identify.add_argument("--limit", type=int, default=10)
+
+    download = add_command(group, "download", cmd_download,
+                           "download the layer's own file (COG for rasters, PMTiles for tiled "
+                           "vectors)")
+    layer_ref_arg(download)
+    download.add_argument("-o", "--output", help="output path (default: the layer name)")
+    download.add_argument("--format", choices=["auto", "cog", "pmtiles", "geojson"], default="auto")
+
+    tile = add_command(group, "tile", cmd_tile, "(re)generate a vector layer's PMTiles archive")
+    layer_ref_arg(tile)
+    tile.add_argument("--wait", action="store_true")
+
+    prepare = add_command(group, "prepare", cmd_prepare, "re-run GeoParquet spatial preparation")
+    layer_ref_arg(prepare)
+    prepare.add_argument("--wait", action="store_true")
+
+    reprocess = add_command(group, "reprocess", cmd_reprocess,
+                            "restart a stalled or failed layer without re-uploading it")
+    layer_ref_arg(reprocess)
+    reprocess.add_argument("--wait", action="store_true")
+
+    delete = add_command(group, "delete", cmd_delete,
+                         "delete a layer (and remove it from every portal that used it)",
+                         aliases=["rm"])
+    layer_ref_arg(delete)
+    delete.add_argument("--yes", action="store_true", help="skip the confirmation")
+
+    add_command(group, "colormaps", cmd_colormaps, "raster colormaps this instance offers")
+
+
+# ── read ─────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_list(ctx, args) -> int:
+    rows = ctx.client().layers.list(args.kind, status=args.status, query=args.search,
+                                    visibility=args.visibility)
+    if not ctx.out.json_mode:
+        for row in rows:
+            if row.get("status") == "processing" and row.get("progress") is not None:
+                row["status"] = "{0}% {1}".format(row["progress"], row.get("current_step") or "")
+    ctx.out.render(rows, LIST_COLUMNS, empty="No layers yet — `geodeploy upload <file>`.")
+    return EXIT_OK
+
+
+def cmd_show(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    if not ctx.out.json_mode:
+        layer = dict(layer)
+        if layer.get("file_size"):
+            layer["file_size"] = human_size(layer["file_size"])
+    ctx.out.render(layer)
+    return EXIT_OK
+
+
+def cmd_fields(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    columns = layer.get("columns") or []
+    if not columns:
+        ctx.out.info("No column information for this layer (rasters have bands, not columns).")
+        return EXIT_OK
+    ctx.out.render(columns)
+    return EXIT_OK
+
+
+def cmd_stats(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    client = ctx.client()
+    if layer["layer_type"] == "raster":
+        ctx.out.render(client.raster.stats(layer["id"]))
+        return EXIT_OK
+    if not args.field:
+        ctx.out.error("Which attribute? Pass --field (see `geodeploy layers fields`).")
+        return EXIT_GENERIC
+    stats = client.vector.field_stats(layer["id"], args.field, classes=args.classes,
+                                      method=args.method, ramp=args.ramp)
+    if ctx.out.json_mode:
+        ctx.out.json(stats)
+        return EXIT_OK
+    ctx.out.record({k: v for k, v in stats.items() if k not in ("suggestion", "categories")})
+    suggestion = stats.get("suggestion") or {}
+    if suggestion.get("classes"):
+        ctx.out.out("")
+        ctx.out.table([{"min": c.get("min"), "max": c.get("max"), "color": c.get("color")}
+                       for c in suggestion["classes"]], ["min", "max", "color"])
+    elif stats.get("categories"):
+        ctx.out.out("")
+        ctx.out.table(stats["categories"][:25])
+    return EXIT_OK
+
+
+def cmd_links(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    data = ctx.client().layers.api(layer["layer_type"]).links(layer["id"])
+    if ctx.out.json_mode:
+        ctx.out.json(data)
+        return EXIT_OK
+    if not data.get("public"):
+        ctx.out.warn("This layer is not public, so these URLs 404 for everyone else. "
+                     "`geodeploy layers share {0} --visibility public` opens it up."
+                     .format(layer["id"]))
+    ctx.out.table(data.get("links") or [], ["label", "url", "hint"])
+    return EXIT_OK
+
+
+def cmd_usage(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    ctx.out.render(ctx.client().layers.api(layer["layer_type"]).usage(layer["id"]),
+                   ["id", "title", "published"], empty="Not used by any portal.")
+    return EXIT_OK
+
+
+def cmd_features(ctx, args) -> int:
+    layer = resolve_layer(ctx, args, )
+    if layer["layer_type"] != "vector":
+        ctx.out.error("Features are a vector thing; {0} is a raster.".format(layer["name"]))
+        return EXIT_GENERIC
+    data = ctx.client().vector.features(layer["id"], bbox=args.bbox, limit=args.limit)
+    if args.output:
+        write_json_file(args.output, data)
+        ctx.out.success("Wrote {0} ({1} features).".format(
+            args.output, len(data.get("features") or [])))
+        return EXIT_OK
+    ctx.out.out(json.dumps(data, ensure_ascii=False))
+    return EXIT_OK
+
+
+def cmd_identify(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    ref = layer.get("uid") or layer["id"]
+    ctx.out.render(ctx.client().vector.identify(ref, args.lng, args.lat, args.tolerance,
+                                                args.limit))
+    return EXIT_OK
+
+
+def cmd_download(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    client = ctx.client()
+    ref = layer.get("uid") or layer["id"]
+    kind = args.format
+    if kind == "auto":
+        if layer["layer_type"] == "raster":
+            kind = "cog"
+        elif layer.get("pmtiles_key"):
+            kind = "pmtiles"
+        else:
+            kind = "geojson"
+
+    if kind == "geojson":
+        data = client.vector.features(layer["id"], limit=1000000)
+        path = args.output or "{0}.geojson".format(_safe(layer["name"]))
+        write_json_file(path, data)
+        ctx.out.success("Wrote {0} ({1} features).".format(path, len(data.get("features") or [])))
+        return EXIT_OK
+
+    path = args.output or "{0}.{1}".format(_safe(layer["name"]),
+                                           "tif" if kind == "cog" else "pmtiles")
+    endpoint = ("/data/raster/{0}/cog" if kind == "cog" else "/data/vector/{0}/pmtiles").format(ref)
+    progress = ctx.out.progress(path)
+    try:
+        with open(path, "wb") as fh:
+            client.download(endpoint, _Counting(fh, progress))
+    except GeoDeployError:
+        progress.finish()
+        raise
+    progress.finish()
+    ctx.out.success("Wrote {0}.".format(path))
+    return EXIT_OK
+
+
+class _Counting(object):
+    """Wraps the output file so a download can show progress without buffering it."""
+
+    def __init__(self, fh, progress):
+        self._fh = fh
+        self._progress = progress
+        self._done = 0
+
+    def write(self, chunk: bytes) -> int:
+        self._done += len(chunk)
+        self._progress.update(self._done)
+        return self._fh.write(chunk)
+
+
+def cmd_colormaps(ctx, args) -> int:
+    ctx.out.render(ctx.client().raster.colormaps())
+    return EXIT_OK
+
+
+# ── write ────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_rename(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    updated = ctx.client().layers.api(layer["layer_type"]).rename(layer["id"], args.name)
+    ctx.out.render(updated, ["id", "name", "status"])
+    if not ctx.out.json_mode:
+        ctx.out.success("Renamed to {0!r}.".format(args.name))
+        ctx.out.info("Published portals keep the old name until they are re-published.")
+    return EXIT_OK
+
+
+def cmd_share(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    updated = ctx.client().layers.api(layer["layer_type"]).share(
+        layer["id"], visibility=args.visibility, abstract=args.abstract, license=args.license,
+        attribution=args.attribution, keywords=args.keywords)
+    ctx.out.render(updated, ["id", "name", "visibility", "is_public", "license", "attribution",
+                             "keywords", "abstract"])
+    if not ctx.out.json_mode and args.visibility == "public":
+        ctx.out.success("{0} is public — it now appears in the STAC catalog and OGC API - Features."
+                        .format(updated.get("name")))
+        ctx.out.info("`geodeploy layers links {0}` lists the URLs to hand out.".format(layer["id"]))
+    return EXIT_OK
+
+
+def cmd_style(ctx, args) -> int:
+    layer = resolve_layer(ctx, args)
+    client = ctx.client()
+    current = (layer.get("default_style") or {})
+    base = {} if args.replace else dict(current.get("style") or {})
+    style = style_from_args(args, client, layer.get("uid") or layer["id"], base, ctx.out)
+
+    body = {"style": style,
+            "opacity": args.opacity if args.opacity is not None else current.get("opacity", 1.0)}
+    fields = parse_fields(args.popup_fields)
+    if layer["layer_type"] == "vector":
+        body["popup_fields"] = fields if fields is not None else (current.get("popup_fields") or [])
+    else:
+        # The raster default-style body is flat: colormap/rescale/algorithm live at the top level.
+        body = {"opacity": body["opacity"]}
+        for key in ("colormap", "rescale", "algorithm", "zfactor", "bidx"):
+            if style.get(key) is not None:
+                body[key] = style[key]
+
+    updated = client.layers.api(layer["layer_type"]).set_default_style(layer["id"], body)
+    ctx.out.render(updated.get("default_style") or body)
+    if not ctx.out.json_mode:
+        ctx.out.success("Default style saved for {0}.".format(layer["name"]))
+        ctx.out.info("Portals already using this layer keep their own styling; re-publish to "
+                     "refresh a portal that follows the default.")
+    return EXIT_OK
+
+
+def cmd_tile(ctx, args) -> int:
+    return _job_command(ctx, args, "tile")
+
+
+def cmd_prepare(ctx, args) -> int:
+    return _job_command(ctx, args, "prepare")
+
+
+def cmd_reprocess(ctx, args) -> int:
+    return _job_command(ctx, args, "reprocess")
+
+
+def _job_command(ctx, args, action: str) -> int:
+    layer = resolve_layer(ctx, args)
+    if layer["layer_type"] != "vector":
+        ctx.out.error("`{0}` applies to vector layers.".format(action))
+        return EXIT_GENERIC
+    client = ctx.client()
+    result = getattr(client.vector, action)(layer["id"])
+    job_id = (result or {}).get("id") if isinstance(result, dict) else None
+    if args.wait and job_id:
+        final = client.jobs.wait(job_id, "vector",
+                                 on_progress=lambda st: ctx.out.info("  {0:3d}%  {1}".format(
+                                     st.get("progress") or 0, st.get("current_step") or "")))
+        ctx.out.render(final)
+        return EXIT_OK
+    ctx.out.render(result)
+    if not ctx.out.json_mode:
+        ctx.out.success("{0} started for {1}.".format(action.capitalize(), layer["name"]))
+    return EXIT_OK
+
+
+def cmd_delete(ctx, args) -> int:
+    client = ctx.client()
+    layer = resolve_layer(ctx, args)
+    portals = client.layers.api(layer["layer_type"]).usage(layer["id"])
+    if portals and not ctx.out.json_mode:
+        ctx.out.warn("Used by {0} portal(s): {1}. They will be updated and re-published."
+                     .format(len(portals), ", ".join(p.get("title") or "?" for p in portals)))
+    if not confirm(ctx.out, "Delete {0} layer {1!r} (id {2})?".format(
+            layer["layer_type"], layer["name"], layer["id"]), args.yes):
+        ctx.out.info("Nothing deleted.")
+        return EXIT_GENERIC
+    client.layers.api(layer["layer_type"]).delete(layer["id"])
+    ctx.out.render({"ok": True, "deleted": layer["id"], "name": layer["name"]})
+    if not ctx.out.json_mode:
+        ctx.out.success("Deleted {0}.".format(layer["name"]))
+    return EXIT_OK
+
+
+def _safe(name: str) -> str:
+    keep = "-_. abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    cleaned = "".join(c if c in keep else "_" for c in (name or "layer")).strip()
+    return cleaned or "layer"

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -6,9 +6,10 @@ and looking up `7` is what a machine does.
 from __future__ import annotations
 
 import json
+import os
 import sys
 
-from ...errors import GeoDeployError, ValidationError
+from ...errors import GeoDeployError, NotFoundError, ValidationError
 from ..main import add_command, group_parser
 from ..output import EXIT_GENERIC, EXIT_OK, human_size
 from ._common import (add_style_args, confirm, layer_ref_arg, parse_fields, resolve_layer,
@@ -96,12 +97,14 @@ examples:
                            epilog="""examples:
   geodeploy layers download roads                 the whole layer, GeoPackage
   geodeploy layers download roads --format csv
-  geodeploy layers download parcels --format geoparquet --crs native
+  geodeploy layers download parcels               a GeoParquet layer: its own files, uncapped
   geodeploy layers download roads --bbox 11,55,12,56    just that area
   geodeploy layers download dem                   the Cloud-Optimized GeoTIFF itself
 
-gpkg / csv / geojson / geoparquet are built by the instance as a job and arrive as a zip. cog and
-pmtiles are the stored file, streamed as-is.
+cog, pmtiles and a whole GeoParquet layer are the STORED files, streamed as they are: complete,
+lossless and not subject to any row cap. gpkg / csv / geojson (and any clipped export) are BUILT by
+the instance as a job and arrive as a zip; those stop at the server's row cap, which the command
+reports when it happens.
 """)
     layer_ref_arg(download)
     download.add_argument("-o", "--output", help="output path (default: the layer name)")
@@ -251,8 +254,20 @@ def cmd_download(ctx, args) -> int:
     ref = layer.get("uid") or layer["id"]
     api = client.layers.api(layer["layer_type"])
     kind = args.format
+    geoparquet_layer = layer.get("storage_backend") == "geoparquet"
     if kind == "auto":
-        kind = "cog" if layer["layer_type"] == "raster" else "gpkg"
+        if layer["layer_type"] == "raster":
+            kind = "cog"
+        else:
+            # A GeoParquet layer's own files are the best copy of it there is: complete, lossless
+            # and not subject to the export row cap. Building a GeoPackage from them by default
+            # would be slower AND worse.
+            kind = "geoparquet" if geoparquet_layer else "gpkg"
+
+    if kind == "geoparquet" and geoparquet_layer and not args.bbox:
+        done = _download_parquet_dataset(ctx, client, layer, ref, args)
+        if done is not None:
+            return done
 
     if kind in ("cog", "pmtiles"):
         if kind == "cog" and layer["layer_type"] != "raster":
@@ -280,12 +295,71 @@ def cmd_download(ctx, args) -> int:
     path = args.output or "{0}.zip".format(_safe(layer["name"]))
     ctx.out.info("Building {0} on the instance{1}…".format(
         kind, " for " + args.bbox if args.bbox else " (whole layer)"))
+    cut = []
     api.export_to_file(ref, path, format=kind, bbox=args.bbox, target_crs=args.crs,
-                       on_status=lambda state: ctx.out.debug("export: {0}".format(state)))
-    ctx.out.render({"ok": True, "file": path, "format": kind})
+                       on_status=lambda state: ctx.out.debug("export: {0}".format(state)),
+                       on_ready=lambda status: cut.extend(status.get("truncated") or []))
+    ctx.out.render({"ok": True, "file": path, "format": kind, "truncated": cut})
     if not ctx.out.json_mode:
         ctx.out.success("Wrote {0}.".format(path))
-        ctx.out.info("Read MANIFEST.txt inside it if the layer is large — it records the row cap.")
+    if cut:
+        # Not a warning buried in the archive: the whole failure mode is that a truncated export
+        # LOOKS finished. Say it on stderr, and leave a non-zero exit for anything scripted.
+        # In --json mode the report is already IN the document (stdout stays one document), so the
+        # exit code carries it there.
+        if not ctx.out.json_mode:
+            for item in cut:
+                ctx.out.error("INCOMPLETE — {0} stopped at the server's {1:,}-row cap.".format(
+                    item.get("file"), item.get("cap") or 0))
+            ctx.out.error(
+                "The rows you have are whichever the scan reached first.",
+                hint=("Complete instead: `geodeploy layers download {0}` (the stored GeoParquet "
+                      "files, uncapped)".format(layer["name"]) if geoparquet_layer else
+                      "Complete instead: ogr2ogr -f GPKG out.gpkg \"OAPIF:{0}/api/ogc\" {1} — "
+                      "paged, no cap. Or ask for a --bbox.".format(client.url, layer["name"])))
+        return EXIT_GENERIC
+    if not ctx.out.json_mode:
+        ctx.out.info("MANIFEST.txt inside the zip records the row counts.")
+    return EXIT_OK
+
+
+def _download_parquet_dataset(ctx, client, layer, ref, args):
+    """The whole GeoParquet layer, straight from storage — no export job, no row cap.
+
+    Returns None when this layer has no partitioned dataset (a single uploaded `.parquet`, or a
+    re-prep that has not run), so the caller falls back to building one.
+    """
+    directory = args.output or "{0}_parquet".format(_safe(layer["name"]))
+    try:
+        manifest = client.vector.parquet_manifest(ref)
+        parts = client.vector.parquet_parts(manifest)
+    except NotFoundError:
+        ctx.out.debug("No partition manifest for this layer; building an export instead.")
+        return None
+    if not parts:
+        return None
+
+    ctx.out.info("{0} partition file(s), {1} — reading the stored files, not rebuilding them.".format(
+        len(parts), "{0:,} features".format(manifest["feature_count"])
+        if manifest.get("feature_count") else "row count unknown"))
+    progress = ctx.out.progress(directory)
+
+    def tick(done, total, part, done_bytes):
+        # Bytes, not files: partitions differ wildly in size, so "3/27 files" would jump around
+        # while a rate in MB/s answers the only question anyone has during a big download.
+        progress.label = "{0}  {1}/{2} files".format(directory, done, total)
+        progress.update(done_bytes)
+
+    result = client.vector.download_dataset(ref, directory, on_file=tick)
+    progress.finish()
+    ctx.out.render({"ok": True, "directory": result["directory"], "files": result["parts"],
+                    "format": "geoparquet", "rows": result.get("rows"), "truncated": []})
+    if not ctx.out.json_mode:
+        ctx.out.success("Wrote {0} file(s) to {1}{2}.".format(
+            result["parts"], directory, os.sep))
+        ctx.out.info("Complete and uncapped. Read it with:")
+        ctx.out.info("  SELECT * FROM read_parquet('{0}/**/*.parquet')".format(
+            directory.replace("\\", "/")))
     return EXIT_OK
 
 

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -92,12 +92,27 @@ examples:
     identify.add_argument("--tolerance", type=float, default=1e-4)
     identify.add_argument("--limit", type=int, default=10)
 
-    download = add_command(group, "download", cmd_download,
-                           "download the layer's own file (COG for rasters, PMTiles for tiled "
-                           "vectors)")
+    download = add_command(group, "download", cmd_download, "download a layer as a file",
+                           epilog="""examples:
+  geodeploy layers download roads                 the whole layer, GeoPackage
+  geodeploy layers download roads --format csv
+  geodeploy layers download parcels --format geoparquet --crs native
+  geodeploy layers download roads --bbox 11,55,12,56    just that area
+  geodeploy layers download dem                   the Cloud-Optimized GeoTIFF itself
+
+gpkg / csv / geojson / geoparquet are built by the instance as a job and arrive as a zip. cog and
+pmtiles are the stored file, streamed as-is.
+""")
     layer_ref_arg(download)
     download.add_argument("-o", "--output", help="output path (default: the layer name)")
-    download.add_argument("--format", choices=["auto", "cog", "pmtiles", "geojson"], default="auto")
+    download.add_argument("--format",
+                          choices=["auto", "gpkg", "csv", "geojson", "geoparquet", "cog",
+                                   "pmtiles"],
+                          default="auto",
+                          help="auto = GeoPackage for a vector layer, the COG for a raster")
+    download.add_argument("--bbox", help="minx,miny,maxx,maxy in EPSG:4326 (default: everything)")
+    download.add_argument("--crs", choices=["4326", "native"], default="4326",
+                          help="native keeps the layer's own CRS where the format can carry it")
 
     tile = add_command(group, "tile", cmd_tile, "(re)generate a vector layer's PMTiles archive")
     layer_ref_arg(tile)
@@ -225,37 +240,52 @@ def cmd_identify(ctx, args) -> int:
 
 
 def cmd_download(ctx, args) -> int:
-    layer = resolve_layer(ctx, args)
-    client = ctx.client()
+    """Two very different mechanisms behind one command.
+
+    A COG or a PMTiles archive already IS a file: it streams straight out of storage. A GeoPackage
+    or a CSV has to be built, so the instance does it as a job and hands back a zip. `auto` picks
+    the one that gives you the data rather than a rendering of it.
+    """
+    layer = resolve_layer(ctx, args, public_ok=True)
+    client = ctx.client(auth_required=False)
     ref = layer.get("uid") or layer["id"]
+    api = client.layers.api(layer["layer_type"])
     kind = args.format
     if kind == "auto":
-        if layer["layer_type"] == "raster":
-            kind = "cog"
-        elif layer.get("pmtiles_key"):
-            kind = "pmtiles"
-        else:
-            kind = "geojson"
+        kind = "cog" if layer["layer_type"] == "raster" else "gpkg"
 
-    if kind == "geojson":
-        data = client.vector.features(layer["id"], limit=1000000)
-        path = args.output or "{0}.geojson".format(_safe(layer["name"]))
-        write_json_file(path, data)
-        ctx.out.success("Wrote {0} ({1} features).".format(path, len(data.get("features") or [])))
+    if kind in ("cog", "pmtiles"):
+        if kind == "cog" and layer["layer_type"] != "raster":
+            ctx.out.error("A COG is a raster thing; {0} is a vector layer.".format(layer["name"]))
+            return EXIT_GENERIC
+        path = args.output or "{0}.{1}".format(_safe(layer["name"]),
+                                               "tif" if kind == "cog" else "pmtiles")
+        endpoint = ("/data/raster/{0}/cog" if kind == "cog"
+                    else "/data/vector/{0}/pmtiles").format(ref)
+        progress = ctx.out.progress(path)
+        try:
+            with open(path, "wb") as fh:
+                client.download(endpoint, _Counting(fh, progress), auth=False)
+        except GeoDeployError:
+            progress.finish()
+            raise
+        progress.finish()
+        ctx.out.render({"ok": True, "file": path, "format": kind})
+        if not ctx.out.json_mode:
+            ctx.out.success("Wrote {0}.".format(path))
         return EXIT_OK
 
-    path = args.output or "{0}.{1}".format(_safe(layer["name"]),
-                                           "tif" if kind == "cog" else "pmtiles")
-    endpoint = ("/data/raster/{0}/cog" if kind == "cog" else "/data/vector/{0}/pmtiles").format(ref)
-    progress = ctx.out.progress(path)
-    try:
-        with open(path, "wb") as fh:
-            client.download(endpoint, _Counting(fh, progress))
-    except GeoDeployError:
-        progress.finish()
-        raise
-    progress.finish()
-    ctx.out.success("Wrote {0}.".format(path))
+    # Built server-side: the result is a zip, because an export can be more than one file (and
+    # carries a MANIFEST.txt saying whether the row cap truncated it).
+    path = args.output or "{0}.zip".format(_safe(layer["name"]))
+    ctx.out.info("Building {0} on the instance{1}…".format(
+        kind, " for " + args.bbox if args.bbox else " (whole layer)"))
+    api.export_to_file(ref, path, format=kind, bbox=args.bbox, target_crs=args.crs,
+                       on_status=lambda state: ctx.out.debug("export: {0}".format(state)))
+    ctx.out.render({"ok": True, "file": path, "format": kind})
+    if not ctx.out.json_mode:
+        ctx.out.success("Wrote {0}.".format(path))
+        ctx.out.info("Read MANIFEST.txt inside it if the layer is large — it records the row cap.")
     return EXIT_OK
 
 

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -15,8 +15,12 @@ from ..output import EXIT_GENERIC, EXIT_OK, human_size
 from ._common import (add_style_args, confirm, layer_ref_arg, parse_fields, resolve_layer,
                       style_from_args, write_json_file)
 
-LIST_COLUMNS = ["layer_type", "id", "name", "status", "geometry_type", "feature_count",
-                "storage_backend", "visibility", "created_by"]
+# `uid` earns its width: it is the identifier every public URL uses, it is unique across both
+# layer kinds (integer ids are two separate sequences), and it survives a rename or a restore that
+# renumbers everything. A listing that shows only the integer teaches people to script with the one
+# handle that is none of those things.
+LIST_COLUMNS = ["layer_type", "id", "uid", "name", "status", "geometry_type", "feature_count",
+                "storage_backend", "visibility"]
 
 
 def register(subparsers) -> None:

--- a/cli/geodeploy/cli/commands/portals.py
+++ b/cli/geodeploy/cli/commands/portals.py
@@ -1,0 +1,515 @@
+"""`geodeploy portals …` — build, style and publish a portal.
+
+The one thing worth internalising: **editing a portal changes a draft.** The live site keeps
+serving its previous bundle until `geodeploy portals publish`. Every command here that changes
+something says so, because "I set the colour and nothing happened" is otherwise the first thing
+anyone hits.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from ...errors import ValidationError
+from ...portals import ACCESS_TYPES, ARCHETYPES
+from ...styles import describe
+from ..main import add_command, group_parser
+from ..output import EXIT_GENERIC, EXIT_OK
+from ._common import (add_style_args, confirm, parse_fields, read_json_arg, read_text_arg,
+                      style_from_args, write_json_file)
+
+LIST_COLUMNS = ["id", "title", "slug", "published", "access_type", "template_id", "created_by"]
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "portals", "create, arrange, style and publish portals",
+                         aliases=["portal"])
+
+    listing = add_command(group, "list", cmd_list, "list portals", aliases=["ls"])
+    listing.add_argument("--published", action="store_true", help="only published portals")
+    listing.add_argument("--draft", action="store_true", help="only unpublished portals")
+    listing.add_argument("--query", dest="search", help="match title or slug")
+
+    show = add_command(group, "show", cmd_show, "a portal's settings and layers")
+    show.add_argument("portal", help="portal id, slug or title")
+
+    create = add_command(group, "create", cmd_create, "create a portal",
+                         epilog="""\
+examples:
+  geodeploy portals create "Field sites 2026"
+  geodeploy portals create "Catalogue" --experience catalog --access organization
+  geodeploy portals create "Story" --experience storymap --template minimal
+""")
+    create.add_argument("title")
+    create.add_argument("--description", help="About text, or @file.md")
+    create.add_argument("--template", default="minimal", dest="template_id",
+                        help="template id (see `geodeploy catalog templates`)")
+    create.add_argument("--experience", choices=ARCHETYPES,
+                        help="webmap (default), storymap or catalog")
+    create.add_argument("--access", choices=ACCESS_TYPES, default="public",
+                        help="who may view the PUBLISHED portal")
+    create.add_argument("--password", help="the password, when --access password")
+    create.add_argument("--publish", action="store_true", help="publish it immediately")
+
+    update = add_command(group, "update", cmd_update, "change a portal's settings")
+    update.add_argument("portal")
+    update.add_argument("--title")
+    update.add_argument("--description", help="About text, or @file.md (Markdown)")
+    update.add_argument("--template", dest="template_id")
+    update.add_argument("--access", choices=ACCESS_TYPES)
+    update.add_argument("--password")
+    update.add_argument("--basemap", help="basemap id (see `geodeploy catalog basemaps`)")
+    update.add_argument("--view", help='start view as JSON: {"center":[lng,lat],"zoom":6,'
+                                       '"pitch":0,"bearing":0}')
+    update.add_argument("--theme", help="theme JSON, e.g. '{\"mode\":\"dark\",\"accent\":\"#22c55e\"}'")
+    update.add_argument("--layout", help="layout_config JSON (archetype, regions, panels)")
+
+    export = add_command(group, "export", cmd_export,
+                         "write a portal's whole editable configuration to a JSON file")
+    export.add_argument("portal")
+    export.add_argument("output", nargs="?", help="file to write (default: stdout)")
+
+    imp = add_command(group, "import", cmd_import,
+                      "push a configuration file back onto a portal")
+    imp.add_argument("portal")
+    imp.add_argument("config", help="the JSON file written by `portals export`")
+
+    layers = add_command(group, "layers", cmd_layers, "the layers on a portal, top of the list first")
+    layers.add_argument("portal")
+
+    add_layer = add_command(group, "add-layer", cmd_add_layer,
+                            "add a data layer to a portal (top of the list = drawn on top)",
+                            epilog="""\
+examples:
+  geodeploy portals add-layer 3 roads
+  geodeploy portals add-layer 3 sites --marker star --radius 6 --color '#e11d48'
+  geodeploy portals add-layer 3 parcels --color-field population --classify quantile --classes 5
+  geodeploy portals add-layer 3 dem --colormap terrain --rescale 0,2400 --bottom
+""")
+    add_layer.add_argument("portal")
+    add_layer.add_argument("layer", help="layer id, uid or name")
+    add_layer.add_argument("--type", dest="layer_type", choices=["vector", "raster"])
+    add_layer.add_argument("--bottom", action="store_true", help="add at the bottom of the list")
+    add_layer.add_argument("--hidden", action="store_true", help="start with the layer switched off")
+    add_layer.add_argument("--popup-fields", help="comma-separated attributes to show in popups")
+    add_layer.add_argument("--replace", action="store_true",
+                           help="update the entry if the layer is already on the portal")
+    add_layer.add_argument("--publish", action="store_true", help="publish afterwards")
+    add_style_args(add_layer)
+
+    remove = add_command(group, "remove-layer", cmd_remove_layer, "take a layer off a portal")
+    remove.add_argument("portal")
+    remove.add_argument("layer")
+    remove.add_argument("--type", dest="layer_type", choices=["vector", "raster"])
+    remove.add_argument("--publish", action="store_true")
+
+    style = add_command(group, "style", cmd_style, "restyle a layer ON a portal")
+    style.add_argument("portal")
+    style.add_argument("layer")
+    style.add_argument("--type", dest="layer_type", choices=["vector", "raster"])
+    style.add_argument("--visible", dest="visible", action="store_true", default=None)
+    style.add_argument("--hidden", dest="visible", action="store_false",
+                       help="hide the layer without removing it")
+    style.add_argument("--popup-fields", help="comma-separated attributes for popups")
+    style.add_argument("--replace", action="store_true", help="replace rather than merge the style")
+    style.add_argument("--publish", action="store_true")
+    add_style_args(style)
+
+    move = add_command(group, "move-layer", cmd_move_layer, "reorder a layer (0 = top of the list)")
+    move.add_argument("portal")
+    move.add_argument("layer")
+    move.add_argument("position", help="top | bottom | up | down | an index")
+    move.add_argument("--type", dest="layer_type", choices=["vector", "raster"])
+    move.add_argument("--publish", action="store_true")
+
+    groups = add_command(group, "folders", cmd_folders,
+                         "read or replace the layer folder tree (V-13 groups)")
+    groups.add_argument("portal")
+    groups.add_argument("--set", dest="tree", help="a JSON array, or @file.json")
+    groups.add_argument("--clear", action="store_true", help="remove all folders (layers stay)")
+    groups.add_argument("--publish", action="store_true")
+
+    describe_p = add_command(group, "set-description", cmd_description,
+                             "set the About text (Markdown; drives the published About page)")
+    describe_p.add_argument("portal")
+    describe_p.add_argument("text", help="the text, or @file.md")
+    describe_p.add_argument("--publish", action="store_true")
+
+    asset = add_command(group, "asset", cmd_asset, "upload a logo or About-page image")
+    asset.add_argument("portal")
+    asset.add_argument("file")
+
+    publish = add_command(group, "publish", cmd_publish, "publish (or re-publish) a portal")
+    publish.add_argument("portal")
+
+    unpublish = add_command(group, "unpublish", cmd_unpublish, "take a portal offline")
+    unpublish.add_argument("portal")
+
+    url = add_command(group, "url", cmd_url, "print the public URL of a portal")
+    url.add_argument("portal")
+
+    delete = add_command(group, "delete", cmd_delete, "delete a portal", aliases=["rm"])
+    delete.add_argument("portal")
+    delete.add_argument("--yes", action="store_true")
+
+    download = add_command(group, "download-area", cmd_download_area,
+                           "download portal layers clipped to a bounding box")
+    download.add_argument("portal")
+    download.add_argument("bbox", help="minx,miny,maxx,maxy in EPSG:4326")
+    download.add_argument("-o", "--output", default="export.zip")
+    download.add_argument("--format", default="geojson",
+                          choices=["geojson", "gpkg", "csv", "tif"],
+                          help="vector format (rasters always come as tif)")
+    download.add_argument("--layers", help="comma-separated layer ids; default every layer")
+    download.add_argument("--crs", default="4326", choices=["4326", "native"])
+
+
+# ── read ─────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_list(ctx, args) -> int:
+    published = True if args.published else (False if args.draft else None)
+    rows = ctx.client().portals.list(published=published, query=args.search)
+    ctx.out.render(rows, LIST_COLUMNS, empty="No portals yet — `geodeploy portals create <title>`.")
+    return EXIT_OK
+
+
+def cmd_show(ctx, args) -> int:
+    portal = ctx.client().portals.get(args.portal)
+    if ctx.out.json_mode:
+        ctx.out.json(portal)
+        return EXIT_OK
+    ctx.out.record(portal, ["id", "title", "slug", "template_id", "access_type", "basemap",
+                            "published", "published_at", "created_by"])
+    ctx.out.out("")
+    _print_layers(ctx, portal)
+    ctx.out.out("")
+    ctx.out.info("URL: {0}".format(ctx.client().portals.url(portal)))
+    return EXIT_OK
+
+
+def cmd_layers(ctx, args) -> int:
+    portal = ctx.client().portals.get(args.portal)
+    if ctx.out.json_mode:
+        ctx.out.json(portal.get("layer_configs") or [])
+        return EXIT_OK
+    _print_layers(ctx, portal)
+    return EXIT_OK
+
+
+def _print_layers(ctx, portal: Dict[str, Any]) -> None:
+    configs = portal.get("layer_configs") or []
+    if not configs:
+        ctx.out.info("No layers on this portal yet.")
+        return
+    names = {}
+    try:
+        for row in ctx.client().layers.list():
+            names[(row["layer_type"], row["id"])] = row.get("name")
+    except Exception:  # noqa: BLE001 - names are decoration; never fail the listing for them
+        pass
+    rows = []
+    for index, entry in enumerate(configs):
+        rows.append({
+            "#": index,
+            "layer_id": entry.get("layer_id"),
+            "type": entry.get("layer_type"),
+            "name": names.get((entry.get("layer_type"), entry.get("layer_id")), "—"),
+            "visible": entry.get("visible", True),
+            "opacity": entry.get("opacity", 1.0),
+            "style": describe(entry.get("style") or {}),
+        })
+    ctx.out.table(rows, ["#", "layer_id", "type", "name", "visible", "opacity", "style"])
+    ctx.out.info("Index 0 is the top of the layer list, and draws on top.")
+
+
+def cmd_export(ctx, args) -> int:
+    portal = ctx.client().portals.get(args.portal)
+    if args.output:
+        write_json_file(args.output, portal)
+        ctx.out.success("Wrote {0}.".format(args.output))
+        ctx.out.info("Edit it and push it back with `geodeploy portals import {0} {1}`."
+                     .format(args.portal, args.output))
+        return EXIT_OK
+    ctx.out.out(json.dumps(portal, indent=2, ensure_ascii=False, default=str))
+    return EXIT_OK
+
+
+def cmd_import(ctx, args) -> int:
+    config = read_json_arg("@" + args.config, "the configuration file")
+    portal = ctx.client().portals.get(args.portal)
+    updated = ctx.client().portals.set_config(portal["id"], config)
+    ctx.out.render(updated, LIST_COLUMNS)
+    if not ctx.out.json_mode:
+        ctx.out.success("Configuration applied to {0}.".format(updated.get("title")))
+        _publish_hint(ctx, updated)
+    return EXIT_OK
+
+
+def cmd_url(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    url = client.portals.url(portal)
+    if ctx.out.json_mode:
+        ctx.out.json({"id": portal["id"], "slug": portal.get("slug"), "url": url,
+                      "published": portal.get("published")})
+        return EXIT_OK
+    ctx.out.out(url)
+    if not portal.get("published"):
+        ctx.out.warn("Not published yet, so that URL is not live.")
+    return EXIT_OK
+
+
+# ── write ────────────────────────────────────────────────────────────────────────────────────────
+
+def cmd_create(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.create(
+        args.title, description=read_text_arg(args.description) if args.description else None,
+        template_id=args.template_id, access_type=args.access, access_password=args.password,
+        archetype=args.experience)
+    if args.publish:
+        portal = client.portals.publish(portal["id"])
+    ctx.out.render(portal, LIST_COLUMNS)
+    if not ctx.out.json_mode:
+        ctx.out.success("Created portal {0} ({1}).".format(portal["id"], portal.get("slug")))
+        if args.publish:
+            ctx.out.info("Published: {0}".format(client.portals.url(portal)))
+        else:
+            ctx.out.info("Add layers with `geodeploy portals add-layer {0} <layer>`, then "
+                         "`geodeploy portals publish {0}`.".format(portal["id"]))
+    return EXIT_OK
+
+
+def cmd_update(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    fields = {"title": args.title, "template_id": args.template_id, "access_type": args.access,
+              "access_password": args.password, "basemap": args.basemap}
+    if args.description is not None:
+        fields["description"] = read_text_arg(args.description)
+    if args.view:
+        fields["initial_view"] = read_json_arg(args.view, "--view")
+    if args.theme:
+        fields["theme"] = read_json_arg(args.theme, "--theme")
+    if args.layout:
+        fields["layout_config"] = read_json_arg(args.layout, "--layout")
+    updated = client.portals.update(portal["id"], **fields)
+    ctx.out.render(updated, LIST_COLUMNS)
+    if not ctx.out.json_mode:
+        ctx.out.success("Updated {0}.".format(updated.get("title")))
+        _publish_hint(ctx, updated)
+    return EXIT_OK
+
+
+def cmd_description(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    text = read_text_arg(args.text)
+    updated = client.portals.update(portal["id"], description=text)
+    _maybe_publish(ctx, updated, args)
+    ctx.out.render({"id": updated["id"], "title": updated["title"],
+                    "description_chars": len(text)})
+    if not ctx.out.json_mode:
+        ctx.out.success("About text set ({0} characters).".format(len(text)))
+        _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_add_layer(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    layer = client.layers.resolve(args.layer, args.layer_type)
+    style = style_from_args(args, client, layer.get("uid") or layer["id"], {}, ctx.out)
+    if not style and (layer.get("default_style") or {}).get("style"):
+        style = dict(layer["default_style"]["style"])   # inherit the layer's own default
+
+    updated = client.portals.add_layer(
+        portal["id"], layer["id"], layer["layer_type"], style=style,
+        visible=not args.hidden, opacity=args.opacity if args.opacity is not None else 1.0,
+        popup_fields=parse_fields(args.popup_fields), bottom=args.bottom, replace=args.replace)
+    _maybe_publish(ctx, updated, args)
+    if ctx.out.json_mode:
+        ctx.out.json(updated.get("layer_configs") or [])
+        return EXIT_OK
+    ctx.out.success("Added {0} ({1}) to {2}.".format(layer["name"], layer["layer_type"],
+                                                     updated.get("title")))
+    _print_layers(ctx, updated)
+    _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_remove_layer(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    layer = client.layers.resolve(args.layer, args.layer_type)
+    updated = client.portals.remove_layer(portal["id"], layer["id"], layer["layer_type"])
+    _maybe_publish(ctx, updated, args)
+    if ctx.out.json_mode:
+        ctx.out.json(updated.get("layer_configs") or [])
+        return EXIT_OK
+    ctx.out.success("Removed {0} from {1}.".format(layer["name"], updated.get("title")))
+    _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_style(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    layer = client.layers.resolve(args.layer, args.layer_type)
+    current = {}
+    for entry in portal.get("layer_configs") or []:
+        if entry.get("layer_id") == layer["id"] and entry.get("layer_type") == layer["layer_type"]:
+            current = dict(entry.get("style") or {})
+            break
+    style = style_from_args(args, client, layer.get("uid") or layer["id"],
+                            {} if args.replace else current, ctx.out)
+    updated = client.portals.set_layer_style(
+        portal["id"], layer["id"], style, layer_type=layer["layer_type"], merge=False,
+        visible=args.visible, opacity=args.opacity, popup_fields=parse_fields(args.popup_fields))
+    _maybe_publish(ctx, updated, args)
+    if ctx.out.json_mode:
+        ctx.out.json(style)
+        return EXIT_OK
+    ctx.out.success("{0}: {1}".format(layer["name"], describe(style)))
+    _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_move_layer(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    layer = client.layers.resolve(args.layer, args.layer_type)
+    updated = client.portals.move_layer(portal["id"], layer["id"], args.position,
+                                        layer["layer_type"])
+    _maybe_publish(ctx, updated, args)
+    if ctx.out.json_mode:
+        ctx.out.json(updated.get("layer_configs") or [])
+        return EXIT_OK
+    _print_layers(ctx, updated)
+    _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_folders(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    if args.clear:
+        updated = client.portals.set_groups(portal["id"], [])
+    elif args.tree:
+        tree = json.loads(read_text_arg(args.tree))
+        if not isinstance(tree, list):
+            raise ValidationError(400, "The folder tree is a JSON array of group objects.")
+        updated = client.portals.set_groups(portal["id"], tree)
+    else:
+        ctx.out.render(portal.get("layer_groups") or [], empty="No folders — the layer list is flat.")
+        return EXIT_OK
+    _maybe_publish(ctx, updated, args)
+    ctx.out.render(updated.get("layer_groups") or [], empty="Folders cleared.")
+    _publish_hint(ctx, updated, args)
+    return EXIT_OK
+
+
+def cmd_asset(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    result = client.portals.upload_asset(portal["id"], args.file)
+    ctx.out.render(result)
+    return EXIT_OK
+
+
+def cmd_publish(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    published = client.portals.publish(portal["id"])
+    ctx.out.render(published, LIST_COLUMNS)
+    if not ctx.out.json_mode:
+        ctx.out.success("Published: {0}".format(client.portals.url(published)))
+    return EXIT_OK
+
+
+def cmd_unpublish(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    result = client.portals.unpublish(portal["id"])
+    ctx.out.render(result, LIST_COLUMNS)
+    if not ctx.out.json_mode:
+        ctx.out.success("{0} is offline. The draft is untouched.".format(portal.get("title")))
+    return EXIT_OK
+
+
+def cmd_delete(ctx, args) -> int:
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    if not confirm(ctx.out, "Delete portal {0!r} (id {1})? Its layers are NOT deleted.".format(
+            portal.get("title"), portal["id"]), args.yes):
+        ctx.out.info("Nothing deleted.")
+        return EXIT_GENERIC
+    client.portals.delete(portal["id"])
+    ctx.out.render({"ok": True, "deleted": portal["id"], "title": portal.get("title")})
+    if not ctx.out.json_mode:
+        ctx.out.success("Deleted {0}.".format(portal.get("title")))
+    return EXIT_OK
+
+
+def cmd_download_area(ctx, args) -> int:
+    import time
+
+    client = ctx.client()
+    portal = client.portals.get(args.portal)
+    wanted = None
+    if args.layers:
+        wanted = {int(x) for x in args.layers.split(",") if x.strip()}
+
+    items = []  # type: List[Dict[str, Any]]
+    for entry in portal.get("layer_configs") or []:
+        if wanted is not None and entry.get("layer_id") not in wanted:
+            continue
+        raster = entry.get("layer_type") == "raster"
+        items.append({"layer_id": entry.get("layer_id"), "layer_type": entry.get("layer_type"),
+                      "format": "tif" if raster else args.format})
+    if not items:
+        ctx.out.error("No layers on this portal match.")
+        return EXIT_GENERIC
+
+    slug = portal.get("slug")
+    job = client.portals.export_bundle(slug, args.bbox, items, target_crs=args.crs)
+    job_id = job.get("job_id") or job.get("id")
+    ctx.out.info("Clipping {0} layer(s) to {1}…".format(len(items), args.bbox))
+    while True:
+        status = client.portals.export_status(slug, job_id)
+        state = (status.get("status") or "").lower()
+        if state == "ready":
+            break
+        if state in ("error", "failed"):
+            ctx.out.error(status.get("error") or status.get("message") or "Export failed.")
+            return EXIT_GENERIC
+        time.sleep(2)
+
+    with open(args.output, "wb") as fh:
+        client.portals.export_download(slug, job_id, fh)
+    ctx.out.render({"ok": True, "file": args.output, "layers": len(items)})
+    if not ctx.out.json_mode:
+        ctx.out.success("Wrote {0}.".format(args.output))
+    return EXIT_OK
+
+
+# ── shared bits ──────────────────────────────────────────────────────────────────────────────────
+
+def _maybe_publish(ctx, portal: Dict[str, Any], args) -> None:
+    if getattr(args, "publish", False):
+        ctx.client().portals.publish(portal["id"])
+
+
+def _publish_hint(ctx, portal: Dict[str, Any], args: Optional[Any] = None) -> None:
+    """Say what is needed to make the change visible — and nothing when it already is."""
+    if ctx.out.json_mode:
+        return
+    if getattr(args, "publish", False):
+        ctx.out.info("Published: {0}".format(ctx.client().portals.url(portal)))
+        return
+    if portal.get("published"):
+        ctx.out.info("The live portal still shows the previous version — "
+                     "`geodeploy portals publish {0}` to update it.".format(portal["id"]))
+    else:
+        ctx.out.info("Draft saved. `geodeploy portals publish {0}` puts it online."
+                     .format(portal["id"]))

--- a/cli/geodeploy/cli/commands/sources.py
+++ b/cli/geodeploy/cli/commands/sources.py
@@ -1,0 +1,97 @@
+"""`geodeploy sources …` — external WMS / XYZ / WFS services used without ingesting them."""
+from __future__ import annotations
+
+from ..main import add_command, group_parser
+from ..output import EXIT_GENERIC, EXIT_OK
+from ._common import confirm
+
+COLUMNS = ["id", "name", "source_type", "kind", "url", "layer_name", "visibility", "created_by"]
+
+
+def register(subparsers) -> None:
+    group = group_parser(subparsers, "sources", "external map services shown alongside your data")
+
+    listing = add_command(group, "list", cmd_list, "list external sources", aliases=["ls"])
+    listing.add_argument("--query", dest="search")
+
+    add = add_command(group, "add", cmd_add, "register an external service",
+                      epilog="""\
+examples:
+  geodeploy sources add "OSM" 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' --type xyz
+  geodeploy sources add "Orthophoto" https://wms.example.org/wms --type wms \\
+      --layer-name ortho_2025 --version 1.3.0
+  geodeploy sources add "Municipalities" https://wfs.example.org/ows --type wfs \\
+      --layer-name ms:kommun
+
+A WFS is probed when it is registered, so a wrong typeName fails here rather than as an empty
+layer on a published map.
+""")
+    add.add_argument("name")
+    add.add_argument("service_url", metavar="url", help="the service endpoint")
+    add.add_argument("--type", dest="source_type", required=True, choices=["xyz", "wms", "wfs"])
+    add.add_argument("--layer-name", help="WMS `layers` / WFS `typeName` (required for both)")
+    add.add_argument("--version", help="WMS (default 1.3.0) or WFS (default 2.0.0) version")
+    add.add_argument("--format", dest="image_format", help="WMS image format (default image/png)")
+    add.add_argument("--attribution")
+
+    show = add_command(group, "show", cmd_show, "one source")
+    show.add_argument("source")
+
+    usage = add_command(group, "usage", cmd_usage, "which portals use this source")
+    usage.add_argument("source")
+
+    share = add_command(group, "share", cmd_share, "set visibility (private | organization)")
+    share.add_argument("source")
+    share.add_argument("visibility", choices=["private", "organization"])
+
+    delete = add_command(group, "delete", cmd_delete, "delete a source", aliases=["rm"])
+    delete.add_argument("source")
+    delete.add_argument("--yes", action="store_true")
+
+
+def cmd_list(ctx, args) -> int:
+    ctx.out.render(ctx.client().sources.list(query=args.search), COLUMNS,
+                   empty="No external sources.")
+    return EXIT_OK
+
+
+def cmd_add(ctx, args) -> int:
+    source = ctx.client().sources.create(
+        args.name, args.source_type, args.service_url, layer_name=args.layer_name, version=args.version,
+        image_format=args.image_format, attribution=args.attribution)
+    ctx.out.render(source, COLUMNS + ["bbox", "geometry_type"])
+    if not ctx.out.json_mode:
+        ctx.out.success("Added {0}. Put it on a portal with "
+                        "`geodeploy portals add-layer <portal> {1} --type external`."
+                        .format(args.name, source.get("id")))
+    return EXIT_OK
+
+
+def cmd_show(ctx, args) -> int:
+    ctx.out.render(ctx.client().sources.get(args.source))
+    return EXIT_OK
+
+
+def cmd_usage(ctx, args) -> int:
+    source = ctx.client().sources.get(args.source)
+    ctx.out.render(ctx.client().sources.usage(source["id"]), ["id", "title", "published"],
+                   empty="Not used by any portal.")
+    return EXIT_OK
+
+
+def cmd_share(ctx, args) -> int:
+    source = ctx.client().sources.get(args.source)
+    ctx.out.render(ctx.client().sources.share(source["id"], args.visibility), COLUMNS)
+    return EXIT_OK
+
+
+def cmd_delete(ctx, args) -> int:
+    client = ctx.client()
+    source = client.sources.get(args.source)
+    if not confirm(ctx.out, "Delete source {0!r}?".format(source.get("name")), args.yes):
+        return EXIT_GENERIC
+    client.sources.delete(source["id"])
+    ctx.out.render({"ok": True, "deleted": source["id"]})
+    if not ctx.out.json_mode:
+        ctx.out.success("Deleted {0}.".format(source.get("name")))
+    return EXIT_OK

--- a/cli/geodeploy/cli/commands/upload.py
+++ b/cli/geodeploy/cli/commands/upload.py
@@ -1,0 +1,154 @@
+"""`geodeploy upload` — one command for every kind of file, and any number of them.
+
+The route (through the API, direct-to-storage, chunked, CSV, raster) is worked out per file by
+`geodeploy.uploads.plan`; `--dry-run` prints those decisions without moving a byte, which is the
+honest way to find out that a 300 MB GeoPackage is going to become a GeoParquet layer rather than
+a PostGIS table.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from ...errors import GeoDeployError
+from ...uploads import LARGE_UPLOAD_THRESHOLD
+from ..main import add_command
+from ..output import EXIT_GENERIC, EXIT_OK, human_size
+from ._common import confirm  # noqa: F401  (kept for symmetry with other command modules)
+
+
+def register(subparsers) -> None:
+    parser = add_command(
+        subparsers, "upload", cmd_upload,
+        "upload one or more files and register them as layers",
+        epilog="""\
+examples:
+  geodeploy upload roads.gpkg                       one file
+  geodeploy upload *.gpkg *.tif --wait              a whole directory's worth, waiting for ingest
+  geodeploy upload sites.csv --x lon --y lat        CSV points (columns guessed if omitted)
+  geodeploy upload plots.csv --wkt geometry         CSV with WKT geometry of any type
+  geodeploy upload big.parquet --name "Parcels"     GeoParquet, direct to storage, chunked
+  geodeploy upload data/*.tif --dry-run             what would happen, without doing it
+
+Files at or over {threshold} bypass the API and upload straight to object storage in parts —
+that is what makes a multi-gigabyte upload survive a proxy in front of the instance.
+""".format(threshold=human_size(LARGE_UPLOAD_THRESHOLD)))
+
+    parser.add_argument("files", nargs="+", help="files to upload")
+    parser.add_argument("--type", dest="layer_type", choices=["vector", "raster"],
+                        help="force the layer type (default: from the extension)")
+    parser.add_argument("--name", help="layer name (only sensible with a single file)")
+    parser.add_argument("--wait", action="store_true",
+                        help="wait for ingest to finish, and fail if it does not")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="show the route each file would take, and stop")
+    parser.add_argument("--concurrency", type=int, default=1,
+                        help="files uploaded at once (default 1; each large file already uses "
+                             "four parallel parts)")
+    parser.add_argument("--stop-on-error", action="store_true",
+                        help="stop at the first failure instead of continuing")
+    parser.add_argument("--public", action="store_true",
+                        help="share each layer publicly once it is ready (STAC + OGC + raw asset)")
+
+    csv_group = parser.add_argument_group("CSV geometry")
+    csv_group.add_argument("--x", dest="x_column", help="longitude/easting column")
+    csv_group.add_argument("--y", dest="y_column", help="latitude/northing column")
+    csv_group.add_argument("--wkt", dest="wkt_column", help="WKT geometry column (any geometry type)")
+    csv_group.add_argument("--srid", type=int, default=4326, help="CRS of the coordinates (default 4326)")
+    csv_group.add_argument("--delimiter", choices=["comma", "semicolon", "tab", "pipe", "space"],
+                           help="field delimiter (default: sniffed from the file)")
+    csv_group.add_argument("--no-guess", action="store_true",
+                           help="do not guess geometry columns — fail instead")
+
+
+def cmd_upload(ctx, args) -> int:
+    client = ctx.client()
+    out = ctx.out
+
+    if args.name and len(args.files) > 1:
+        out.error("--name applies to a single file; upload them one at a time to name each.")
+        return EXIT_GENERIC
+
+    plans = []
+    for path in args.files:
+        plans.append(client.uploads.plan(
+            path, layer_type=args.layer_type, name=args.name, x_column=args.x_column,
+            y_column=args.y_column, wkt_column=args.wkt_column, srid=args.srid,
+            delimiter=args.delimiter, guess_csv=not args.no_guess))
+
+    for plan in plans:
+        if plan.csv_opts and plan.csv_opts.get("guessed"):
+            geometry = (("WKT column {0}".format(plan.csv_opts["wkt_column"]))
+                        if plan.csv_opts.get("wkt_column")
+                        else "x={0}, y={1}".format(plan.csv_opts.get("x_column"),
+                                                   plan.csv_opts.get("y_column")))
+            out.warn("{0}: guessed geometry from the header ({1}). Pass --x/--y or --wkt to be "
+                     "explicit.".format(os.path.basename(plan.path), geometry))
+
+    if args.dry_run:
+        ctx.out.render([dict(p.as_dict(), size_h=human_size(p.size)) for p in plans],
+                       ["path", "layer_type", "route", "name", "size_h", "chunked", "reason"])
+        return EXIT_OK
+
+    results = []  # type: List[Any]
+    failures = 0
+    for plan in plans:
+        progress = out.progress(os.path.basename(plan.path), plan.size)
+        out.info("{0} → {1} ({2}, {3})".format(os.path.basename(plan.path), plan.name,
+                                               plan.route, human_size(plan.size)))
+        try:
+            result = client.uploads.upload(
+                plan.path, plan=plan, wait=False,
+                on_progress=lambda done, total: progress.update(done, total))
+            progress.finish()
+            out.info("  queued as layer {0} (job {1})".format(result.layer_id, result.job_id))
+            results.append(result)
+        except GeoDeployError as exc:
+            progress.finish()
+            failures += 1
+            out.error("{0}: {1}".format(os.path.basename(plan.path), exc))
+            if args.stop_on_error:
+                break
+
+    if args.wait:
+        for result in results:
+            failures += _wait_for(ctx, result)
+
+    if args.public:
+        for result in results:
+            if result.final is None or (result.final or {}).get("status") in ("ready", "completed"):
+                try:
+                    client.layers.api(result.plan.layer_type).share(result.layer_id,
+                                                                    visibility="public")
+                    out.info("  {0} is now public.".format(result.plan.name))
+                except GeoDeployError as exc:
+                    out.warn("Could not share {0}: {1}".format(result.plan.name, exc))
+
+    payload = [r.as_dict() for r in results]
+    if out.json_mode:
+        out.json({"ok": failures == 0, "uploaded": payload, "failed": failures})
+    else:
+        out.table(payload, ["file", "name", "layer_type", "layer_id", "job_id"]) if payload else None
+        if not failures:
+            out.success("{0} file(s) uploaded.{1}".format(
+                len(results), "" if args.wait else " Ingest continues in the background — "
+                                                   "`geodeploy layers list` shows progress."))
+    return EXIT_GENERIC if failures else EXIT_OK
+
+
+def _wait_for(ctx, result) -> int:
+    """Follow one ingest job to the end. Returns 1 if it failed, 0 otherwise."""
+    out = ctx.out
+    label = os.path.basename(result.plan.path)
+
+    def on_progress(status: Dict[str, Any]) -> None:
+        out.info("  {0}: {1:3d}%  {2}".format(label, status.get("progress") or 0,
+                                              status.get("current_step") or status.get("status")))
+    try:
+        result.final = ctx.client().jobs.wait(result.job_id, result.plan.layer_type,
+                                              on_progress=on_progress)
+        out.success("{0} ready (layer {1}).".format(label, result.layer_id))
+        return 0
+    except GeoDeployError as exc:
+        out.error("{0}: {1}".format(label, exc))
+        return 1

--- a/cli/geodeploy/cli/main.py
+++ b/cli/geodeploy/cli/main.py
@@ -1,0 +1,261 @@
+"""`geodeploy` — the entry point: global options, dispatch, and the one place errors become exits.
+
+Argparse rather than a framework, for the no-dependency rule. The shape is conventional so it needs
+no learning: `geodeploy <group> <command> [args]`, `--json` anywhere, `-h` at every level.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, List, Optional
+
+from .. import __version__
+from ..config import Config, resolve
+from ..errors import (APIError, AuthError, ConfigError, GeoDeployError, PermissionError_,
+                      ServerError, TransportError, ValidationError)
+from ..jobs import JobFailed, JobTimeout
+from . import output
+from .output import (EXIT_AUTH, EXIT_GENERIC, EXIT_NETWORK, EXIT_OK, EXIT_SERVER, EXIT_USAGE,
+                     Formatter)
+
+EPILOG = """\
+examples:
+  geodeploy login https://geodeploy.example.org      log in and remember the instance
+  geodeploy upload roads.gpkg sites.csv --wait       upload several files and wait for ingest
+  geodeploy layers list --type vector                what is on the instance
+  geodeploy portals add-layer 3 roads --color '#e11d48' --marker star
+  geodeploy portals style 3 roads --color-field pop --classify quantile --classes 5
+  geodeploy portals publish 3                        make the edits live
+
+Every command takes --json for machine-readable output. Exit codes: 0 ok, 1 failed, 2 bad usage,
+3 authentication, 4 network, 5 server error.
+"""
+
+
+class Context(object):
+    """Everything a command handler needs: the formatter, the resolved instance, a lazy client."""
+
+    def __init__(self, args: argparse.Namespace, fmt: Formatter):
+        self.args = args
+        self.out = fmt
+        self.config = Config.load()
+        self._client = None  # type: Optional[Any]
+        self._resolved = None  # type: Optional[Any]
+
+    @property
+    def resolved(self):
+        if self._resolved is None:
+            self._resolved = resolve(url=getattr(self.args, "url", None),
+                                     token=getattr(self.args, "token", None),
+                                     profile=getattr(self.args, "profile", None),
+                                     config=self.config)
+        return self._resolved
+
+    def client(self, auth_required: bool = True, session: bool = False):
+        """The API client for this invocation, built once.
+
+        `auth_required=False` is for the public surfaces (STAC, OGC, templates): those work with a
+        URL alone, and demanding a token to read what the whole internet can read would be silly.
+
+        `session=True` marks a command that hits a route which REJECTS API tokens by design
+        (`/admin/*`, `/tokens`, ownership transfer). It prefers a stored password session; with
+        only a token available it still sends it, so the user gets the server's own 403 — which
+        `admin.py` rewrites into "run `geodeploy login --password`" — rather than a client-side
+        guess about what the instance would have said.
+        """
+        if self._client is None:
+            info = self.resolved
+            if not info.url:
+                raise AuthError(401, "No instance configured.", "")
+            token, jwt = info.token, info.jwt
+            if session and jwt:
+                token = None           # a session outranks a token for these routes
+            if auth_required and not token and not jwt:
+                raise AuthError(401, "No credentials for {0}.".format(info.url), "")
+            from ..client import Client
+            self._client = Client(
+                info.url, token=token, jwt=jwt,
+                timeout=getattr(self.args, "timeout", None) or 120.0,
+                verify_tls=not getattr(self.args, "insecure", False),
+                on_request=(lambda method, url: self.out.debug("{0} {1}".format(method, url)))
+                if self.out.verbose else None)
+            self.out.debug("instance {0} (from {1}), credential from {2}".format(
+                info.url, info.source_url, info.source_token))
+        return self._client
+
+
+def _global_flags() -> argparse.ArgumentParser:
+    """The flags every command accepts, as a PARENT parser.
+
+    Attached to the root *and* to every leaf command, because `geodeploy layers list --json` is
+    what people type — argparse would otherwise only accept `geodeploy --json layers list`, which
+    nobody does twice. `SUPPRESS` as the default is what makes that safe: an unmentioned flag on
+    the subparser leaves the root's value alone instead of resetting it.
+    """
+    parent = argparse.ArgumentParser(add_help=False)
+    common = parent.add_argument_group("connection")
+    common.add_argument("-p", "--profile", default=argparse.SUPPRESS,
+                        help="use a saved profile (see `geodeploy profile`)")
+    common.add_argument("--url", default=argparse.SUPPRESS,
+                        help="instance URL, overriding the profile and GEODEPLOY_URL")
+    common.add_argument("--token", default=argparse.SUPPRESS,
+                        help="API token, overriding the stored one and GEODEPLOY_TOKEN")
+    common.add_argument("--timeout", type=float, default=argparse.SUPPRESS,
+                        help="seconds to wait for an API call (default 120)")
+    common.add_argument("--insecure", action="store_true", default=argparse.SUPPRESS,
+                        help="skip TLS verification (self-signed instances only)")
+
+    fmt = parent.add_argument_group("output")
+    fmt.add_argument("--json", action="store_true", dest="json_mode", default=argparse.SUPPRESS,
+                     help="machine-readable JSON on stdout, and nothing else")
+    fmt.add_argument("-q", "--quiet", action="store_true", default=argparse.SUPPRESS,
+                     help="only errors")
+    fmt.add_argument("-v", "--verbose", action="store_true", default=argparse.SUPPRESS,
+                     help="log each request to stderr")
+    return parent
+
+
+GLOBAL_FLAGS = _global_flags()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="geodeploy",
+        description="Upload data, build portals and operate a GeoDeploy instance from the shell.",
+        epilog=EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[GLOBAL_FLAGS])
+    parser.add_argument("--version", action="version", version="geodeploy {0}".format(__version__))
+    # NO `set_defaults` for the global flags here. `parents=` shares ACTION OBJECTS between this
+    # parser and every leaf, and `set_defaults` rewrites `action.default` in place — which would
+    # replace the SUPPRESS above with a real default on every leaf, so `geodeploy --json layers
+    # list` would have its --json reset to False by the leaf parser. Callers read these with
+    # `getattr(args, name, default)` instead.
+
+    subparsers = parser.add_subparsers(dest="_group", metavar="<command>")
+
+    from .commands import admin, auth, catalog, imports, jobs, layers, portals, sources, upload
+    for module in (auth, upload, layers, portals, sources, imports, jobs, catalog, admin):
+        module.register(subparsers)
+    return parser
+
+
+def _tolerate_legacy_console() -> None:
+    """Never let a code-page limitation turn help text into a traceback.
+
+    `Formatter` degrades typographic characters it knows about, but argparse writes help and usage
+    straight to the stream, and an em dash in a `--help` epilog would raise UnicodeEncodeError on a
+    Windows console still running code page 437. Mojibake is a cosmetic problem; a crash printing
+    help is not.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(errors="replace")
+            except (ValueError, OSError):  # pragma: no cover - a stream that cannot be reconfigured
+                pass
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    _tolerate_legacy_console()
+    parser = build_parser()
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    fmt = Formatter(json_mode=getattr(args, "json_mode", False),
+                    quiet=getattr(args, "quiet", False),
+                    verbose=getattr(args, "verbose", False))
+
+    handler = getattr(args, "_handler", None)
+    if handler is None:
+        # A bare `geodeploy`, or a group with no command: show that group's help, not a traceback.
+        sub = getattr(args, "_subparser", None)
+        (sub or parser).print_help(sys.stderr)
+        return EXIT_USAGE
+
+    ctx = Context(args, fmt)
+    try:
+        return handler(ctx, args) or EXIT_OK
+    except KeyboardInterrupt:
+        fmt.error("Interrupted.")
+        return EXIT_GENERIC
+    except AuthError as exc:
+        fmt.error(exc.detail or "Authentication failed.", hint=_auth_hint(ctx, exc))
+        return EXIT_AUTH
+    except PermissionError_ as exc:
+        scope = exc.missing_scope
+        fmt.error(exc.detail or "Not allowed.",
+                  hint=("Mint a token with the {0} scope (Settings → API tokens)."
+                        .format(scope) if scope else
+                        "Your role may be too low for this — an editor cannot administer an "
+                        "instance, and administration is session-only anyway."))
+        return EXIT_AUTH
+    except ServerError as exc:
+        fmt.error(exc.detail or "The instance returned an error.",
+                  hint="Check `geodeploy admin health`, or the service logs.")
+        return EXIT_SERVER
+    except TransportError as exc:
+        fmt.error(str(exc), hint="If the host is right, check the instance is up and reachable.")
+        return EXIT_NETWORK
+    except JobTimeout as exc:
+        fmt.error(str(exc))
+        return EXIT_GENERIC
+    except JobFailed as exc:
+        fmt.error("Ingest failed: {0}".format(exc),
+                  hint="`geodeploy layers reprocess <layer>` restarts it without re-uploading.")
+        return EXIT_GENERIC
+    except ValidationError as exc:
+        # A ValidationError raised before any request has no URL: that is the CLI rejecting the
+        # arguments, which is a usage error (2). One that came back from the instance is a failed
+        # operation (1) — the arguments were fine, the data or the state was not.
+        fmt.error(exc.detail or str(exc))
+        return EXIT_GENERIC if exc.url else EXIT_USAGE
+    except APIError as exc:
+        fmt.error(exc.detail or str(exc))
+        return EXIT_GENERIC
+    except ConfigError as exc:
+        fmt.error(str(exc))
+        return EXIT_USAGE
+    except GeoDeployError as exc:
+        fmt.error(str(exc))
+        return EXIT_GENERIC
+    except BrokenPipeError:  # `geodeploy … | head` — not an error worth a message
+        return EXIT_OK
+    except OSError as exc:
+        fmt.error(str(exc))
+        return EXIT_GENERIC
+
+
+def _auth_hint(ctx: Context, exc: AuthError) -> str:
+    info = ctx.resolved
+    if not info.url:
+        return "Run `geodeploy login <instance-url>`, or set GEODEPLOY_URL."
+    if not info.token:
+        return ("Run `geodeploy login {0}` with a token from Settings → API tokens, "
+                "or set GEODEPLOY_TOKEN.".format(info.url))
+    return ("The credential for {0} was refused — it may be revoked or expired. "
+            "`geodeploy login {0}` stores a new one.".format(info.url))
+
+
+def add_command(group, name: str, handler, help_text: str, aliases=(), epilog: Optional[str] = None):
+    """Register one command on a group's subparser set, wiring its handler and help."""
+    parser = group.add_parser(name, help=help_text, description=help_text, aliases=list(aliases),
+                              epilog=epilog, parents=[GLOBAL_FLAGS],
+                              formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.set_defaults(_handler=handler)
+    return parser
+
+
+def group_parser(subparsers, name: str, help_text: str, aliases=()):
+    """Register a command GROUP (`geodeploy layers …`) and return its own subparser set.
+
+    `_subparser` is stashed so that `geodeploy layers` with no command prints the group's help
+    rather than the root's — the root's help is a wall, and the user has already narrowed down.
+    """
+    parser = subparsers.add_parser(name, help=help_text, description=help_text,
+                                   aliases=list(aliases),
+                                   formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.set_defaults(_subparser=parser)
+    return parser.add_subparsers(dest="_command", metavar="<subcommand>")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/cli/geodeploy/cli/main.py
+++ b/cli/geodeploy/cli/main.py
@@ -133,8 +133,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="_group", metavar="<command>")
 
-    from .commands import admin, auth, catalog, imports, jobs, layers, portals, sources, upload
-    for module in (auth, upload, layers, portals, sources, imports, jobs, catalog, admin):
+    from .commands import (admin, auth, browse, catalog, imports, jobs, layers, portals,
+                           sources, upload)
+    for module in (auth, browse, upload, layers, portals, sources, imports, jobs,
+                   catalog, admin):
         module.register(subparsers)
     return parser
 

--- a/cli/geodeploy/cli/output.py
+++ b/cli/geodeploy/cli/output.py
@@ -1,0 +1,317 @@
+"""Printing, tables, progress and exit codes — the only module allowed to write to a terminal.
+
+Three rules:
+
+* **stdout is the answer, stderr is the commentary.** `geodeploy layers list --json | jq` must
+  receive JSON and nothing else, so progress, warnings and "publish to make this live" hints all go
+  to stderr. This is also why a progress bar can never appear on stdout.
+* **`--json` is a contract.** With it, stdout is exactly one JSON document — including for errors,
+  which come back as `{"ok": false, "error": …}` so a script can read the failure instead of
+  scraping it.
+* **The exit code is the other contract.** A CI job branches on it long before it parses anything.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+import shutil
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+# ── Exit codes ───────────────────────────────────────────────────────────────────────────────────
+# Same matrix the docs publish. Separating AUTH from USAGE from SERVER is what lets a nightly job
+# alert on "your token expired" without alerting on "the instance is restarting".
+EXIT_OK = 0
+EXIT_GENERIC = 1      # the operation failed (a 4xx that is not auth, a bad file, a failed job)
+EXIT_USAGE = 2        # the command line itself was wrong — argparse's own convention
+EXIT_AUTH = 3         # 401/403: no credential, expired token, missing scope, or too low a role
+EXIT_NETWORK = 4      # never got an answer: DNS, TLS, connection reset, timeout
+EXIT_SERVER = 5       # 5xx: the instance is up but broke
+
+
+def _supports_color(stream) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("GEODEPLOY_FORCE_COLOR"):
+        return True
+    if not hasattr(stream, "isatty") or not stream.isatty():
+        return False
+    if sys.platform.startswith("win"):
+        # Windows 10+ terminals understand ANSI once VT processing is on; enabling it is cheap and
+        # failing to enable it just means no colour, never mojibake.
+        try:
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+        except Exception:
+            return False
+    return True
+
+
+#: Typographic characters, and what to write instead on a console that cannot encode them.
+#: A Windows console still running code page 437 raises UnicodeEncodeError on "✓" — which would
+#: turn a SUCCESSFUL command into a traceback. Degrading the glyph is the only acceptable failure.
+_FALLBACKS = {"✓": "OK", "→": "->", "—": "-", "…": "...", "·": "-", "≥": ">=", "≤": "<="}
+
+
+def _encodable(stream) -> bool:
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        "".join(_FALLBACKS).encode(encoding)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
+class Formatter(object):
+    """Writes everything the CLI shows, honouring --json / --quiet / --verbose / NO_COLOR."""
+
+    def __init__(self, json_mode: bool = False, quiet: bool = False, verbose: bool = False,
+                 stdout=None, stderr=None):
+        self.json_mode = json_mode
+        self.quiet = quiet
+        self.verbose = verbose
+        self.stdout = stdout or sys.stdout
+        self.stderr = stderr or sys.stderr
+        self._color = _supports_color(self.stdout) and not json_mode
+        self._color_err = _supports_color(self.stderr) and not json_mode
+        self._plain = not (_encodable(self.stdout) and _encodable(self.stderr))
+
+    def _text(self, text: str) -> str:
+        if not self._plain:
+            return text
+        for fancy, plain in _FALLBACKS.items():
+            text = text.replace(fancy, plain)
+        return text
+
+    # -- styling ---------------------------------------------------------------------------------
+
+    def paint(self, text: str, code: str, err: bool = False) -> str:
+        enabled = self._color_err if err else self._color
+        return "\033[{0}m{1}\033[0m".format(code, text) if enabled else text
+
+    def dim(self, text: str, err: bool = False) -> str:
+        return self.paint(text, "2", err)
+
+    def bold(self, text: str, err: bool = False) -> str:
+        return self.paint(text, "1", err)
+
+    def green(self, text: str, err: bool = False) -> str:
+        return self.paint(text, "32", err)
+
+    def red(self, text: str, err: bool = False) -> str:
+        return self.paint(text, "31", err)
+
+    def yellow(self, text: str, err: bool = False) -> str:
+        return self.paint(text, "33", err)
+
+    # -- messages --------------------------------------------------------------------------------
+
+    def out(self, text: str = "") -> None:
+        """A line of the ANSWER — the thing the command was asked for."""
+        self.stdout.write(self._text(text) + "\n")
+
+    def info(self, text: str) -> None:
+        """Commentary: what happened, what to do next. Silent under --json/--quiet."""
+        if self.json_mode or self.quiet:
+            return
+        self.stderr.write(self._text(text) + "\n")
+
+    def success(self, text: str) -> None:
+        if self.json_mode or self.quiet:
+            return
+        self.stderr.write(self._text(self.green("✓ ", err=True) + text) + "\n")
+
+    def warn(self, text: str) -> None:
+        if self.json_mode or self.quiet:
+            return
+        self.stderr.write(self._text(self.yellow("warning: ", err=True) + text) + "\n")
+
+    def error(self, text: str, hint: Optional[str] = None) -> None:
+        """Errors always print, even under --quiet — silence on failure is how a CI job lies."""
+        if self.json_mode:
+            payload = {"ok": False, "error": text}
+            if hint:
+                payload["hint"] = hint
+            self.stdout.write(_json.dumps(payload, indent=2) + "\n")
+            return
+        self.stderr.write(self._text(self.red("error: ", err=True) + text) + "\n")
+        if hint:
+            self.stderr.write(self._text(self.dim("  " + hint, err=True)) + "\n")
+
+    def debug(self, text: str) -> None:
+        if self.verbose and not self.json_mode:
+            self.stderr.write(self._text(self.dim("· " + text, err=True)) + "\n")
+
+    # -- structured output -----------------------------------------------------------------------
+
+    def json(self, payload: Any) -> None:
+        self.stdout.write(_json.dumps(payload, indent=2, default=str, ensure_ascii=False) + "\n")
+
+    def render(self, payload: Any, columns: Optional[Sequence[Any]] = None,
+               empty: str = "Nothing to show.") -> None:
+        """The default way a command answers: JSON under --json, otherwise a table or a record."""
+        if self.json_mode:
+            self.json(payload)
+            return
+        if isinstance(payload, list):
+            if not payload:
+                self.info(empty)
+                return
+            self.table(payload, columns)
+        elif isinstance(payload, dict):
+            self.record(payload, columns)
+        elif payload is not None:
+            self.out(str(payload))
+
+    def table(self, rows: List[Dict[str, Any]], columns: Optional[Sequence[Any]] = None) -> None:
+        """A plain aligned table. `columns` is a list of keys, or (key, heading) pairs."""
+        if not rows:
+            return
+        if columns:
+            cols = [(c, c.replace("_", " ")) if isinstance(c, str) else c for c in columns]
+        else:
+            keys = []  # type: List[str]
+            for row in rows:
+                for key in row:
+                    if key not in keys:
+                        keys.append(key)
+            cols = [(k, k.replace("_", " ")) for k in keys]
+
+        cells = [[_cell(row.get(key)) for key, _ in cols] for row in rows]
+        widths = [len(str(head)) for _, head in cols]
+        for line in cells:
+            for i, value in enumerate(line):
+                widths[i] = max(widths[i], len(value))
+        # Keep the table inside the terminal: trim the widest column rather than wrapping, since a
+        # wrapped table is unreadable and the full value is one --json away.
+        budget = (shutil.get_terminal_size((100, 24)).columns
+                  if hasattr(self.stdout, "isatty") and self.stdout.isatty() else 1000)
+        while sum(widths) + 2 * (len(widths) - 1) > budget and max(widths) > 8:
+            widths[widths.index(max(widths))] -= 1
+
+        self.out(self.dim("  ".join(
+            str(head).upper().ljust(widths[i]) for i, (_, head) in enumerate(cols))))
+        for line in cells:
+            self.out("  ".join(_fit(value, widths[i]) for i, value in enumerate(line)))
+
+    def record(self, row: Dict[str, Any], keys: Optional[Sequence[str]] = None) -> None:
+        """One object as `key: value` lines — a portal, a layer, a job."""
+        items = [(k, row.get(k)) for k in keys] if keys else list(row.items())
+        width = max((len(str(k)) for k, _ in items), default=0)
+        for key, value in items:
+            if value is None and keys is None:
+                continue
+            self.out("{0}  {1}".format(self.dim(str(key).ljust(width)), _cell(value, wide=True)))
+
+    def progress(self, label: str, total: Optional[int] = None) -> "Progress":
+        return Progress(self, label, total)
+
+
+class Progress(object):
+    """A one-line progress bar on stderr, and a no-op when nobody is watching.
+
+    Rate and remaining bytes are shown rather than a spinner because the question during a 4 GB
+    upload is always "will this finish before I have to leave", and only a rate answers it.
+    """
+
+    def __init__(self, fmt: Formatter, label: str, total: Optional[int] = None):
+        self._f = fmt
+        self.label = label
+        self.total = total
+        self._last = 0.0
+        self._started = time.time()
+        self._active = (not fmt.json_mode and not fmt.quiet
+                        and hasattr(fmt.stderr, "isatty") and fmt.stderr.isatty())
+        self._done = False
+
+    def update(self, done: int, total: Optional[int] = None) -> None:
+        if not self._active:
+            return
+        if total:
+            self.total = total
+        now = time.time()
+        complete = self.total and done >= self.total
+        if not complete and now - self._last < 0.1:   # ~10 fps is plenty and keeps the CPU idle
+            return
+        self._last = now
+        elapsed = max(now - self._started, 1e-6)
+        rate = done / elapsed
+        if self.total:
+            fraction = min(max(done / float(self.total), 0.0), 1.0)
+            filled = int(round(fraction * 24))
+            bar = "#" * filled + "-" * (24 - filled)
+            text = "{0} [{1}] {2:3.0f}%  {3} / {4}  {5}/s".format(
+                self.label, bar, fraction * 100, human_size(done), human_size(self.total),
+                human_size(rate))
+        else:
+            text = "{0}  {1}  {2}/s".format(self.label, human_size(done), human_size(rate))
+        self._f.stderr.write("\r\033[K" + text)
+        self._f.stderr.flush()
+
+    def finish(self, message: Optional[str] = None) -> None:
+        if self._done:
+            return
+        self._done = True
+        if self._active:
+            self._f.stderr.write("\r\033[K")
+            self._f.stderr.flush()
+        if message:
+            self._f.info(message)
+
+    def __enter__(self) -> "Progress":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.finish()
+
+
+# ── value formatting ─────────────────────────────────────────────────────────────────────────────
+
+def human_size(num: float) -> str:
+    """Bytes as something readable. Binary units, because storage tooling reports binary units."""
+    value = float(num or 0)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return "{0:.0f} {1}".format(value, unit) if unit == "B" else "{0:.1f} {1}".format(value, unit)
+        value /= 1024.0
+    return "{0:.1f} TB".format(value)  # pragma: no cover - unreachable, loop returns
+
+
+def human_count(num: Any) -> str:
+    try:
+        return "{0:,}".format(int(num))
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _cell(value: Any, wide: bool = False) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return "—"
+        if all(isinstance(v, (int, float)) for v in value):
+            return ", ".join("{0:g}".format(v) for v in value)
+        return _json.dumps(value) if wide else "{0} item{1}".format(
+            len(value), "" if len(value) == 1 else "s")
+    if isinstance(value, dict):
+        return _json.dumps(value) if wide else "{0} key{1}".format(
+            len(value), "" if len(value) == 1 else "s")
+    text = str(value)
+    if len(text) == 19 and text[4] == "-" and text[10] == "T":      # an ISO timestamp
+        return text.replace("T", " ")
+    return text
+
+
+def _fit(text: str, width: int) -> str:
+    if len(text) <= width:
+        return text.ljust(width)
+    return text[: max(1, width - 1)] + "…"
+
+
+def iter_rows(payload: Any) -> Iterable[Dict[str, Any]]:  # pragma: no cover - convenience
+    return payload if isinstance(payload, list) else [payload]

--- a/cli/geodeploy/client.py
+++ b/cli/geodeploy/client.py
@@ -1,0 +1,327 @@
+"""The GeoDeploy API client.
+
+This is the piece the QGIS plugin imports. It is deliberately a *library*: it never prints, never
+reads the config file, never calls `sys.exit` — it takes a URL and a credential, makes requests, and
+raises the typed errors in `errors.py`. Everything user-facing lives in `geodeploy.cli`.
+
+    from geodeploy import Client
+    gd = Client("https://geodeploy.example.org", token="gdp_…")
+    gd.whoami()
+    gd.uploads.upload("roads.gpkg", wait=True)
+    gd.portals.publish(3)
+
+Grouping is by API area (`gd.vector`, `gd.portals`, `gd.admin`, …) so that discovering the client
+in an editor mirrors discovering the API in `/api/docs`.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+from typing import Any, Callable, Dict, Optional, Union
+from urllib.parse import quote, urlencode, urljoin
+
+from . import errors
+from .transport import Request, Response, UrllibTransport
+
+__all__ = ["Client"]
+
+#: Sent on every request. An instance's access log is where an operator works out that "the API is
+#: hammering us" is in fact someone's nightly CLI job, so it names the tool and its version.
+def _default_user_agent() -> str:
+    from . import __version__
+    return "geodeploy-cli/{0}".format(__version__)
+
+
+class Client(object):
+    """A connection to one GeoDeploy instance.
+
+    Args:
+        url: instance origin, e.g. ``https://geodeploy.example.org`` (with or without ``/api``).
+        token: a scoped API token (``gdp_…``) from Settings → API tokens.
+        jwt: a session JWT instead of a token — what ``geodeploy login --password`` obtains. Admin
+            routes (`/admin/*`, ownership transfer, token management) REJECT API tokens by design,
+            so anything under `gd.admin` needs this rather than a `gdp_` token.
+        transport: anything with ``send(Request) -> Response``. Swap in a Qt/QGIS network stack to
+            inherit the host's proxy and certificate configuration.
+        timeout: seconds for ordinary API calls.
+        upload_timeout: seconds for calls that move file bytes — a 5 GB PUT over a slow link is not
+            a hung request, and killing it at 120 s would make big uploads impossible.
+    """
+
+    def __init__(self, url: str, token: Optional[str] = None, jwt: Optional[str] = None,
+                 transport: Optional[Any] = None, timeout: float = 120.0,
+                 upload_timeout: float = 3600.0, user_agent: Optional[str] = None,
+                 verify_tls: bool = True, retries: int = 2,
+                 on_request: Optional[Callable[[str, str], None]] = None):
+        from .config import normalize_url
+        self.url = normalize_url(url)
+        self.token = token or None
+        self.jwt = jwt or None
+        self.timeout = timeout
+        self.upload_timeout = upload_timeout
+        self.user_agent = user_agent or _default_user_agent()
+        self.transport = transport or UrllibTransport(verify_tls=verify_tls, retries=retries)
+        #: Called with (method, url) before each request — the CLI's `-v` uses it, and a plugin can
+        #: route it to the QGIS message log without this module knowing what logging is.
+        self.on_request = on_request
+
+        # Namespaces. Imported here rather than at module scope because each one imports this
+        # module for typing; the cost is one attribute lookup at construction.
+        from .admin import Admin, Users
+        from .catalog import Catalog
+        from .imports import Imports
+        from .jobs import Jobs
+        from .layers import Layers, RasterLayers, VectorLayers
+        from .portals import Portals
+        from .sources import Sources
+        from .uploads import Uploads
+
+        self.vector = VectorLayers(self)
+        self.raster = RasterLayers(self)
+        #: Backend-agnostic helpers: resolve a layer by id/uid/name across both kinds.
+        self.layers = Layers(self)
+        self.portals = Portals(self)
+        self.sources = Sources(self)
+        self.imports = Imports(self)
+        self.jobs = Jobs(self)
+        self.uploads = Uploads(self)
+        self.admin = Admin(self)
+        self.users = Users(self)
+        self.catalog = Catalog(self)
+
+    # ── URLs ─────────────────────────────────────────────────────────────────────────────────────
+
+    def api_url(self, path: str, params: Optional[Dict[str, Any]] = None) -> str:
+        """Absolute URL for an API path. `path` is relative to `/api` unless it already starts there."""
+        if path.startswith("http://") or path.startswith("https://"):
+            base = path
+        else:
+            clean = path if path.startswith("/") else "/" + path
+            if not clean.startswith("/api"):
+                clean = "/api" + clean
+            base = self.url + clean
+        query = _query(params)
+        return base + (("&" if "?" in base else "?") + query if query else "")
+
+    def absolute(self, url_or_path: str) -> str:
+        """Resolve something the API handed back (`/s3/…?X-Amz-…`) against this instance.
+
+        Presigned upload URLs come back RELATIVE for a managed MinIO — nginx proxies `/s3/` with
+        the signed Host preserved — and absolute for an external S3 endpoint. Both must work, and
+        only the client knows the origin.
+        """
+        if url_or_path.startswith("http://") or url_or_path.startswith("https://"):
+            return url_or_path
+        return urljoin(self.url + "/", url_or_path.lstrip("/"))
+
+    # ── Requests ─────────────────────────────────────────────────────────────────────────────────
+
+    def request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None,
+                json: Any = None, body: Any = None, headers: Optional[Dict[str, str]] = None,
+                timeout: Optional[float] = None, auth: bool = True,
+                parse: bool = True, content_type: Optional[str] = None) -> Any:
+        """One API call. Returns parsed JSON by default, or the raw `Response` when `parse=False`."""
+        url = self.api_url(path, params)
+        hdrs = {"Accept": "application/json", "User-Agent": self.user_agent}
+        if auth:
+            hdrs.update(self.auth_headers())
+        if headers:
+            hdrs.update(headers)
+
+        data = body
+        if json is not None:
+            data = _json.dumps(json).encode("utf-8")
+            hdrs.setdefault("Content-Type", "application/json")
+        if content_type:
+            hdrs["Content-Type"] = content_type
+
+        if self.on_request:
+            self.on_request(method.upper(), url)
+        response = self.transport.send(
+            Request(method, url, hdrs, data, timeout if timeout is not None else self.timeout))
+        return self._handle(response, parse)
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None, **kw: Any) -> Any:
+        return self.request("GET", path, params=params, **kw)
+
+    def post(self, path: str, json: Any = None, **kw: Any) -> Any:
+        return self.request("POST", path, json=json, **kw)
+
+    def put(self, path: str, json: Any = None, **kw: Any) -> Any:
+        return self.request("PUT", path, json=json, **kw)
+
+    def delete(self, path: str, **kw: Any) -> Any:
+        return self.request("DELETE", path, **kw)
+
+    def send_absolute(self, method: str, url: str, body: Any = None,
+                      headers: Optional[Dict[str, str]] = None,
+                      timeout: Optional[float] = None) -> Response:
+        """A request to a URL that is NOT the API — a presigned storage PUT.
+
+        Auth headers are deliberately absent: a presigned URL carries its own signature in the
+        query string, and an extra `Authorization` header makes S3 reject the request as
+        double-authenticated. (The UI's api client has the same note for the same reason.)
+        """
+        hdrs = {"User-Agent": self.user_agent}
+        hdrs.update(headers or {})
+        if self.on_request:
+            self.on_request(method.upper(), url)
+        return self.transport.send(
+            Request(method, self.absolute(url), hdrs, body,
+                    timeout if timeout is not None else self.upload_timeout))
+
+    def download(self, path: str, sink, params: Optional[Dict[str, Any]] = None,
+                 auth: bool = True, timeout: Optional[float] = None) -> Response:
+        """Stream a GET into a writable binary file object (COG, PMTiles, an export bundle)."""
+        url = self.api_url(path, params)
+        hdrs = {"User-Agent": self.user_agent}
+        if auth:
+            hdrs.update(self.auth_headers())
+        streamer = getattr(self.transport, "stream", None)
+        if streamer is None:  # a custom transport without streaming: fall back to buffered
+            response = self.transport.send(Request("GET", url, hdrs, None,
+                                                   timeout or self.upload_timeout))
+            self._handle(response, parse=False)
+            sink.write(response.content)
+            return response
+        response = streamer(Request("GET", url, hdrs, None, timeout or self.upload_timeout), sink)
+        return self._handle(response, parse=False)
+
+    def auth_headers(self) -> Dict[str, str]:
+        if self.token:
+            return {"Authorization": "Bearer " + self.token}
+        if self.jwt:
+            return {"Authorization": "Bearer " + self.jwt}
+        return {}
+
+    # ── Responses ────────────────────────────────────────────────────────────────────────────────
+
+    def _handle(self, response: Response, parse: bool = True) -> Any:
+        if response.status >= 400:
+            raise errors.from_status(response.status, _detail(response), response.url,
+                                     _safe_json(response))
+        if not parse:
+            return response
+        if response.status == 204 or not response.content:
+            return None
+        ctype = response.headers.get("content-type", "")
+        if "json" in ctype:
+            return response.json()
+        return response.text
+
+    # ── Identity ─────────────────────────────────────────────────────────────────────────────────
+
+    def whoami(self) -> Dict[str, Any]:
+        """The authenticated user (`GET /auth/me`). Works for both a token and a session JWT."""
+        return self.get("/auth/me")
+
+    def login(self, email: str, password: str) -> str:
+        """Exchange a password for a session JWT, store it on this client, and return it.
+
+        Needed for the routes that refuse API tokens on purpose (`/admin/*`, `/tokens`, ownership
+        transfer): a leaked token must not be able to reconfigure the instance or mint more tokens.
+        """
+        form = urlencode({"username": email, "password": password}).encode()
+        data = self.request("POST", "/auth/login", body=form, auth=False,
+                            content_type="application/x-www-form-urlencoded")
+        jwt = (data or {}).get("access_token")
+        if not jwt:
+            raise errors.AuthError(401, "Login did not return a token.", self.api_url("/auth/login"))
+        self.jwt = jwt
+        self.token = None  # a session supersedes any token on this client instance
+        return jwt
+
+    def setup_status(self) -> Dict[str, Any]:
+        """Public: whether the instance is set up, and which login methods it offers."""
+        return self.get("/setup/status", auth=False)
+
+    def tokens(self) -> Any:
+        """List the acting user's API tokens (session auth only — a token cannot list tokens)."""
+        return self.get("/tokens")
+
+    def create_token(self, name: str, scopes, expires_in_days: int = 90) -> Dict[str, Any]:
+        """Mint an API token. The raw `gdp_…` secret is in the response and never retrievable again."""
+        return self.post("/tokens", {"name": name, "scopes": list(scopes),
+                                     "expires_in_days": expires_in_days})
+
+    def revoke_token(self, token_id: int) -> Any:
+        return self.delete("/tokens/{0}".format(int(token_id)))
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        how = "token" if self.token else ("session" if self.jwt else "anonymous")
+        return "<geodeploy.Client {0} ({1})>".format(self.url, how)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────────────────────────
+
+def _query(params: Optional[Dict[str, Any]]) -> str:
+    """Encode query params, dropping Nones and flattening lists — `?bbox=…&ids=a&ids=b`."""
+    if not params:
+        return ""
+    pairs = []
+    for key, value in params.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            pairs.append((key, "true" if value else "false"))
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                if item is not None:
+                    pairs.append((key, str(item)))
+        else:
+            pairs.append((key, str(value)))
+    return urlencode(pairs)
+
+
+def _safe_json(response: Response) -> Any:
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _detail(response: Response) -> str:
+    """The most useful one-line message an error response contains.
+
+    FastAPI puts a string in `detail` for a raised HTTPException and a LIST of field errors there
+    for a validation failure; nginx returns HTML. All three have to become something a person can
+    read on one line, because that line is what the CLI prints.
+    """
+    payload = _safe_json(response)
+    if isinstance(payload, dict):
+        detail = payload.get("detail")
+        if isinstance(detail, str):
+            return detail
+        if isinstance(detail, list):
+            parts = []
+            for item in detail:
+                if isinstance(item, dict):
+                    loc = ".".join(str(x) for x in (item.get("loc") or [])[1:])
+                    parts.append("{0}: {1}".format(loc, item.get("msg")) if loc else str(item.get("msg")))
+                else:
+                    parts.append(str(item))
+            return "; ".join(parts)
+        if detail is not None:
+            return str(detail)
+        for key in ("message", "error"):
+            if payload.get(key):
+                return str(payload[key])
+    text = (response.text or "").strip()
+    if text.startswith("<"):  # an nginx/proxy HTML page — the status is the only real information
+        return {413: "Request body too large for the server or a proxy in front of it.",
+                502: "Bad gateway — the instance is up but the API did not answer.",
+                504: "Gateway timeout."}.get(response.status, "HTTP {0}".format(response.status))
+    return text[:500] or "HTTP {0}".format(response.status)
+
+
+def path_segment(value: Any) -> str:
+    """URL-quote one path segment (a slug, a uid, a storage key)."""
+    return quote(str(value), safe="")
+
+
+def env_client(**kw: Any) -> Client:
+    """A client from `GEODEPLOY_URL` / `GEODEPLOY_TOKEN` alone — for scripts and doctests."""
+    url = os.environ.get("GEODEPLOY_URL")
+    if not url:
+        raise errors.ConfigError("Set GEODEPLOY_URL (and usually GEODEPLOY_TOKEN).")
+    return Client(url, token=os.environ.get("GEODEPLOY_TOKEN"), **kw)

--- a/cli/geodeploy/config.py
+++ b/cli/geodeploy/config.py
@@ -1,0 +1,412 @@
+"""Where the CLI remembers your instances, and where it does NOT remember your tokens.
+
+Three rules this module exists to keep:
+
+1. **A token never lands in the config file.** `config.json` holds instance URLs, profile names and
+   the account each was logged in as — the things worth reading and editing by hand. Secrets go to
+   the OS keyring when there is one, and to a separate `credentials.json` (0600, in a 0700 parent)
+   when there is not. That separation is what lets someone paste their config into an issue.
+
+2. **Writes are atomic.** temp file in the same directory, chmod, `os.replace`. A CLI that is
+   interrupted mid-write must not leave a truncated config that locks the user out of their own
+   instance.
+
+3. **Explicit beats remembered.** Flags override the environment, which overrides the active
+   profile — so a CI job that sets `GEODEPLOY_URL`/`GEODEPLOY_TOKEN` needs no config file at all,
+   and `--url` in a one-off command never silently writes itself down.
+
+The env var names are `GEODEPLOY_URL` and `GEODEPLOY_TOKEN`, unchanged from the reference script in
+`examples/`, because people already have them exported.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from typing import Any, Dict, Optional
+
+from .errors import ConfigError
+
+APP_NAME = "geodeploy"
+
+#: Service name under which tokens are filed in the OS keyring.
+KEYRING_SERVICE = "geodeploy-cli"
+
+
+# ── Locations ────────────────────────────────────────────────────────────────────────────────────
+
+def config_dir() -> str:
+    """The per-user config directory, following each platform's own convention.
+
+    Hand-rolled rather than `platformdirs` for the no-dependency rule (see pyproject). The three
+    branches below are the whole of what that library would do for us.
+    """
+    override = os.environ.get("GEODEPLOY_CONFIG_DIR")
+    if override:
+        return os.path.expanduser(override)
+    if sys.platform.startswith("win"):
+        base = os.environ.get("APPDATA") or os.path.expanduser("~")
+        return os.path.join(base, "GeoDeploy")
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/Application Support/geodeploy")
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+    return os.path.join(base, APP_NAME)
+
+
+def config_path() -> str:
+    return os.path.join(config_dir(), "config.json")
+
+
+def credentials_path() -> str:
+    return os.path.join(config_dir(), "credentials.json")
+
+
+# ── Atomic, permission-aware writes ──────────────────────────────────────────────────────────────
+
+def atomic_write(path: str, text: str, mode: int = 0o600, tighten_parent: bool = False) -> None:
+    """Write `text` to `path` atomically, with `mode` on the file.
+
+    `tighten_parent` is for the credentials file only: 0700 on the directory keeps another account
+    on a shared machine from listing it. It is deliberately NOT applied to ordinary output files —
+    tightening a directory a user chose (their home, a project folder) is not ours to do.
+    """
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    if tighten_parent:
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass  # Windows: chmod is largely a no-op, and NTFS ACLs already scope %APPDATA%.
+    fd, tmp = tempfile.mkstemp(dir=parent, prefix="." + os.path.basename(path) + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        try:
+            os.chmod(tmp, mode)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: str) -> Dict[str, Any]:
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8-sig") as fh:  # -sig: a BOM from Notepad is not an error
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (ValueError, OSError) as exc:
+        raise ConfigError("Could not read {0}: {1}".format(path, exc))
+
+
+# ── URL handling ─────────────────────────────────────────────────────────────────────────────────
+
+def normalize_url(url: str) -> str:
+    """Canonical instance origin: scheme + host (+ port), no trailing slash, no `/api`.
+
+    Everything downstream builds `<origin>/api/...`, so `https://gd.example.org/api/` and
+    `gd.example.org` have to resolve to the same string — otherwise a token saved under one spelling
+    is invisible to the other, which is the single most confusing thing a multi-instance CLI can do.
+    """
+    raw = (url or "").strip()
+    if not raw:
+        raise ConfigError("An instance URL is required (e.g. https://geodeploy.example.org).")
+    if "://" not in raw:
+        # A bare host is what people type. Default to https — the wrong guess is a TLS error the
+        # user can read, whereas defaulting to http would silently send their token in clear.
+        raw = "https://" + raw
+    scheme, _, rest = raw.partition("://")
+    if scheme not in ("http", "https"):
+        raise ConfigError("Instance URL must be http:// or https:// (got {0}://).".format(scheme))
+    rest = rest.rstrip("/")
+    for suffix in ("/api/docs", "/api/openapi.json", "/api"):
+        if rest.endswith(suffix):
+            rest = rest[: -len(suffix)]
+            break
+    if not rest:
+        raise ConfigError("Instance URL has no host: {0}".format(url))
+    return "{0}://{1}".format(scheme, rest.rstrip("/"))
+
+
+# ── The config file ──────────────────────────────────────────────────────────────────────────────
+
+class Config:
+    """`config.json` — profiles and which one is active. No secrets, ever."""
+
+    def __init__(self, data: Optional[Dict[str, Any]] = None, path: Optional[str] = None):
+        self.path = path or config_path()
+        data = data or {}
+        self.profiles = dict(data.get("profiles") or {})   # name -> {url, email, ...}
+        self.current = data.get("current") or None
+
+    @classmethod
+    def load(cls, path: Optional[str] = None) -> "Config":
+        p = path or config_path()
+        return cls(_read_json(p), p)
+
+    def save(self) -> None:
+        payload = {"current": self.current, "profiles": self.profiles}
+        atomic_write(self.path, json.dumps(payload, indent=2, sort_keys=True) + "\n", mode=0o600)
+
+    # -- profiles --------------------------------------------------------------------------------
+
+    def set_profile(self, name: str, url: str, email: Optional[str] = None,
+                    make_current: bool = True, **extra: Any) -> Dict[str, Any]:
+        entry = dict(self.profiles.get(name) or {})
+        entry["url"] = normalize_url(url)
+        if email is not None:
+            entry["email"] = email
+        for key, value in extra.items():
+            if value is None:
+                entry.pop(key, None)
+            else:
+                entry[key] = value
+        self.profiles[name] = entry
+        if make_current or not self.current:
+            self.current = name
+        return entry
+
+    def remove_profile(self, name: str) -> bool:
+        existed = self.profiles.pop(name, None) is not None
+        if self.current == name:
+            self.current = next(iter(self.profiles), None)
+        return existed
+
+    def get(self, name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        key = name or self.current
+        if not key:
+            return None
+        entry = self.profiles.get(key)
+        if entry is None:
+            return None
+        out = dict(entry)
+        out["name"] = key
+        return out
+
+    def resolve_name(self, name: Optional[str]) -> Optional[str]:
+        if name:
+            if name not in self.profiles:
+                raise ConfigError(
+                    "No profile named {0!r}. Known profiles: {1}".format(
+                        name, ", ".join(sorted(self.profiles)) or "(none)"))
+            return name
+        return self.current
+
+
+# ── Credentials ──────────────────────────────────────────────────────────────────────────────────
+# Keyed by the NORMALIZED instance URL rather than the profile name, so two profiles pointing at
+# one instance share the credential and deleting a profile does not orphan a secret.
+
+def _keyring():
+    """The `keyring` module if the host has it, else None.
+
+    Optional on purpose: an install that has it (most desktops, and QGIS on Windows/macOS) gets the
+    OS credential store; a bare server without it gets the 0600 file. Refusing to run without
+    keyring would make the CLI unusable in exactly the headless case it is most needed.
+    """
+    if os.environ.get("GEODEPLOY_NO_KEYRING"):
+        return None
+    try:
+        import keyring  # type: ignore
+        # A keyring with no usable backend raises only on USE, so probe the backend up front.
+        from keyring.backends import fail as _fail  # type: ignore
+        if isinstance(keyring.get_keyring(), _fail.Keyring):
+            return None
+        return keyring
+    except Exception:
+        return None
+
+
+def save_credential(url: str, token: Optional[str] = None, jwt: Optional[str] = None,
+                    email: Optional[str] = None, use_keyring: bool = True) -> str:
+    """Store credentials for `url`. Returns where they went: "keyring" or the file path.
+
+    TWO kinds live side by side because the API deliberately treats them differently: an API token
+    (`gdp_…`) is scoped and cannot touch `/admin/*` or mint more tokens, while a password login
+    yields a session JWT that can. Someone who does both should not have to choose, so a `login
+    --password` does not wipe a stored token.
+    """
+    origin = normalize_url(url)
+    entry = load_credential(origin)
+    if token is not None:
+        entry["token"] = token
+    if jwt is not None:
+        entry["jwt"] = jwt
+    if email is not None:
+        entry["email"] = email
+    return _store_credential(origin, entry, use_keyring)
+
+
+def _store_credential(origin: str, entry: Dict[str, Any], use_keyring: bool = True) -> str:
+    """Write `entry` as the WHOLE credential for `origin` — no merge.
+
+    Separate from `save_credential` because deletion needs it: pruning a key and then saving
+    through the merging path re-reads the stored entry and puts the key straight back, which is a
+    "logged out" that leaves you logged in.
+    """
+    if use_keyring:
+        kr = _keyring()
+        if kr is not None:
+            try:
+                kr.set_password(KEYRING_SERVICE, origin, _json_dumps(entry))
+                # Drop any older file copy, so a secret lives in ONE place, not two.
+                _write_credentials({k: v for k, v in _read_credentials().items() if k != origin})
+                return "keyring"
+            except Exception:
+                pass  # Locked/denied keyring: fall back to the file rather than losing the login.
+    creds = _read_credentials()
+    creds[origin] = entry
+    _write_credentials(creds)
+    return credentials_path()
+
+
+def load_credential(url: str) -> Dict[str, Any]:
+    """`{token?, jwt?, email?}` for an instance — empty when nothing is stored."""
+    origin = normalize_url(url)
+    kr = _keyring()
+    if kr is not None:
+        try:
+            value = kr.get_password(KEYRING_SERVICE, origin)
+            if value:
+                try:
+                    data = json.loads(value)
+                    if isinstance(data, dict):
+                        return dict(data)
+                except ValueError:
+                    # Pre-1.3 entries stored the bare token string. Read it rather than making a
+                    # working login look like no login at all.
+                    return {"token": value}
+        except Exception:
+            pass
+    entry = _read_credentials().get(origin) or {}
+    return dict(entry) if isinstance(entry, dict) else {}
+
+
+def save_token(url: str, token: str, use_keyring: bool = True) -> str:
+    """Back-compat shim for the common case of storing just an API token."""
+    return save_credential(url, token=token, use_keyring=use_keyring)
+
+
+def load_token(url: str) -> Optional[str]:
+    return load_credential(url).get("token") or None
+
+
+def delete_token(url: str, kind: Optional[str] = None) -> bool:
+    """Forget stored credentials for an instance. `kind` limits it to "token" or "jwt"."""
+    origin = normalize_url(url)
+    entry = load_credential(origin)
+    if not entry:
+        return False
+    if kind:
+        if entry.pop(kind, None) is None:
+            return False
+        if any(entry.get(k) for k in ("token", "jwt")):
+            _store_credential(origin, entry)
+            return True
+        # Nothing left worth keeping — fall through and remove the instance entirely.
+
+    removed = False
+    kr = _keyring()
+    if kr is not None:
+        try:
+            if kr.get_password(KEYRING_SERVICE, origin):
+                kr.delete_password(KEYRING_SERVICE, origin)
+                removed = True
+        except Exception:
+            pass
+    creds = _read_credentials()
+    if creds.pop(origin, None) is not None:
+        _write_credentials(creds)
+        removed = True
+    return removed
+
+
+def _json_dumps(data: Dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True)
+
+
+def _read_credentials() -> Dict[str, Any]:
+    data = _read_json(credentials_path())
+    return dict(data.get("instances") or {})
+
+
+def _write_credentials(instances: Dict[str, Any]) -> None:
+    atomic_write(credentials_path(),
+                 json.dumps({"instances": instances}, indent=2, sort_keys=True) + "\n",
+                 mode=0o600, tighten_parent=True)
+
+
+# ── Resolution ───────────────────────────────────────────────────────────────────────────────────
+
+class Resolved(object):
+    """The instance + credential one command will actually use, and where each came from.
+
+    `source_*` is not decoration: "why is it talking to the wrong server" is the commonest CLI
+    support question there is, and `geodeploy profile show` answers it by printing these.
+    """
+
+    __slots__ = ("url", "token", "jwt", "profile", "source_url", "source_token", "email")
+
+    def __init__(self, url: Optional[str], token: Optional[str], profile: Optional[str],
+                 source_url: str, source_token: str, email: Optional[str] = None,
+                 jwt: Optional[str] = None):
+        self.url = url
+        self.token = token
+        #: A session JWT from `login --password`, used for the routes that refuse API tokens.
+        self.jwt = jwt
+        self.profile = profile
+        self.source_url = source_url
+        self.source_token = source_token
+        self.email = email
+
+
+def resolve(url: Optional[str] = None, token: Optional[str] = None,
+            profile: Optional[str] = None, config: Optional[Config] = None) -> Resolved:
+    """Flags → environment → active profile, for the URL and the token independently.
+
+    Independently matters: `GEODEPLOY_TOKEN=… geodeploy layers list` against the profile's URL is a
+    normal thing to do, and so is `--url` at a staging instance using the token already stored
+    for it.
+    """
+    cfg = config or Config.load()
+    name = cfg.resolve_name(profile)
+    entry = cfg.get(name) if name else None
+
+    if url:
+        final_url, src_url = normalize_url(url), "flag"
+    elif os.environ.get("GEODEPLOY_URL"):
+        final_url, src_url = normalize_url(os.environ["GEODEPLOY_URL"]), "env"
+    elif entry and entry.get("url"):
+        final_url, src_url = entry["url"], "profile:" + str(name)
+    else:
+        final_url, src_url = None, "none"
+
+    # An API TOKEN is the normal credential — scoped, revocable, and what the docs tell people to
+    # mint. A session JWT only appears when someone has run `login --password`, and is kept for the
+    # routes that refuse tokens on purpose (`/admin/*`, `/tokens`); it never displaces a token.
+    jwt = None
+    if token:
+        final_token, src_token = token, "flag"
+    elif os.environ.get("GEODEPLOY_TOKEN"):
+        final_token, src_token = os.environ["GEODEPLOY_TOKEN"], "env"
+    elif final_url:
+        stored = load_credential(final_url)
+        jwt = stored.get("jwt") or None
+        if stored.get("token"):
+            final_token, src_token = stored["token"], "stored"
+        elif jwt:
+            final_token, src_token = None, "stored session"
+        else:
+            final_token, src_token = None, "none"
+    else:
+        final_token, src_token = None, "none"
+
+    return Resolved(final_url, final_token, name, src_url, src_token,
+                    (entry or {}).get("email"), jwt)

--- a/cli/geodeploy/config.py
+++ b/cli/geodeploy/config.py
@@ -24,7 +24,7 @@ import json
 import os
 import sys
 import tempfile
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from .errors import ConfigError
 
@@ -133,6 +133,32 @@ def normalize_url(url: str) -> str:
     if not rest:
         raise ConfigError("Instance URL has no host: {0}".format(url))
     return "{0}://{1}".format(scheme, rest.rstrip("/"))
+
+
+def split_portal_url(value: str) -> Tuple[Optional[str], str]:
+    """A portal reference → `(instance URL or None, slug)`.
+
+    Accepts a bare slug (`field-sites-2026`) or the URL a person copies out of the address bar
+    (`https://gd.example.org/portals/field-sites-2026/`, with or without a trailing
+    `style.json`). The URL already names its instance, so demanding the slug be cut out of it by
+    hand — and the instance be supplied a second time — is friction with nothing behind it.
+    """
+    raw = (value or "").strip()
+    if not raw:
+        raise ConfigError("A portal is required: a slug, or the URL of a published portal.")
+    if "://" not in raw:
+        if "/portals/" not in raw:
+            return None, raw.strip("/")          # a plain slug, which is the common case
+        raw = "https://" + raw                   # `host/portals/slug` pasted without the scheme
+    head, sep, tail = raw.partition("/portals/")
+    if not sep:
+        raise ConfigError(
+            "That does not look like a portal URL: {0}\n"
+            "Expected something like https://gd.example.org/portals/<slug>/".format(value))
+    slug = tail.strip("/").split("/")[0]
+    if not slug:
+        raise ConfigError("That portal URL has no slug: {0}".format(value))
+    return normalize_url(head), slug
 
 
 # ── The config file ──────────────────────────────────────────────────────────────────────────────

--- a/cli/geodeploy/errors.py
+++ b/cli/geodeploy/errors.py
@@ -1,0 +1,93 @@
+"""Typed errors.
+
+Every failure a caller can reasonably branch on gets its own class, because the alternative — one
+exception carrying a status code — pushes `if err.status == 404` into every plugin and script that
+uses this client. The QGIS plugin in particular needs to tell "your token is wrong" (stop and ask
+the user) from "that layer is gone" (refresh the tree) from "the network blipped" (retry), and it
+should not have to read status codes to do it.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class GeoDeployError(Exception):
+    """Base class — catching this catches everything this package raises."""
+
+
+class ConfigError(GeoDeployError):
+    """Nothing usable to talk to: no instance URL, no credentials, unreadable profile file."""
+
+
+class TransportError(GeoDeployError):
+    """The request never got an HTTP answer — DNS, TLS, connection reset, timeout.
+
+    Distinct from every `APIError` below: the server may or may not have done the work, so a caller
+    retrying this must think about idempotency, which is never true of a 4xx.
+    """
+
+
+class APIError(GeoDeployError):
+    """The instance answered, with a status we did not want."""
+
+    def __init__(self, status: int, detail: str, url: str = "", payload: Any = None):
+        self.status = status
+        self.detail = detail
+        self.url = url
+        #: The decoded JSON body when there was one — FastAPI validation errors put the useful
+        #: part (which field, why) in a list here that no single-line message can carry.
+        self.payload = payload
+        super().__init__(f"HTTP {status}: {detail}" if detail else f"HTTP {status}")
+
+
+class AuthError(APIError):
+    """401 — no credentials, an expired session, or a revoked/expired API token."""
+
+
+class PermissionError_(APIError):
+    """403 — authenticated, but not allowed.
+
+    Two distinguishable causes, and the message says which: the caller's ROLE is too low, or the
+    API TOKEN lacks a scope ("Token missing scope: data:write"). The second is fixable by minting a
+    better token, the first is not — see `missing_scope`.
+    """
+
+    @property
+    def missing_scope(self) -> Optional[str]:
+        marker = "Token missing scope:"
+        if marker in (self.detail or ""):
+            return self.detail.split(marker, 1)[1].strip() or None
+        return None
+
+
+class NotFoundError(APIError):
+    """404 — including "exists but you cannot see it": a private resource is hidden as absent."""
+
+
+class ConflictError(APIError):
+    """409 — the state moved under you (a backup already running, an email already registered)."""
+
+
+class ValidationError(APIError):
+    """400 / 413 / 422 — the request itself was wrong: bad geometry columns, oversized file."""
+
+
+class ServerError(APIError):
+    """5xx — the instance failed. Worth retrying; not worth reformulating the request."""
+
+
+def from_status(status: int, detail: str, url: str = "", payload: Any = None) -> APIError:
+    """Map an HTTP status onto the class above that a caller can act on."""
+    if status == 401:
+        return AuthError(status, detail, url, payload)
+    if status == 403:
+        return PermissionError_(status, detail, url, payload)
+    if status == 404:
+        return NotFoundError(status, detail, url, payload)
+    if status == 409:
+        return ConflictError(status, detail, url, payload)
+    if status in (400, 413, 422) or status == 415:
+        return ValidationError(status, detail, url, payload)
+    if status >= 500:
+        return ServerError(status, detail, url, payload)
+    return APIError(status, detail, url, payload)

--- a/cli/geodeploy/imports.py
+++ b/cli/geodeploy/imports.py
@@ -1,0 +1,65 @@
+"""Register data that is ALREADY there — in the database, or in the bucket.
+
+"Import existing" is not an upload: nothing is copied and nothing is destroyed. A PostGIS table is
+introspected and registered; a `.parquet`/`.tif`/`.csv` already in object storage is attached where
+it lies. For GeoParquet the spatial prep writes its partitioned copy under `vectors/` and leaves the
+source key alone — which is why `source_s3_key` exists, so re-scanning still recognises the file as
+already imported after the prep repoints the layer.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .errors import ValidationError
+
+
+class Imports(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    # ── PostGIS ─────────────────────────────────────────────────────────────────────────────────
+
+    def database_tables(self) -> List[Dict[str, Any]]:
+        """Spatial tables visible to the instance, each flagged if it is already registered."""
+        return self._c.get("/data/discover/database") or []
+
+    def database(self, tables: List[Dict[str, Any]]) -> Any:
+        """Register tables. Each item needs `schema_name`, `table_name`, `geometry_column`;
+        `srid`, `geometry_type` and a `name` override are optional."""
+        if not tables:
+            raise ValidationError(400, "No tables selected.")
+        return self._c.post("/data/discover/database", {"tables": tables})
+
+    # ── Object storage ──────────────────────────────────────────────────────────────────────────
+
+    def storage_objects(self, kind: Optional[str] = None) -> List[Dict[str, Any]]:
+        """`.tif` (raster), `.parquet`/`.geoparquet` (geoparquet) and `.csv` files in the bucket."""
+        rows = self._c.get("/data/discover/storage") or []
+        if kind:
+            rows = [r for r in rows if (r.get("kind") or "") == kind]
+        return rows
+
+    def storage(self, items: List[Dict[str, Any]]) -> Any:
+        """Attach objects by key. GeoParquet items come back with `jobs` to poll (inspect + prep);
+        rasters are registered from their header alone and need no job."""
+        if not items:
+            raise ValidationError(400, "No objects selected.")
+        return self._c.post("/data/discover/storage", {"items": items})
+
+    def csv_columns(self, key: str, delimiter: str = "comma") -> Any:
+        """The header of a CSV in the bucket, so geometry columns can be chosen before importing."""
+        return self._c.get("/data/discover/storage/csv-columns",
+                           {"key": key, "delimiter": delimiter})
+
+    def csv(self, key: str, name: Optional[str] = None, x_column: Optional[str] = None,
+            y_column: Optional[str] = None, wkt_column: Optional[str] = None, srid: int = 4326,
+            delimiter: str = "comma") -> Dict[str, Any]:
+        """Build a PostGIS layer from a CSV already in storage (queued; returns a job to poll)."""
+        if not wkt_column and not (x_column and y_column):
+            raise ValidationError(400, "Pick X and Y columns, or a WKT column.")
+        body = {"key": key, "srid": srid, "delimiter": delimiter}
+        for field, value in (("name", name), ("x_column", x_column), ("y_column", y_column),
+                             ("wkt_column", wkt_column)):
+            if value is not None:
+                body[field] = value
+        return self._c.post("/data/discover/storage/csv", body)

--- a/cli/geodeploy/jobs.py
+++ b/cli/geodeploy/jobs.py
@@ -1,0 +1,73 @@
+"""Ingest jobs — status, and waiting for one to finish.
+
+Every heavy operation in GeoDeploy is queued to Celery and answers 202 with a job id: uploads,
+conversions, PMTiles tiling, CSV imports, re-processing. So "did my upload work?" is always this
+module, and a CLI that did not wait would report success for work that has not started.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Optional
+
+from .errors import GeoDeployError
+
+#: Terminal job states. `ready` and `completed` are both used by the API depending on the pipeline,
+#: and a client that knows only one of them polls forever on the other.
+DONE = ("ready", "completed", "done")
+FAILED = ("failed", "error")
+
+
+class JobFailed(GeoDeployError):
+    """A job reached a terminal FAILED state. Carries the last status payload for the message."""
+
+    def __init__(self, job: Dict[str, Any]):
+        self.job = job or {}
+        message = self.job.get("error_message") or self.job.get("current_step") or "Job failed"
+        super().__init__(message)
+
+
+class JobTimeout(GeoDeployError):
+    """`wait` gave up. The job is still running server-side — this is a client-side deadline."""
+
+    def __init__(self, job: Dict[str, Any], seconds: float):
+        self.job = job or {}
+        super().__init__("Still {0} after {1:.0f}s (job {2}). It keeps running on the server; "
+                         "check with `geodeploy jobs show`."
+                         .format(self.job.get("status") or "running", seconds,
+                                 self.job.get("id")))
+
+
+class Jobs(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    def get(self, job_id: str, layer_type: str = "vector") -> Dict[str, Any]:
+        return self._c.get("/data/{0}/jobs/{1}".format(
+            "raster" if layer_type == "raster" else "vector", job_id))
+
+    def wait(self, job_id: str, layer_type: str = "vector", interval: float = 2.0,
+             timeout: Optional[float] = 3600.0,
+             on_progress: Optional[Callable[[Dict[str, Any]], None]] = None) -> Dict[str, Any]:
+        """Poll until the job finishes. Returns the final status; raises `JobFailed` if it failed.
+
+        `on_progress` is called only when the printable state CHANGES (percentage or step), not on
+        every poll — the difference between a readable log and 600 identical lines for a long
+        conversion.
+        """
+        started = time.time()
+        last_seen = None
+        status = {}  # type: Dict[str, Any]
+        while True:
+            status = self.get(job_id, layer_type) or {}
+            marker = (status.get("progress"), status.get("current_step"), status.get("status"))
+            if on_progress and marker != last_seen:
+                on_progress(status)
+                last_seen = marker
+            state = (status.get("status") or "").lower()
+            if state in FAILED:
+                raise JobFailed(status)
+            if state in DONE:
+                return status
+            if timeout is not None and (time.time() - started) > timeout:
+                raise JobTimeout(status, time.time() - started)
+            time.sleep(interval)

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -1,10 +1,10 @@
 """Data layers — vector, raster, and the resolver that lets you name one.
 
 The API addresses a layer three ways and they are not interchangeable: authenticated routes take
-the integer **id**, public routes take the stable **uid** (`models.new_uid`, 12 hex chars — integer
-ids can be reused after a delete, so a shared URL must never use one), and a person thinks in
-**names**. `Layers.resolve` accepts all three plus a `vector-3` / `raster-7` prefix, so every
-command in the CLI can take whatever the user has to hand.
+the integer **id**, public routes take the stable **uid** (`models.new_uid`, 12 hex chars — an
+integer is unique only within one layer kind and one database, so a shared URL must never use
+one), and a person thinks in **names**. `Layers.resolve` accepts all three plus a `vector-3` /
+`raster-7` prefix, so every command in the CLI can take whatever the user has to hand.
 """
 from __future__ import annotations
 

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -125,11 +125,16 @@ class _LayerBase(object):
     def export_to_file(self, ref: Any, path: str, format: Optional[str] = None,
                        bbox: Optional[str] = None, target_crs: str = "4326",
                        interval: float = 2.0, timeout: Optional[float] = 1800.0,
-                       on_status: Optional[Any] = None) -> str:
+                       on_status: Optional[Any] = None,
+                       on_ready: Optional[Any] = None) -> str:
         """Queue, wait, download. Returns the path written (a zip: an export may be several files).
 
         Waiting is the caller's time either way — the work is a Celery job — so doing it here keeps
         the common case to one line for both a script and a plugin.
+
+        `on_ready(status)` receives the final status document, whose `truncated` list names any
+        file that stopped at the server's row cap. A caller that ignores it gets a file that looks
+        complete and is not, so the CLI does not ignore it.
         """
         import time
 
@@ -140,10 +145,13 @@ class _LayerBase(object):
             raise GeoDeployError("The instance did not return an export job id.")
         started = time.time()
         while True:
-            state = (self.export_status(ref, job_id) or {}).get("status")
+            status = self.export_status(ref, job_id) or {}
+            state = status.get("status")
             if on_status:
                 on_status(state)
             if state == "ready":
+                if on_ready:
+                    on_ready(status)
                 break
             if state in ("error", "failed"):
                 raise GeoDeployError("The export failed on the server.")
@@ -178,6 +186,75 @@ class VectorLayers(_LayerBase):
 
     def tilejson(self, ref: Any) -> Dict[str, Any]:
         return self._c.get("/data/vector/{0}/tilejson".format(ref), auth=False)
+
+    # -- the whole GeoParquet dataset, straight from storage ---------------------------------------
+
+    def parquet_manifest(self, ref: Any) -> Dict[str, Any]:
+        """The partition map of a prepared GeoParquet layer: grid, CRS, columns and file keys.
+
+        Raises `NotFoundError` when the layer has no partitioned dataset — a PostGIS layer, or a
+        single `.parquet` uploaded as-is. Callers treat that as "use the export job instead".
+        """
+        return self._c.get("/data/vector/{0}/parquet/manifest.json".format(ref), auth=False)
+
+    def parquet_parts(self, manifest: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Every partition file the manifest lists, flattened and in a stable order."""
+        parts: List[Dict[str, Any]] = []
+        for cell, entries in sorted((manifest.get("cells") or {}).items(),
+                                    key=lambda kv: (len(kv[0]), kv[0])):
+            for entry in entries or []:
+                key = entry.get("key")
+                if not key:
+                    continue
+                if key.startswith("/") or ".." in key.split("/") or ":" in key:
+                    # The key becomes a local path. The server is not hostile, but a path from
+                    # over the network must not be able to name a file outside the target folder.
+                    raise ValidationError(400, "Refusing a suspicious partition key: {0!r}".format(key))
+                parts.append({"cell": cell, "key": key, "rows": entry.get("rows")})
+        return parts
+
+    def download_dataset(self, ref: Any, directory: str,
+                         on_file: Optional[Any] = None) -> Dict[str, Any]:
+        """Download a prepared GeoParquet layer WHOLE — manifest plus every partition file.
+
+        This is the complete, lossless, **uncapped** copy: the files are what the instance stores,
+        byte for byte, with no worker, no row limit and no format conversion. `layers export` is
+        the other path, and the one to use for a clip or another format; it builds a new file and
+        stops at the server's row cap, which for exactly these layers (the big ones — GeoParquet is
+        where the millions of features live) is a real ceiling.
+
+        The result reads directly in DuckDB or GDAL:
+
+            SELECT * FROM read_parquet('<directory>/**/*.parquet')
+        """
+        import json as _json
+        import os
+
+        manifest = self.parquet_manifest(ref)
+        parts = self.parquet_parts(manifest)
+        if not parts:
+            raise NotFoundError(404, "That GeoParquet dataset lists no partition files.")
+
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, "manifest.json"), "w", encoding="utf-8") as fh:
+            _json.dump(manifest, fh, indent=1)
+
+        written, done_bytes = [], 0
+        for index, part in enumerate(parts):
+            dest = os.path.join(directory, *part["key"].split("/"))
+            parent = os.path.dirname(dest)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(dest, "wb") as fh:
+                self._c.download("/data/vector/{0}/parquet/{1}".format(ref, part["key"]),
+                                 fh, auth=False)
+            written.append(dest)
+            done_bytes += os.path.getsize(dest)
+            if on_file:                       # (files done, files total, this part, bytes so far)
+                on_file(index + 1, len(parts), part, done_bytes)
+        return {"directory": directory, "files": written, "parts": len(written),
+                "bytes": done_bytes, "rows": manifest.get("feature_count"),
+                "crs": manifest.get("crs")}
 
     def field_stats(self, ref: Any, field: str, classes: int = 5, method: str = "quantile",
                     ramp: str = "viridis") -> Dict[str, Any]:
@@ -258,9 +335,21 @@ class Layers(object):
                     break
         rows = self.list(kind)
 
-        for row in rows:                                   # id or uid
-            if str(row.get("id")) == text or str(row.get("uid") or "") == text:
-                return row
+        by_uid = [r for r in rows if str(r.get("uid") or "") == text]
+        if by_uid:
+            return by_uid[0]                               # uids are unique across both kinds
+        by_id = [r for r in rows if str(r.get("id")) == text]
+        if len(by_id) == 1:
+            return by_id[0]
+        if len(by_id) > 1:
+            # Vector and raster ids are two separate sequences, so "1" can be two different
+            # layers. Returning whichever the listing happened to put first is how you download a
+            # vector while asking for a raster.
+            raise ValidationError(
+                400, "Layer id {0} is ambiguous — vector and raster layers are numbered "
+                     "separately. Use {1}, or the layer's uid.".format(
+                         text, " or ".join(sorted(
+                             "{0}-{1}".format(r.get("layer_type"), r.get("id")) for r in by_id))))
         exact = [r for r in rows if (r.get("name") or "") == text]
         if len(exact) == 1:
             return exact[0]

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -1,0 +1,239 @@
+"""Data layers — vector, raster, and the resolver that lets you name one.
+
+The API addresses a layer three ways and they are not interchangeable: authenticated routes take
+the integer **id**, public routes take the stable **uid** (`models.new_uid`, 12 hex chars — integer
+ids can be reused after a delete, so a shared URL must never use one), and a person thinks in
+**names**. `Layers.resolve` accepts all three plus a `vector-3` / `raster-7` prefix, so every
+command in the CLI can take whatever the user has to hand.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .errors import NotFoundError, ValidationError
+
+#: Layer fields worth showing in a list, in the order a table should print them.
+SUMMARY_FIELDS = ("id", "uid", "name", "status", "geometry_type", "feature_count",
+                  "crs", "storage_backend", "visibility", "created_by")
+
+
+class _LayerBase(object):
+    """Shared implementation for the two layer kinds — the routes are deliberately parallel."""
+
+    kind = ""      # "vector" | "raster"
+    base = ""      # "/data/vector" | "/data/raster"
+
+    def __init__(self, client: Any):
+        self._c = client
+
+    # -- read ------------------------------------------------------------------------------------
+
+    def list(self, status: Optional[str] = None, query: Optional[str] = None,
+             visibility: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Every layer of this kind that the caller can see.
+
+        Filtering is client-side because the API has no filter params on the list endpoints (and
+        `routers/README.md` explicitly asks that no `?created_by=` be added). At the scale a list
+        endpoint is still un-paginated, filtering here is honest and instant.
+        """
+        rows = self._c.get(self.base) or []
+        if status:
+            rows = [r for r in rows if (r.get("status") or "") == status]
+        if visibility:
+            rows = [r for r in rows if (r.get("visibility") or "") == visibility]
+        if query:
+            needle = query.lower()
+            rows = [r for r in rows
+                    if needle in (r.get("name") or "").lower()
+                    or needle in (r.get("abstract") or "").lower()
+                    or needle in (r.get("keywords") or "").lower()]
+        return rows
+
+    def get(self, layer_id: Any) -> Dict[str, Any]:
+        """One layer. There is no by-id authed GET, so this reads the list — the same data the
+        dashboard shows, including live `progress`/`current_step` for a layer still ingesting."""
+        wanted = str(layer_id)
+        for row in self.list():
+            if str(row.get("id")) == wanted or str(row.get("uid") or "") == wanted:
+                return row
+        raise NotFoundError(404, "No {0} layer {1}.".format(self.kind, layer_id))
+
+    def usage(self, layer_id: Any) -> List[Dict[str, Any]]:
+        """The portals that include this layer — what the UI shows before a delete."""
+        return self._c.get("{0}/{1}/usage".format(self.base, int(layer_id))) or []
+
+    def links(self, layer_id: Any) -> Dict[str, Any]:
+        """Tool-labelled share URLs (OGC API - Features, WMTS, TileJSON, PMTiles, COG, …).
+
+        The server decides which artifact suits which backend, so this is always current — the CLI
+        must not build these URLs itself.
+        """
+        return self._c.get("{0}/{1}/links".format(self.base, int(layer_id)))
+
+    # -- write -----------------------------------------------------------------------------------
+
+    def rename(self, layer_id: Any, name: str) -> Dict[str, Any]:
+        return self._c.put("{0}/{1}/rename".format(self.base, int(layer_id)), {"name": name})
+
+    def share(self, layer_id: Any, visibility: Optional[str] = None, abstract: Optional[str] = None,
+              license: Optional[str] = None, attribution: Optional[str] = None,
+              keywords: Optional[str] = None) -> Dict[str, Any]:
+        """Visibility + catalog metadata. Partial: only what you pass is applied.
+
+        `visibility="public"` is the opt-IN that puts a layer in the STAC catalog and OGC API -
+        Features collections and makes its raw asset readable — nothing is public by default.
+        """
+        body = {}
+        for key, value in (("visibility", visibility), ("abstract", abstract), ("license", license),
+                           ("attribution", attribution), ("keywords", keywords)):
+            if value is not None:
+                body[key] = value
+        if not body:
+            raise ValidationError(400, "Nothing to change — pass a visibility or a metadata field.")
+        return self._c.put("{0}/{1}/sharing".format(self.base, int(layer_id)), body)
+
+    def set_default_style(self, layer_id: Any, style: Dict[str, Any]) -> Dict[str, Any]:
+        """The layer's own default styling — what a portal starts from when the layer is added."""
+        return self._c.put("{0}/{1}/default-style".format(self.base, int(layer_id)), style)
+
+    def delete(self, layer_id: Any) -> Any:
+        """Delete the layer AND prune it from every portal that used it (the API re-publishes the
+        published ones, so no ghost layer is left on a live map)."""
+        return self._c.delete("{0}/{1}".format(self.base, int(layer_id)))
+
+
+class VectorLayers(_LayerBase):
+    kind = "vector"
+    base = "/data/vector"
+
+    def features(self, ref: Any, bbox: Optional[str] = None, limit: int = 50000,
+                 public: bool = False) -> Dict[str, Any]:
+        """GeoJSON for a viewport. `public=True` uses the unauthenticated `.geojson` route (which
+        takes a uid) — useful for checking what a published portal actually serves."""
+        params = {"bbox": bbox, "limit": limit}
+        if public:
+            return self._c.get("/data/vector/{0}/features.geojson".format(ref), params, auth=False)
+        return self._c.get("/data/vector/{0}/features".format(int(ref)), params)
+
+    def identify(self, ref: Any, lng: float, lat: float, tol: float = 1e-4,
+                 limit: int = 10) -> Any:
+        """Attributes of the features under a point — the same call a portal popup makes."""
+        return self._c.get("/data/vector/{0}/identify".format(ref),
+                           {"lng": lng, "lat": lat, "tol": tol, "limit": limit}, auth=False)
+
+    def tilejson(self, ref: Any) -> Dict[str, Any]:
+        return self._c.get("/data/vector/{0}/tilejson".format(ref), auth=False)
+
+    def field_stats(self, ref: Any, field: str, classes: int = 5, method: str = "quantile",
+                    ramp: str = "viridis") -> Dict[str, Any]:
+        """Distribution of ONE attribute plus a ready-made classification `suggestion`.
+
+        The classification maths lives on the server (`services/symbology.py`) and is shared with
+        the editor and the published portal. The CLI asks for the suggestion rather than computing
+        breaks itself, so a CLI-styled layer lands in exactly the classes the editor would show —
+        two implementations of quantile breaks would eventually disagree, and the disagreement
+        would only be visible on a published map.
+        """
+        return self._c.get("/data/vector/{0}/field-stats".format(ref),
+                           {"field": field, "classes": classes, "method": method, "ramp": ramp})
+
+    def tile(self, layer_id: Any) -> Dict[str, Any]:
+        """(Re)generate the layer's PMTiles archive — the fallback display path for heavy layers."""
+        return self._c.post("/data/vector/{0}/tile".format(int(layer_id)))
+
+    def prepare(self, layer_id: Any) -> Dict[str, Any]:
+        """Re-run the GeoParquet spatial prep (partitioning + covering column)."""
+        return self._c.post("/data/vector/{0}/prepare".format(int(layer_id)))
+
+    def reprocess(self, layer_id: Any) -> Dict[str, Any]:
+        """Restart a stalled/failed layer's background processing without re-uploading it.
+
+        The usual cause is the worker being recreated mid-convert, which leaves the layer stuck at
+        whatever percentage it had reached.
+        """
+        return self._c.post("/data/vector/{0}/reprocess".format(int(layer_id)))
+
+
+class RasterLayers(_LayerBase):
+    kind = "raster"
+    base = "/data/raster"
+
+    def stats(self, layer_id: Any) -> Dict[str, Any]:
+        """TiTiler statistics plus a suggested 2–98 % `rescale` — the auto-stretch the UI offers."""
+        return self._c.get("/data/raster/{0}/stats".format(int(layer_id)))
+
+    def colormaps(self) -> List[str]:
+        return self._c.get("/data/raster/colormaps")
+
+    def tilejson(self, ref: Any) -> Dict[str, Any]:
+        return self._c.get("/data/raster/{0}/tilejson".format(ref), auth=False)
+
+    def wmts(self, ref: Any) -> str:
+        """The WMTS capabilities document — the URL to paste into QGIS, because it is the only one
+        of our raster surfaces that carries an extent, so *Zoom to Layer* works."""
+        return self._c.get("/data/raster/{0}/wmts".format(ref), auth=False, parse=False).text
+
+
+class Layers(object):
+    """Kind-agnostic helpers: resolve a reference, list both kinds, delete whatever it is."""
+
+    def __init__(self, client: Any):
+        self._c = client
+
+    def list(self, kind: Optional[str] = None, **kw: Any) -> List[Dict[str, Any]]:
+        out = []  # type: List[Dict[str, Any]]
+        if kind in (None, "all", "vector"):
+            out += [dict(r, layer_type="vector") for r in self._c.vector.list(**kw)]
+        if kind in (None, "all", "raster"):
+            out += [dict(r, layer_type="raster") for r in self._c.raster.list(**kw)]
+        return out
+
+    def resolve(self, ref: Any, kind: Optional[str] = None) -> Dict[str, Any]:
+        """Find a layer from an id, a uid, a `vector-3` style reference, or a name.
+
+        Name matching is exact first, then case-insensitively, then as a unique substring. An
+        ambiguous name raises rather than guessing — picking one of two layers called "roads" and
+        publishing it is not a mistake the user can see.
+        """
+        text = str(ref).strip()
+        if kind is None:
+            for prefix in ("vector-", "raster-"):
+                if text.lower().startswith(prefix):
+                    kind, text = prefix[:-1], text[len(prefix):]
+                    break
+        rows = self.list(kind)
+
+        for row in rows:                                   # id or uid
+            if str(row.get("id")) == text or str(row.get("uid") or "") == text:
+                return row
+        exact = [r for r in rows if (r.get("name") or "") == text]
+        if len(exact) == 1:
+            return exact[0]
+        ci = [r for r in rows if (r.get("name") or "").lower() == text.lower()]
+        if len(ci) == 1:
+            return ci[0]
+        partial = [r for r in rows if text.lower() in (r.get("name") or "").lower()]
+        if len(partial) == 1:
+            return partial[0]
+
+        candidates = exact or ci or partial
+        if len(candidates) > 1:
+            names = ", ".join("{0} (id {1}, {2})".format(r.get("name"), r.get("id"),
+                                                         r.get("layer_type"))
+                              for r in candidates[:8])
+            raise ValidationError(400, "{0!r} matches several layers: {1}. Use the id.".format(
+                ref, names))
+        raise NotFoundError(404, "No layer matching {0!r}.".format(ref))
+
+    def api(self, layer_type: str):
+        """The namespace for a layer kind — lets kind-agnostic code stay short."""
+        if layer_type == "raster":
+            return self._c.raster
+        if layer_type == "vector":
+            return self._c.vector
+        raise ValidationError(400, "Unknown layer type {0!r}.".format(layer_type))
+
+    def delete(self, ref: Any, kind: Optional[str] = None) -> Dict[str, Any]:
+        layer = self.resolve(ref, kind)
+        self.api(layer["layer_type"]).delete(layer["id"])
+        return layer

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -101,6 +101,61 @@ class _LayerBase(object):
         published ones, so no ghost layer is left on a live map)."""
         return self._c.delete("{0}/{1}".format(self.base, int(layer_id)))
 
+    # -- download --------------------------------------------------------------------------------
+
+    def export(self, ref: Any, format: Optional[str] = None, bbox: Optional[str] = None,
+               target_crs: str = "4326") -> Dict[str, Any]:
+        """Queue a file export of this layer. No bbox = the whole layer.
+
+        Public on the same terms as the layer's other artifacts, so this works with no token for a
+        shared layer — which is the point: it is how an outside client downloads a PostGIS layer,
+        the one backend that has no file to fetch directly.
+        """
+        body = {"format": format, "bbox": bbox, "target_crs": target_crs}
+        return self._c.post("{0}/{1}/export".format(self.base, ref),
+                            {k: v for k, v in body.items() if v is not None}, auth=False)
+
+    def export_status(self, ref: Any, job_id: str) -> Dict[str, Any]:
+        return self._c.get("{0}/{1}/export-status/{2}".format(self.base, ref, job_id), auth=False)
+
+    def export_download(self, ref: Any, job_id: str, sink) -> Any:
+        return self._c.download("{0}/{1}/export-download/{2}".format(self.base, ref, job_id),
+                                sink, auth=False)
+
+    def export_to_file(self, ref: Any, path: str, format: Optional[str] = None,
+                       bbox: Optional[str] = None, target_crs: str = "4326",
+                       interval: float = 2.0, timeout: Optional[float] = 1800.0,
+                       on_status: Optional[Any] = None) -> str:
+        """Queue, wait, download. Returns the path written (a zip: an export may be several files).
+
+        Waiting is the caller's time either way — the work is a Celery job — so doing it here keeps
+        the common case to one line for both a script and a plugin.
+        """
+        import time
+
+        from .errors import GeoDeployError
+
+        job_id = (self.export(ref, format, bbox, target_crs) or {}).get("job_id")
+        if not job_id:
+            raise GeoDeployError("The instance did not return an export job id.")
+        started = time.time()
+        while True:
+            state = (self.export_status(ref, job_id) or {}).get("status")
+            if on_status:
+                on_status(state)
+            if state == "ready":
+                break
+            if state in ("error", "failed"):
+                raise GeoDeployError("The export failed on the server.")
+            if timeout is not None and time.time() - started > timeout:
+                raise GeoDeployError(
+                    "The export is still running after {0:.0f}s. It continues on the server; "
+                    "poll export_status(job_id={1!r}).".format(time.time() - started, job_id))
+            time.sleep(interval)
+        with open(path, "wb") as fh:
+            self.export_download(ref, job_id, fh)
+        return path
+
 
 class VectorLayers(_LayerBase):
     kind = "vector"
@@ -224,6 +279,38 @@ class Layers(object):
             raise ValidationError(400, "{0!r} matches several layers: {1}. Use the id.".format(
                 ref, names))
         raise NotFoundError(404, "No layer matching {0!r}.".format(ref))
+
+    def resolve_public(self, ref: Any, kind: Optional[str] = None) -> Dict[str, Any]:
+        """Resolve a layer WITHOUT a credential, from the instance's public index.
+
+        Without this, an anonymous client could only ever address a layer by its opaque uid — but
+        the public artifacts are readable by anyone, so "download the layer called roads" should
+        work for anyone too. Only public layers are visible here, which is the correct limit.
+        """
+        text = str(ref).strip()
+        index = self._c.catalog.public() or {}
+        rows = []
+        for group, entries in (index.get("layers") or {}).items():
+            layer_type = "raster" if group == "raster" else "vector"
+            if kind and kind != layer_type:
+                continue
+            for entry in entries:
+                rows.append(dict(entry, layer_type=layer_type, uid=entry.get("id")))
+
+        for row in rows:
+            if str(row.get("id")) == text:
+                return row
+        matches = [r for r in rows if (r.get("name") or "").lower() == text.lower()]
+        if len(matches) == 1:
+            return matches[0]
+        partial = [r for r in rows if text.lower() in (r.get("name") or "").lower()]
+        if len(partial) == 1:
+            return partial[0]
+        if len(matches or partial) > 1:
+            raise ValidationError(400, "{0!r} matches several public layers; use the id.".format(ref))
+        raise NotFoundError(
+            404, "No PUBLIC layer matching {0!r}. Only shared layers are visible without a "
+                 "token — log in to reach the rest.".format(ref))
 
     def api(self, layer_type: str):
         """The namespace for a layer kind — lets kind-agnostic code stay short."""

--- a/cli/geodeploy/portals.py
+++ b/cli/geodeploy/portals.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, List, Optional
 
+from .config import split_portal_url
 from .errors import NotFoundError, ValidationError
 
 ACCESS_TYPES = ("public", "password", "organization", "owner")
@@ -42,8 +43,15 @@ class Portals(object):
         return rows
 
     def get(self, ref: Any) -> Dict[str, Any]:
-        """A portal by id, or by slug/title — the CLI should not force people to look up ids."""
+        """A portal by id, slug, title, or its published URL — the CLI should not force people to
+        look up ids, nor to edit a URL they just copied out of the address bar."""
         text = str(ref).strip()
+        if "/portals/" in text:
+            origin, text = split_portal_url(text)
+            if origin and origin != self._c.url:
+                raise ValidationError(
+                    400, "That portal is on {0}, but this command is talking to {1}.".format(
+                        origin, self._c.url))
         if text.isdigit():
             return self._c.get("/portals/{0}".format(int(text)))
         rows = self.list()

--- a/cli/geodeploy/portals.py
+++ b/cli/geodeploy/portals.py
@@ -1,0 +1,272 @@
+"""Portals — create, arrange layers, style them, publish.
+
+The editing model is the one the dashboard uses and the one the plugins are written against:
+
+    GET /api/portals/{id}  →  mutate `layer_configs`  →  PUT /api/portals/{id}  →  POST …/publish
+
+Two conventions are load-bearing and easy to get wrong:
+
+* **`layer_configs[0]` is the TOP of the layer list and draws on top.** Adding a layer therefore
+  prepends by default, matching what "add a layer" does in the editor.
+* **A draft edit changes nothing that is live.** Publishing re-bakes the static bundle; until then
+  the published portal serves its previous state. Every mutating method here says so in the message
+  the CLI prints, because "I changed it and nothing happened" is otherwise the first support
+  question.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from .errors import NotFoundError, ValidationError
+
+ACCESS_TYPES = ("public", "password", "organization", "owner")
+ARCHETYPES = ("webmap", "storymap", "catalog")
+
+
+class Portals(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    # ── read ────────────────────────────────────────────────────────────────────────────────────
+
+    def list(self, published: Optional[bool] = None,
+             query: Optional[str] = None) -> List[Dict[str, Any]]:
+        rows = self._c.get("/portals") or []
+        if published is not None:
+            rows = [r for r in rows if bool(r.get("published")) is published]
+        if query:
+            needle = query.lower()
+            rows = [r for r in rows if needle in (r.get("title") or "").lower()
+                    or needle in (r.get("slug") or "").lower()]
+        return rows
+
+    def get(self, ref: Any) -> Dict[str, Any]:
+        """A portal by id, or by slug/title — the CLI should not force people to look up ids."""
+        text = str(ref).strip()
+        if text.isdigit():
+            return self._c.get("/portals/{0}".format(int(text)))
+        rows = self.list()
+        for row in rows:
+            if (row.get("slug") or "") == text:
+                return self._c.get("/portals/{0}".format(row["id"]))
+        matches = [r for r in rows if (r.get("title") or "").lower() == text.lower()]
+        if len(matches) == 1:
+            return self._c.get("/portals/{0}".format(matches[0]["id"]))
+        if len(matches) > 1:
+            raise ValidationError(400, "Several portals are called {0!r}; use the id.".format(ref))
+        partial = [r for r in rows if text.lower() in (r.get("title") or "").lower()]
+        if len(partial) == 1:
+            return self._c.get("/portals/{0}".format(partial[0]["id"]))
+        raise NotFoundError(404, "No portal matching {0!r}.".format(ref))
+
+    def url(self, portal: Dict[str, Any]) -> str:
+        """The public URL of a portal's published bundle (valid once it has been published)."""
+        return "{0}/portals/{1}/".format(self._c.url, portal.get("slug"))
+
+    # ── write ───────────────────────────────────────────────────────────────────────────────────
+
+    def create(self, title: str, description: Optional[str] = None, template_id: str = "minimal",
+               access_type: str = "public", access_password: Optional[str] = None,
+               archetype: Optional[str] = None, layer_configs: Optional[List[Dict]] = None,
+               theme: Optional[Dict] = None, layout_config: Optional[Dict] = None,
+               story: Optional[Dict] = None) -> Dict[str, Any]:
+        _check_access(access_type, access_password)
+        body = {"title": title, "template_id": template_id, "access_type": access_type,
+                "layer_configs": layer_configs or []}
+        if description is not None:
+            body["description"] = description
+        if access_password:
+            body["access_password"] = access_password
+        if theme:
+            body["theme"] = theme
+        if story:
+            body["story"] = story
+        if layout_config or archetype:
+            merged = dict(layout_config or {})
+            if archetype:
+                if archetype not in ARCHETYPES:
+                    raise ValidationError(400, "Experience must be one of {0}.".format(
+                        ", ".join(ARCHETYPES)))
+                merged["archetype"] = archetype
+            body["layout_config"] = merged
+        return self._c.post("/portals", body)
+
+    def update(self, portal_id: Any, **fields: Any) -> Dict[str, Any]:
+        """PUT the fields given. Anything omitted is left exactly as it was."""
+        body = {k: v for k, v in fields.items() if v is not None}
+        if not body:
+            raise ValidationError(400, "Nothing to change.")
+        if "access_type" in body:
+            _check_access(body["access_type"], body.get("access_password"))
+        return self._c.put("/portals/{0}".format(int(portal_id)), body)
+
+    def set_config(self, portal_id: Any, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Push a whole portal document back (the `portal-get` → edit → `portal-set` round trip).
+
+        Read-only and server-owned fields are dropped rather than sent and rejected: `slug` is
+        derived from the title, and `id`/`published`/timestamps are not settable.
+        """
+        return self._c.put("/portals/{0}".format(int(portal_id)), editable_config(config))
+
+    def delete(self, portal_id: Any) -> Any:
+        return self._c.delete("/portals/{0}".format(int(portal_id)))
+
+    def publish(self, portal_id: Any) -> Dict[str, Any]:
+        return self._c.post("/portals/{0}/publish".format(int(portal_id)))
+
+    def unpublish(self, portal_id: Any) -> Dict[str, Any]:
+        return self._c.post("/portals/{0}/unpublish".format(int(portal_id)))
+
+    def upload_asset(self, portal_id: Any, path: str) -> Dict[str, Any]:
+        """A logo or an About-page image. SVG is accepted and served with a strict CSP."""
+        from .transport import MultipartBody
+        body = MultipartBody(file_path=path, filename=os.path.basename(path))
+        return self._c.request("POST", "/portals/{0}/assets".format(int(portal_id)),
+                               body=body, content_type=body.content_type,
+                               timeout=self._c.upload_timeout)
+
+    # ── layers on a portal ──────────────────────────────────────────────────────────────────────
+
+    def layers(self, portal: Any) -> List[Dict[str, Any]]:
+        """The portal's layer configs, top of the list first."""
+        doc = portal if isinstance(portal, dict) else self.get(portal)
+        return list(doc.get("layer_configs") or [])
+
+    def add_layer(self, portal_id: Any, layer_id: int, layer_type: str, style: Optional[Dict] = None,
+                  visible: bool = True, opacity: float = 1.0, popup_fields: Optional[List[str]] = None,
+                  bottom: bool = False, replace: bool = False) -> Dict[str, Any]:
+        """Add a layer to a portal. Prepends, because index 0 is the top of the list.
+
+        `replace=True` updates the entry when the layer is already there instead of refusing —
+        which is what a script re-running its own setup wants.
+        """
+        doc = self._c.get("/portals/{0}".format(int(portal_id)))
+        configs = list(doc.get("layer_configs") or [])
+        entry = {"layer_id": int(layer_id), "layer_type": layer_type, "visible": visible,
+                 "opacity": opacity, "style": dict(style or {}),
+                 "popup_fields": list(popup_fields or [])}
+        existing = _find_config(configs, layer_id, layer_type)
+        if existing is not None:
+            if not replace:
+                raise ValidationError(400, "Layer {0} ({1}) is already on this portal.".format(
+                    layer_id, layer_type))
+            configs[existing] = entry
+        elif bottom:
+            configs.append(entry)
+        else:
+            configs.insert(0, entry)
+        return self._c.put("/portals/{0}".format(int(portal_id)), {"layer_configs": configs})
+
+    def remove_layer(self, portal_id: Any, layer_id: int,
+                     layer_type: Optional[str] = None) -> Dict[str, Any]:
+        doc = self._c.get("/portals/{0}".format(int(portal_id)))
+        configs = list(doc.get("layer_configs") or [])
+        kept = [c for c in configs
+                if not (int(c.get("layer_id", -1)) == int(layer_id)
+                        and (layer_type is None or c.get("layer_type") == layer_type))]
+        if len(kept) == len(configs):
+            raise NotFoundError(404, "Layer {0} is not on portal {1}.".format(layer_id, portal_id))
+        return self._c.put("/portals/{0}".format(int(portal_id)), {"layer_configs": kept})
+
+    def set_layer_style(self, portal_id: Any, layer_id: int, style: Dict[str, Any],
+                        layer_type: Optional[str] = None, merge: bool = True,
+                        visible: Optional[bool] = None, opacity: Optional[float] = None,
+                        popup_fields: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Restyle one layer on one portal, keeping everything else about the entry."""
+        doc = self._c.get("/portals/{0}".format(int(portal_id)))
+        configs = list(doc.get("layer_configs") or [])
+        index = _find_config(configs, layer_id, layer_type)
+        if index is None:
+            raise NotFoundError(404, "Layer {0} is not on portal {1}.".format(layer_id, portal_id))
+        entry = dict(configs[index])
+        entry["style"] = dict(entry.get("style") or {}, **style) if merge else dict(style)
+        if visible is not None:
+            entry["visible"] = visible
+        if opacity is not None:
+            entry["opacity"] = opacity
+        if popup_fields is not None:
+            entry["popup_fields"] = list(popup_fields)
+        configs[index] = entry
+        return self._c.put("/portals/{0}".format(int(portal_id)), {"layer_configs": configs})
+
+    def move_layer(self, portal_id: Any, layer_id: int, position: Any,
+                   layer_type: Optional[str] = None) -> Dict[str, Any]:
+        """Reorder: `position` is `top`, `bottom`, `up`, `down`, or a 0-based index (0 = top)."""
+        doc = self._c.get("/portals/{0}".format(int(portal_id)))
+        configs = list(doc.get("layer_configs") or [])
+        index = _find_config(configs, layer_id, layer_type)
+        if index is None:
+            raise NotFoundError(404, "Layer {0} is not on portal {1}.".format(layer_id, portal_id))
+        entry = configs.pop(index)
+        if position == "top":
+            target = 0
+        elif position == "bottom":
+            target = len(configs)
+        elif position == "up":
+            target = max(0, index - 1)
+        elif position == "down":
+            target = min(len(configs), index + 1)
+        else:
+            try:
+                target = max(0, min(int(position), len(configs)))
+            except (TypeError, ValueError):
+                raise ValidationError(400, "Position must be top, bottom, up, down or an index.")
+        configs.insert(target, entry)
+        return self._c.put("/portals/{0}".format(int(portal_id)), {"layer_configs": configs})
+
+    # ── folders (V-13 layer groups) ─────────────────────────────────────────────────────────────
+
+    def groups(self, portal: Any) -> Optional[List[Dict[str, Any]]]:
+        doc = portal if isinstance(portal, dict) else self.get(portal)
+        return doc.get("layer_groups")
+
+    def set_groups(self, portal_id: Any, groups: Optional[List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """Replace the folder tree. `None` is not "clear" for the API (it means leave alone), so
+        clearing is an explicit empty list."""
+        return self._c.put("/portals/{0}".format(int(portal_id)),
+                           {"layer_groups": [] if groups is None else groups})
+
+    # ── export (draw-a-box download, the public route) ──────────────────────────────────────────
+
+    def export_bundle(self, slug: str, bbox: str, items: List[Dict[str, Any]],
+                      target_crs: str = "4326") -> Dict[str, Any]:
+        """Queue a clipped export of portal layers. Public endpoint — no auth needed."""
+        return self._c.post("/portals/{0}/export-bundle".format(slug),
+                            {"bbox": bbox, "items": items, "target_crs": target_crs}, auth=False)
+
+    def export_status(self, slug: str, job_id: str) -> Dict[str, Any]:
+        return self._c.get("/portals/{0}/export-status/{1}".format(slug, job_id), auth=False)
+
+    def export_download(self, slug: str, job_id: str, sink) -> Any:
+        return self._c.download("/portals/{0}/export-download/{1}".format(slug, job_id), sink,
+                                auth=False)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────────────────────────
+
+#: Fields `PUT /portals/{id}` accepts. Anything else in a saved document is server-owned; sending
+#: it back is at best ignored and at worst a 422, so the round trip filters rather than hopes.
+EDITABLE_FIELDS = ("title", "description", "template_id", "layer_configs", "layer_groups",
+                   "layout_config", "story", "theme", "initial_view", "access_type",
+                   "access_password", "basemap")
+
+
+def editable_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: v for k, v in (config or {}).items() if k in EDITABLE_FIELDS}
+
+
+def _find_config(configs: List[Dict[str, Any]], layer_id: Any,
+                 layer_type: Optional[str]) -> Optional[int]:
+    for index, entry in enumerate(configs):
+        if int(entry.get("layer_id", -1)) == int(layer_id) and (
+                layer_type is None or entry.get("layer_type") == layer_type):
+            return index
+    return None
+
+
+def _check_access(access_type: str, password: Optional[str]) -> None:
+    if access_type not in ACCESS_TYPES:
+        raise ValidationError(400, "Access must be one of {0}.".format(", ".join(ACCESS_TYPES)))
+    if access_type == "password" and not password:
+        raise ValidationError(400, "A password-protected portal needs --password.")

--- a/cli/geodeploy/sources.py
+++ b/cli/geodeploy/sources.py
@@ -1,0 +1,70 @@
+"""External sources — WMS / XYZ rasters and WFS vectors shown in a portal without ingesting them.
+
+A source is a reference, not a copy: nothing is downloaded, and the published portal fetches from
+the provider (raster) or through GeoDeploy's same-origin GeoJSON proxy (WFS, so an unauthenticated
+portal is not blocked by the provider's CORS policy).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .errors import NotFoundError, ValidationError
+
+SOURCE_TYPES = ("xyz", "wms", "wfs")
+
+
+class Sources(object):
+    def __init__(self, client: Any):
+        self._c = client
+
+    def list(self, query: Optional[str] = None) -> List[Dict[str, Any]]:
+        rows = self._c.get("/data/sources") or []
+        if query:
+            needle = query.lower()
+            rows = [r for r in rows if needle in (r.get("name") or "").lower()
+                    or needle in (r.get("url") or "").lower()]
+        return rows
+
+    def get(self, ref: Any) -> Dict[str, Any]:
+        text = str(ref)
+        for row in self.list():
+            if str(row.get("id")) == text or (row.get("name") or "") == text:
+                return row
+        raise NotFoundError(404, "No external source matching {0!r}.".format(ref))
+
+    def create(self, name: str, source_type: str, url: str, layer_name: Optional[str] = None,
+               version: Optional[str] = None, image_format: Optional[str] = None,
+               attribution: Optional[str] = None) -> Dict[str, Any]:
+        """Register a source. A WFS is probed on creation, which is where a wrong `typeName` or an
+        unreachable host surfaces — better here than as an empty layer on a published map."""
+        if source_type not in SOURCE_TYPES:
+            raise ValidationError(400, "Source type must be one of {0}.".format(
+                ", ".join(SOURCE_TYPES)))
+        if source_type in ("wms", "wfs") and not layer_name:
+            raise ValidationError(
+                400, "A {0} source needs --layer-name (the WMS `layers` / WFS `typeName`)."
+                     .format(source_type.upper()))
+        body = {"name": name, "source_type": source_type, "url": url}
+        for key, value in (("layer_name", layer_name), ("version", version),
+                           ("image_format", image_format), ("attribution", attribution)):
+            if value is not None:
+                body[key] = value
+        return self._c.post("/data/sources", body)
+
+    def usage(self, source_id: Any) -> List[Dict[str, Any]]:
+        return self._c.get("/data/sources/{0}/usage".format(int(source_id))) or []
+
+    def share(self, source_id: Any, visibility: str) -> Dict[str, Any]:
+        """private | organization. There is no public tier: a source has no asset of ours to
+        expose, so "public" would mean nothing."""
+        if visibility not in ("private", "organization"):
+            raise ValidationError(400, "External sources are private or organization only.")
+        return self._c.put("/data/sources/{0}/sharing".format(int(source_id)),
+                           {"visibility": visibility})
+
+    def features(self, source_id: Any) -> Dict[str, Any]:
+        """The WFS proxied to GeoJSON — the same feed a published portal reads."""
+        return self._c.get("/data/sources/{0}/features.geojson".format(int(source_id)), auth=False)
+
+    def delete(self, source_id: Any) -> Any:
+        return self._c.delete("/data/sources/{0}".format(int(source_id)))

--- a/cli/geodeploy/styles.py
+++ b/cli/geodeploy/styles.py
@@ -1,0 +1,271 @@
+"""Symbology — the style dict a layer config carries, built from plain arguments.
+
+The vocabulary is `api/geodeploy/services/symbology.py`'s, exactly: single-symbol keys (`color`,
+`fill_opacity`, `outline_color`, `line_width`, `radius`, `marker`, `lineType`) plus the v1.1
+data-driven ones (`color_mode`/`color_field`/`classes`/`categories`/`other_color`,
+`size_mode`/`size_field`/`size_stops`, `extrusion`). This module only ASSEMBLES that dict.
+
+**The classification maths is not reimplemented here, on purpose.** Breaks come from
+`GET /data/vector/{ref}/field-stats`, which computes them with the same module the editor preview
+and the published portal use. A second quantile implementation in the client would eventually
+disagree with the server's, and the disagreement would first be visible as a published map whose
+legend does not match its colours — the exact failure `services/symbology.py` was extracted to
+prevent.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .errors import ValidationError
+
+#: Named ramps the server knows (`symbology.RAMPS`). Listed so the CLI can reject a typo up front
+#: instead of silently falling back to viridis on the server.
+RAMPS = ("viridis", "magma", "blues", "reds", "greens", "oranges", "rdbu", "brbg", "spectral")
+
+MARKERS = ("circle", "square", "triangle", "diamond", "star", "cross")
+LINE_TYPES = ("solid", "dashed", "dotted")
+CLASSIFY_METHODS = ("quantile", "equal", "jenks")
+COLOR_MODES = ("single", "graduated", "categorized")
+
+#: `outline_color="none"` means draw NO outline — a sentinel, not an empty string, because "" is
+#: what an uninitialised colour input produces and would silently turn outlines off.
+NO_OUTLINE = "none"
+
+#: CLI/keyword name → the key the style dict actually uses. Only `line_type` differs, and it
+#: differs because the stored key is camelCase (`lineType`) for historical reasons.
+_SIMPLE_KEYS = (
+    ("color", "color"),
+    ("fill_opacity", "fill_opacity"),
+    ("outline_color", "outline_color"),
+    ("outline_width", "outline_width"),
+    ("line_width", "line_width"),
+    ("radius", "radius"),
+    ("marker", "marker"),
+    ("line_type", "lineType"),
+    ("colormap", "colormap"),
+    ("rescale", "rescale"),
+    ("algorithm", "algorithm"),
+    ("zfactor", "zfactor"),
+    ("bidx", "bidx"),
+    ("other_color", "other_color"),
+    ("color_field", "color_field"),
+    ("color_mode", "color_mode"),
+    ("size_field", "size_field"),
+    ("size_mode", "size_mode"),
+)
+
+
+def build_style(base: Optional[Dict[str, Any]] = None, **kw: Any) -> Dict[str, Any]:
+    """Merge only the styling arguments that were actually given onto `base`.
+
+    "Only what was given" is the whole contract: `geodeploy portals style … --color red` must not
+    reset the marker shape and the classes someone spent ten minutes on, so an argument left at
+    None is absent, not a default.
+    """
+    style = dict(base or {})
+    for arg, key in _SIMPLE_KEYS:
+        value = kw.get(arg)
+        if value is not None:
+            style[key] = value
+
+    _validate(style)
+
+    stops = kw.get("size_stops")
+    if stops is not None:
+        style["size_stops"] = parse_size_stops(stops)
+        style.setdefault("size_mode", "proportional")
+    if style.get("size_mode") == "proportional" and not style.get("size_field"):
+        raise ValidationError(400, "Proportional size needs a field (--size-field).")
+
+    classes = kw.get("classes")
+    if classes is not None:
+        style["classes"] = classes
+        style["color_mode"] = "graduated"
+    categories = kw.get("categories")
+    if categories is not None:
+        style["categories"] = categories
+        style["color_mode"] = "categorized"
+
+    extrusion = build_extrusion(style.get("extrusion"), **kw)
+    if extrusion is not None:
+        style["extrusion"] = extrusion
+
+    if kw.get("clear_classification"):
+        for key in ("color_mode", "color_field", "classes", "categories", "other_color"):
+            style.pop(key, None)
+    return style
+
+
+def build_extrusion(base: Optional[Dict[str, Any]] = None, **kw: Any) -> Optional[Dict[str, Any]]:
+    """The 3D block, or None when no 3D argument was given.
+
+    Points get a footprint `radius` in METRES (a point has no area, so extruding one needs a width
+    that polygons get for free); left unset, the server derives it from the layer's own extent —
+    which is why this does not invent a default: a fixed 30 m bar is invisible on a world map.
+    """
+    fields = (("extrude", "enabled"), ("extrude_field", "field"), ("extrude_scale", "scale"),
+              ("extrude_base", "base"), ("extrude_color", "color"),
+              ("extrude_opacity", "opacity"), ("extrude_radius", "radius"))
+    given = {key: kw.get(arg) for arg, key in fields if kw.get(arg) is not None}
+    if not given:
+        return None
+    out = dict(base or {})
+    out.update(given)
+    if out.get("enabled") and not (out.get("field") or out.get("height")):
+        raise ValidationError(400, "3D extrusion needs a numeric field (--extrude-field).")
+    return out
+
+
+def parse_size_stops(raw: Any) -> List[List[float]]:
+    """`"0:2,100:12"` (or an already-parsed list) → `[[0, 2], [100, 12]]`, ascending.
+
+    Two stops minimum, because `interpolate` between one point is not an interpolation — the server
+    silently falls back to the fixed radius, which looks like the flag did nothing.
+    """
+    if isinstance(raw, (list, tuple)):
+        pairs = [list(p) for p in raw]
+    else:
+        pairs = []
+        for chunk in str(raw).split(","):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            if ":" not in chunk:
+                raise ValidationError(400, "Size stops look like value:size — got {0!r}.".format(chunk))
+            value, _, size = chunk.partition(":")
+            try:
+                pairs.append([float(value), float(size)])
+            except ValueError:
+                raise ValidationError(400, "Size stop {0!r} is not numeric.".format(chunk))
+    if len(pairs) < 2:
+        raise ValidationError(400, "Give at least two size stops, e.g. 0:2,1000:12.")
+    return sorted(pairs, key=lambda p: p[0])
+
+
+def parse_classes(raw: Any) -> List[Dict[str, Any]]:
+    """`"0-10:#fee,10-50:#f00"` → the `classes` list. `*` is an open edge (`<10`, `≥50`)."""
+    if isinstance(raw, list):
+        return raw
+    out = []  # type: List[Dict[str, Any]]
+    for chunk in str(raw).split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        span, _, color = chunk.rpartition(":")
+        if not span or not color:
+            raise ValidationError(400, "Classes look like min-max:#colour — got {0!r}.".format(chunk))
+        lo, _, hi = span.partition("-")
+        out.append({"min": _edge(lo), "max": _edge(hi), "color": color.strip()})
+    if not out:
+        raise ValidationError(400, "No classes parsed.")
+    return out
+
+
+def parse_categories(raw: Any) -> List[Dict[str, Any]]:
+    """`"forest:#2c7,water:#39f"` → the `categories` list."""
+    if isinstance(raw, list):
+        return raw
+    out = []  # type: List[Dict[str, Any]]
+    for chunk in str(raw).split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        value, _, color = chunk.rpartition(":")
+        if not value or not color:
+            raise ValidationError(400, "Categories look like value:#colour — got {0!r}.".format(chunk))
+        out.append({"value": value.strip(), "color": color.strip()})
+    if not out:
+        raise ValidationError(400, "No categories parsed.")
+    return out
+
+
+def _edge(text: str) -> Optional[float]:
+    text = (text or "").strip()
+    if text in ("", "*", "inf", "-inf", "none"):
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        raise ValidationError(400, "{0!r} is not a number.".format(text))
+
+
+def classify(client: Any, layer_ref: Any, field: str, mode: Optional[str] = None,
+             classes: int = 5, method: str = "quantile", ramp: str = "viridis",
+             base: Optional[Dict[str, Any]] = None) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Ask the server to classify `field`, and fold the answer into a style dict.
+
+    Returns `(style, stats)` — the stats carry the distribution the server saw, which is what makes
+    "why are all my features one colour" answerable (a column that is 90 % one value collapses its
+    quantile breaks, and the server drops the empty classes rather than publish a legend the map
+    does not match).
+    """
+    if method not in CLASSIFY_METHODS:
+        raise ValidationError(400, "Classification method must be one of {0}.".format(
+            ", ".join(CLASSIFY_METHODS)))
+    if ramp not in RAMPS:
+        raise ValidationError(400, "Unknown colour ramp {0!r}. Known: {1}".format(
+            ramp, ", ".join(RAMPS)))
+    stats = client.vector.field_stats(layer_ref, field, classes=classes, method=method, ramp=ramp)
+    suggestion = (stats or {}).get("suggestion") or {}
+    kind = (stats or {}).get("kind")
+    resolved = mode or suggestion.get("color_mode") or (
+        "graduated" if kind == "numeric" else "categorized")
+
+    style = dict(base or {})
+    style["color_field"] = field
+    style["color_mode"] = resolved
+    if resolved == "graduated":
+        found = suggestion.get("classes") or []
+        if not found:
+            raise ValidationError(
+                400, "{0!r} produced no classes — it is {1}, and graduated colouring needs a "
+                     "numeric column.".format(field, kind or "not numeric"))
+        style["classes"] = found
+        style.pop("categories", None)
+    else:
+        found = suggestion.get("categories") or []
+        if not found:
+            raise ValidationError(400, "{0!r} produced no categories.".format(field))
+        style["categories"] = found
+        style.pop("classes", None)
+    return style, stats
+
+
+def _validate(style: Dict[str, Any]) -> None:
+    marker = style.get("marker")
+    if marker is not None and marker not in MARKERS:
+        raise ValidationError(400, "Marker must be one of {0}.".format(", ".join(MARKERS)))
+    line_type = style.get("lineType")
+    if line_type is not None and line_type not in LINE_TYPES:
+        raise ValidationError(400, "Line type must be one of {0}.".format(", ".join(LINE_TYPES)))
+    mode = style.get("color_mode")
+    if mode is not None and mode not in COLOR_MODES:
+        raise ValidationError(400, "Colour mode must be one of {0}.".format(", ".join(COLOR_MODES)))
+    for key in ("fill_opacity", "outline_width"):
+        value = style.get(key)
+        if value is not None and not 0 <= float(value) <= 1:
+            raise ValidationError(400, "{0} is a fraction between 0 and 1.".format(key))
+
+
+def describe(style: Dict[str, Any]) -> str:
+    """A one-line human summary of a style — what a table cell shows."""
+    if not style:
+        return "default"
+    mode = style.get("color_mode") or "single"
+    if mode == "graduated" and style.get("color_field"):
+        return "graduated on {0} ({1} classes)".format(style["color_field"],
+                                                       len(style.get("classes") or []))
+    if mode == "categorized" and style.get("color_field"):
+        return "categorized on {0} ({1} values)".format(style["color_field"],
+                                                        len(style.get("categories") or []))
+    bits = []  # type: List[str]
+    for key in ("color", "marker", "radius", "line_width", "colormap", "rescale"):
+        if style.get(key) is not None:
+            bits.append("{0}={1}".format(key, style[key]))
+    if (style.get("extrusion") or {}).get("enabled"):
+        bits.append("3D")
+    return ", ".join(bits) or "default"
+
+
+def merge_iterable(pairs: Iterable[Tuple[str, Any]]) -> Dict[str, Any]:  # pragma: no cover - util
+    return {k: v for k, v in pairs if v is not None}

--- a/cli/geodeploy/transport.py
+++ b/cli/geodeploy/transport.py
@@ -1,0 +1,355 @@
+"""HTTP transport — stdlib only, and swappable.
+
+Two things this module exists for:
+
+1. **No dependencies.** `urllib.request` sends every request this client makes, including a 10 GB
+   presigned PUT, because a file object passed as the body is streamed by `http.client` in 8 KB
+   blocks rather than read into memory.
+
+2. **A seam for a host that has its own network stack.** A QGIS plugin should go through
+   `QgsNetworkAccessManager` so it inherits the user's proxy, their CA bundle and their
+   authentication configuration — none of which urllib knows about. Anything with a
+   `send(Request) -> Response` method can be passed as `Client(transport=…)`, so that plugin
+   supplies ~30 lines and reuses every other line in this package.
+"""
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import socket
+import ssl
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, Iterable, Optional, Union
+
+from .errors import TransportError
+
+#: Bytes read per chunk when streaming a file body. Matches http.client's own block size, so a
+#: progress callback fires at the same rate the socket is actually fed.
+BLOCK = 64 * 1024
+
+
+class Request:
+    """One HTTP request, fully resolved: absolute URL, final headers, body ready to send."""
+
+    __slots__ = ("method", "url", "headers", "body", "timeout")
+
+    def __init__(self, method: str, url: str, headers: Optional[Dict[str, str]] = None,
+                 body: Union[bytes, io.IOBase, None] = None, timeout: Optional[float] = None):
+        self.method = method.upper()
+        self.url = url
+        self.headers = dict(headers or {})
+        #: bytes, or a file-like object with `read(n)` (streamed — never loaded whole).
+        self.body = body
+        self.timeout = timeout
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<Request {0} {1}>".format(self.method, self.url)
+
+
+class Response:
+    """One HTTP answer. `content` is always bytes; decoding is the caller's business."""
+
+    __slots__ = ("status", "headers", "content", "url")
+
+    def __init__(self, status: int, headers: Dict[str, str], content: bytes, url: str = ""):
+        self.status = status
+        #: Lower-cased keys — HTTP header names are case-insensitive and callers should not have to
+        #: remember whether this instance's nginx wrote `ETag` or `etag`.
+        self.headers = {str(k).lower(): v for k, v in (headers or {}).items()}
+        self.content = content
+        self.url = url
+
+    @property
+    def text(self) -> str:
+        return self.content.decode("utf-8", "replace")
+
+    def json(self) -> Any:
+        if not self.content:
+            return None
+        return json.loads(self.text)
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status < 400
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<Response {0} {1}>".format(self.status, self.url)
+
+
+class ProgressReader(io.RawIOBase):
+    """A file wrapper that reports how much of it has been sent.
+
+    Wrapping the READER rather than counting before the request is what makes the number honest:
+    it advances as the socket drains, so a stalled upload stops moving instead of showing 100 %
+    while the connection hangs.
+    """
+
+    def __init__(self, fh, total: int, on_progress: Optional[Callable[[int, int], None]] = None,
+                 cancel: Optional[Callable[[], bool]] = None):
+        self._fh = fh
+        self._total = total
+        self._sent = 0
+        self._on_progress = on_progress
+        self._cancel = cancel
+
+    def read(self, size: int = -1) -> bytes:  # noqa: D102 - file protocol
+        if self._cancel is not None and self._cancel():
+            # http.client turns this into a failed request, which is what a cancel should look
+            # like: the upload stops mid-flight and the caller gets an exception, not a silent
+            # truncated object on the far end.
+            raise TransportError("Upload cancelled.")
+        chunk = self._fh.read(BLOCK if size is None or size < 0 else size)
+        if chunk:
+            self._sent += len(chunk)
+            if self._on_progress:
+                self._on_progress(self._sent, self._total)
+        return chunk
+
+    def readable(self) -> bool:
+        return True
+
+    def __len__(self) -> int:
+        return self._total
+
+
+class MultipartBody(io.RawIOBase):
+    """`multipart/form-data` built as a STREAM, so a 2 GB upload never enters memory.
+
+    `urllib` will happily take a bytes body, and every "upload a file" example does exactly that —
+    which is fine until the file is a GeoPackage. This reads the parts in order (preamble, file
+    from disk, epilogue) and reports a real `Content-Length`, which the API needs since it does not
+    accept chunked transfer.
+    """
+
+    def __init__(self, fields: Optional[Dict[str, Any]] = None,
+                 file_field: str = "file", file_path: Optional[str] = None,
+                 filename: Optional[str] = None, content_type: str = "application/octet-stream",
+                 boundary: Optional[str] = None,
+                 on_progress: Optional[Callable[[int, int], None]] = None,
+                 cancel: Optional[Callable[[], bool]] = None):
+        self.boundary = boundary or ("gd" + os.urandom(16).hex())
+        self._path = file_path
+        self._fh = None
+        self._on_progress = on_progress
+        self._cancel = cancel
+        self._sent = 0
+
+        pre = io.BytesIO()
+        for key, value in (fields or {}).items():
+            if value is None:
+                continue
+            pre.write(self._dash())
+            pre.write('Content-Disposition: form-data; name="{0}"\r\n\r\n'.format(key).encode())
+            pre.write(str(value).encode("utf-8"))
+            pre.write(b"\r\n")
+        if file_path is not None:
+            pre.write(self._dash())
+            pre.write(
+                'Content-Disposition: form-data; name="{0}"; filename="{1}"\r\n'
+                .format(file_field, filename or os.path.basename(file_path)).encode("utf-8"))
+            pre.write("Content-Type: {0}\r\n\r\n".format(content_type).encode())
+        self._pre = pre.getvalue()
+        self._post = b"\r\n" + self._dash(final=True) if file_path is not None else self._dash(final=True)
+        self._file_size = os.path.getsize(file_path) if file_path is not None else 0
+        self._stage = 0  # 0 preamble, 1 file, 2 epilogue, 3 done
+        self._offset = 0
+
+    def _dash(self, final: bool = False) -> bytes:
+        return "--{0}{1}\r\n".format(self.boundary, "--" if final else "").encode()
+
+    @property
+    def content_type(self) -> str:
+        return "multipart/form-data; boundary={0}".format(self.boundary)
+
+    def __len__(self) -> int:
+        return len(self._pre) + self._file_size + len(self._post)
+
+    def read(self, size: int = -1) -> bytes:  # noqa: D102 - file protocol
+        if self._cancel is not None and self._cancel():
+            raise TransportError("Upload cancelled.")
+        want = BLOCK if size is None or size < 0 else size
+        if self._stage == 0:
+            chunk = self._pre[self._offset:self._offset + want]
+            self._offset += len(chunk)
+            if self._offset >= len(self._pre):
+                self._stage, self._offset = (1 if self._path else 2), 0
+            return self._advance(chunk)
+        if self._stage == 1:
+            if self._fh is None:
+                self._fh = open(self._path, "rb")
+            chunk = self._fh.read(want)
+            if not chunk:
+                self._fh.close()
+                self._fh = None
+                self._stage, self._offset = 2, 0
+                return self.read(size)
+            return self._advance(chunk)
+        if self._stage == 2:
+            chunk = self._post[self._offset:self._offset + want]
+            self._offset += len(chunk)
+            if self._offset >= len(self._post):
+                self._stage = 3
+            return self._advance(chunk)
+        return b""
+
+    def _advance(self, chunk: bytes) -> bytes:
+        self._sent += len(chunk)
+        if self._on_progress and chunk:
+            self._on_progress(min(self._sent, len(self)), len(self))
+        return chunk
+
+    def readable(self) -> bool:
+        return True
+
+    def close(self) -> None:  # pragma: no cover - cleanup path
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            finally:
+                self._fh = None
+        super().close()
+
+
+class _MethodRequest(urllib.request.Request):
+    """urllib picks GET/POST from whether there is a body; PUT and DELETE need saying out loud."""
+
+    def __init__(self, *args, **kwargs):
+        self._method = kwargs.pop("method_", "GET")
+        urllib.request.Request.__init__(self, *args, **kwargs)
+
+    def get_method(self) -> str:
+        return self._method
+
+
+class UrllibTransport:
+    """The default transport: `urllib.request`, no dependencies.
+
+    Retries are deliberately narrow — connection-level failures and 502/503/504, which mean the
+    request did not run or the gateway gave up. A 4xx is never retried (it will fail identically),
+    and neither is a non-idempotent request that actually reached the app.
+    """
+
+    #: Statuses worth a second attempt: an nginx/gateway answer, not the application's.
+    RETRY_STATUS = (502, 503, 504)
+
+    def __init__(self, verify_tls: bool = True, retries: int = 2, backoff: float = 0.75,
+                 ca_bundle: Optional[str] = None):
+        self.retries = max(0, int(retries))
+        self.backoff = backoff
+        if verify_tls:
+            self._ctx = ssl.create_default_context(cafile=ca_bundle) if ca_bundle else None
+        else:
+            # For a self-signed instance on a lab network. The CLI only reaches this via an
+            # explicit --insecure, and it says so on every run.
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            self._ctx = ctx
+        # No cookie jar and no redirect-following for anything but GET: a 307 on a streamed upload
+        # cannot be replayed (the file object is already partly consumed), so it must surface.
+        self._opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=self._ctx)
+                                                   if self._ctx else urllib.request.HTTPSHandler())
+
+    def send(self, request: Request) -> Response:
+        streamed = not isinstance(request.body, (bytes, bytearray, type(None)))
+        attempts = 1 if streamed else self.retries + 1
+        last_exc = None  # type: Optional[Exception]
+        for attempt in range(attempts):
+            try:
+                return self._send_once(request)
+            except TransportError as exc:
+                last_exc = exc
+                if attempt == attempts - 1:
+                    raise
+                time.sleep(self.backoff * (2 ** attempt))
+            except _RetryStatus as exc:
+                last_exc = exc
+                if attempt == attempts - 1:
+                    return exc.response
+                time.sleep(self.backoff * (2 ** attempt))
+        raise last_exc if last_exc else TransportError("Request failed")  # pragma: no cover
+
+    def _send_once(self, request: Request) -> Response:
+        headers = dict(request.headers)
+        body = request.body
+        if body is not None and not isinstance(body, (bytes, bytearray)):
+            # Streamed body: urllib will not guess a length for a file object, and without
+            # Content-Length http.client falls back to chunked encoding, which S3 presigned PUTs
+            # reject outright (the signature covers the exact length).
+            length = len(body) if hasattr(body, "__len__") else None
+            if length is not None:
+                headers.setdefault("Content-Length", str(length))
+        req = _MethodRequest(request.url, data=body, headers=headers, method_=request.method)
+        try:
+            with self._opener.open(req, timeout=request.timeout) as resp:
+                content = resp.read()
+                if (resp.headers.get("Content-Encoding") or "").lower() == "gzip":
+                    content = gzip.decompress(content)
+                out = Response(resp.status, dict(resp.headers), content, request.url)
+        except urllib.error.HTTPError as exc:
+            content = exc.read() or b""
+            if (exc.headers.get("Content-Encoding") or "").lower() == "gzip":
+                try:
+                    content = gzip.decompress(content)
+                except OSError:  # pragma: no cover - a lying header
+                    pass
+            out = Response(exc.code, dict(exc.headers or {}), content, request.url)
+            if exc.code in self.RETRY_STATUS:
+                raise _RetryStatus(out)
+            return out
+        except urllib.error.URLError as exc:
+            raise TransportError(_reason(exc.reason, request.url)) from exc
+        except (socket.timeout, TimeoutError) as exc:
+            raise TransportError("Timed out talking to {0}".format(request.url)) from exc
+        except ConnectionError as exc:  # reset mid-body, broken pipe on a big upload
+            raise TransportError("Connection lost talking to {0}: {1}".format(request.url, exc)) from exc
+        return out
+
+    def stream(self, request: Request, sink, chunk: int = BLOCK) -> Response:
+        """GET straight to a writable file object — for downloads that must not enter memory."""
+        req = _MethodRequest(request.url, data=None, headers=dict(request.headers),
+                             method_=request.method)
+        try:
+            with self._opener.open(req, timeout=request.timeout) as resp:
+                total = int(resp.headers.get("Content-Length") or 0)
+                read = 0
+                while True:
+                    block = resp.read(chunk)
+                    if not block:
+                        break
+                    sink.write(block)
+                    read += len(block)
+                return Response(resp.status, dict(resp.headers), b"", request.url)
+        except urllib.error.HTTPError as exc:
+            return Response(exc.code, dict(exc.headers or {}), exc.read() or b"", request.url)
+        except urllib.error.URLError as exc:
+            raise TransportError(_reason(exc.reason, request.url)) from exc
+
+
+class _RetryStatus(Exception):
+    """Internal: a gateway status that `send` may retry, carrying the response if it will not."""
+
+    def __init__(self, response: Response):
+        self.response = response
+        Exception.__init__(self, "HTTP {0}".format(response.status))
+
+
+def _reason(reason: Any, url: str) -> str:
+    """Turn urllib's reason object into something that names the instance that failed.
+
+    "[Errno 11001] getaddrinfo failed" tells a user nothing; which URL could not be reached tells
+    them they typed the host wrong, which is the actual cause most of the time.
+    """
+    if isinstance(reason, ssl.SSLError):
+        return ("TLS error talking to {0}: {1}. If this is a self-signed instance, pass --insecure."
+                .format(url, reason))
+    return "Could not reach {0}: {1}".format(url, reason)
+
+
+def iter_chunks(paths: Iterable[str]) -> Iterable[bytes]:  # pragma: no cover - reserved
+    """Placeholder kept out of the public API on purpose; multipart uploads read per part."""
+    raise NotImplementedError

--- a/cli/geodeploy/uploads.py
+++ b/cli/geodeploy/uploads.py
@@ -1,0 +1,474 @@
+"""Uploads — one entry point, five routes, chosen for you.
+
+GeoDeploy has five ways in, and picking the wrong one fails in ways that are hard to read:
+
+===========================  ==========================================================
+route                        when
+===========================  ==========================================================
+``vector-api``               .zip/.geojson/.json/.gpkg under the direct-upload threshold
+``csv-api``                  a small .csv, with X/Y or WKT columns → PostGIS
+``large-vector``             any of the above at or over the threshold → GeoParquet
+``geoparquet``               .parquet/.geoparquet, at any size
+``raster-api`` / ``raster-large``  .tif/.tiff, small / large
+===========================  ==========================================================
+
+**The threshold is 48 MB, not the API's 2 GB.** A file POSTed through the API is buffered by
+whatever proxy sits in front of the instance, and Cloudflare's free tier cuts a request body at
+100 MB — which surfaced as a bare "Network error" at 1 % with *nothing in the API log*, because the
+request never arrived. Above 48 MB everything goes direct-to-storage in 48 MB presigned parts, so
+no single request approaches an edge limit whatever the total size. `ui/src/composables/useUpload.js`
+makes the same decision with the same numbers; the two must stay in step.
+"""
+from __future__ import annotations
+
+import csv as _csv
+import os
+import threading
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from .errors import ValidationError
+from .transport import MultipartBody, ProgressReader, Request
+
+#: At or above this, bypass the API and upload direct to object storage. See the module docstring.
+LARGE_UPLOAD_THRESHOLD = 48 * 1024 * 1024
+
+#: Above this a single presigned PUT is replaced by chunked parts. Must stay <= the server's
+#: PART_SIZE (48 MB), which is itself sized to clear a CDN's ~100 MB request-body cap.
+CHUNK_THRESHOLD = 48 * 1024 * 1024
+
+#: Parts uploaded at once. Four saturates a normal uplink without making progress unreadable.
+PART_CONCURRENCY = 4
+
+#: Retries for ONE part. Parts are the only safely retryable piece of a big upload: each is an
+#: idempotent PUT to its own presigned URL, so a reset at 90 % costs one part, not the whole file.
+PART_RETRIES = 3
+
+VECTOR_API_EXTENSIONS = frozenset((".zip", ".geojson", ".json", ".gpkg"))
+GEOPARQUET_EXTENSIONS = frozenset((".parquet", ".geoparquet"))
+LARGE_VECTOR_EXTENSIONS = frozenset(VECTOR_API_EXTENSIONS | {".csv"})
+RASTER_EXTENSIONS = frozenset((".tif", ".tiff"))
+
+#: Column names that are almost always coordinates. Used ONLY to offer a default for a CSV that
+#: was given no geometry options — the choice is always reported, never silent.
+X_NAMES = ("longitude", "lon", "lng", "long", "x", "easting", "east", "xcoord", "x_coord")
+Y_NAMES = ("latitude", "lat", "y", "northing", "north", "ycoord", "y_coord")
+WKT_NAMES = ("wkt", "geom", "geometry", "the_geom", "wkt_geom", "geometry_wkt")
+
+DELIMITERS = {",": "comma", ";": "semicolon", "\t": "tab", "|": "pipe", " ": "space"}
+
+
+class UploadPlan(object):
+    """What will happen to one file, decided before a byte moves.
+
+    Separated from the doing so the CLI can show `--dry-run` and a plugin can explain the route to
+    a user before committing to a multi-gigabyte transfer.
+    """
+
+    __slots__ = ("path", "route", "layer_type", "name", "size", "csv_opts", "chunked", "reason")
+
+    def __init__(self, path: str, route: str, layer_type: str, name: str, size: int,
+                 csv_opts: Optional[Dict[str, Any]] = None, chunked: bool = False,
+                 reason: str = ""):
+        self.path = path
+        self.route = route
+        self.layer_type = layer_type
+        self.name = name
+        self.size = size
+        self.csv_opts = csv_opts
+        self.chunked = chunked
+        self.reason = reason
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"path": self.path, "route": self.route, "layer_type": self.layer_type,
+                "name": self.name, "size": self.size, "chunked": self.chunked,
+                "csv_opts": self.csv_opts, "reason": self.reason}
+
+
+class UploadResult(object):
+    """The outcome for one file: which layer it became, and the job that is (or was) building it."""
+
+    __slots__ = ("plan", "job", "layer_id", "job_id", "final")
+
+    def __init__(self, plan: UploadPlan, job: Dict[str, Any]):
+        self.plan = plan
+        self.job = job or {}
+        self.layer_id = self.job.get("layer_id")
+        self.job_id = self.job.get("id")
+        #: The last status seen when `wait=True`; None when the caller did not wait.
+        self.final = None  # type: Optional[Dict[str, Any]]
+
+    def as_dict(self) -> Dict[str, Any]:
+        out = {"file": self.plan.path, "name": self.plan.name, "route": self.plan.route,
+               "layer_type": self.plan.layer_type, "layer_id": self.layer_id,
+               "job_id": self.job_id, "size": self.plan.size}
+        if self.final is not None:
+            out["status"] = self.final.get("status")
+            out["error_message"] = self.final.get("error_message")
+        return out
+
+
+def detect_layer_type(path: str) -> str:
+    return "raster" if os.path.splitext(path)[1].lower() in RASTER_EXTENSIONS else "vector"
+
+
+def sniff_csv(path: str, sample_bytes: int = 64 * 1024) -> Dict[str, Any]:
+    """Header + delimiter of a CSV, and a guess at its geometry columns.
+
+    A guess, offered — never applied silently. The CLI prints "using x=lon, y=lat" so a file whose
+    `x`/`y` are something else entirely (a grid reference, a pixel index) is caught by the person
+    who knows, not discovered later as a layer sitting off the coast of Ghana.
+    """
+    with open(path, "r", encoding="utf-8-sig", errors="replace", newline="") as fh:
+        sample = fh.read(sample_bytes)
+    delimiter = ","
+    try:
+        delimiter = _csv.Sniffer().sniff(sample, delimiters=",;\t|").delimiter
+    except _csv.Error:
+        pass
+    header = []  # type: List[str]
+    for row in _csv.reader(sample.splitlines()[:1], delimiter=delimiter):
+        header = [c.strip() for c in row]
+        break
+    lowered = {c.lower(): c for c in header}
+    guess = {"x_column": None, "y_column": None, "wkt_column": None}
+    for name in WKT_NAMES:
+        if name in lowered:
+            guess["wkt_column"] = lowered[name]
+            break
+    if not guess["wkt_column"]:
+        for name in X_NAMES:
+            if name in lowered:
+                guess["x_column"] = lowered[name]
+                break
+        for name in Y_NAMES:
+            if name in lowered:
+                guess["y_column"] = lowered[name]
+                break
+        if not (guess["x_column"] and guess["y_column"]):
+            guess["x_column"] = guess["y_column"] = None
+    return {"header": header, "delimiter": DELIMITERS.get(delimiter, "comma"), "guess": guess}
+
+
+class Uploads(object):
+    """Upload files and register them as layers."""
+
+    def __init__(self, client: Any):
+        self._c = client
+
+    # ── planning ────────────────────────────────────────────────────────────────────────────────
+
+    def plan(self, path: str, layer_type: Optional[str] = None, name: Optional[str] = None,
+             x_column: Optional[str] = None, y_column: Optional[str] = None,
+             wkt_column: Optional[str] = None, srid: int = 4326,
+             delimiter: Optional[str] = None, guess_csv: bool = True) -> UploadPlan:
+        """Decide the route for one file, or raise with a message that says what to do instead."""
+        if not os.path.isfile(path):
+            raise ValidationError(400, "No such file: {0}".format(path))
+        size = os.path.getsize(path)
+        if size == 0:
+            raise ValidationError(400, "{0} is empty.".format(path))
+        ext = os.path.splitext(path)[1].lower()
+        kind = layer_type or detect_layer_type(path)
+        base = name or os.path.splitext(os.path.basename(path))[0]
+
+        if kind == "raster":
+            if ext not in RASTER_EXTENSIONS:
+                raise ValidationError(400, "{0} is not a GeoTIFF (.tif/.tiff).".format(path))
+            if size >= LARGE_UPLOAD_THRESHOLD:
+                return UploadPlan(path, "raster-large", "raster", base, size, chunked=True,
+                                  reason="over the {0} MB direct-upload threshold"
+                                         .format(LARGE_UPLOAD_THRESHOLD // (1024 * 1024)))
+            return UploadPlan(path, "raster-api", "raster", base, size)
+
+        if ext in GEOPARQUET_EXTENSIONS:
+            return UploadPlan(path, "geoparquet", "vector", base, size,
+                              chunked=size > CHUNK_THRESHOLD,
+                              reason="GeoParquet is always uploaded direct to storage")
+
+        if ext not in LARGE_VECTOR_EXTENSIONS:
+            raise ValidationError(
+                400, "Unsupported file type {0}. Vector: {1}, {2}; raster: {3}.".format(
+                    ext or "(none)", ", ".join(sorted(LARGE_VECTOR_EXTENSIONS)),
+                    ", ".join(sorted(GEOPARQUET_EXTENSIONS)), ", ".join(sorted(RASTER_EXTENSIONS))))
+
+        csv_opts = None
+        if ext == ".csv":
+            csv_opts = self._csv_options(path, x_column, y_column, wkt_column, srid, delimiter,
+                                         guess_csv)
+
+        if size >= LARGE_UPLOAD_THRESHOLD:
+            return UploadPlan(path, "large-vector", "vector", base, size, csv_opts,
+                              chunked=size > CHUNK_THRESHOLD,
+                              reason="over the {0} MB direct-upload threshold — converts to "
+                                     "GeoParquet in the background"
+                                     .format(LARGE_UPLOAD_THRESHOLD // (1024 * 1024)))
+        if ext == ".csv":
+            return UploadPlan(path, "csv-api", "vector", base, size, csv_opts)
+        return UploadPlan(path, "vector-api", "vector", base, size)
+
+    def _csv_options(self, path: str, x_column, y_column, wkt_column, srid, delimiter,
+                     guess_csv: bool) -> Dict[str, Any]:
+        opts = {"x_column": x_column, "y_column": y_column, "wkt_column": wkt_column,
+                "srid": int(srid or 4326), "delimiter": delimiter or "comma", "guessed": False}
+        if wkt_column or (x_column and y_column):
+            return opts
+        if not guess_csv:
+            raise ValidationError(400, "A CSV needs geometry columns: --x and --y, or --wkt.")
+        sniffed = sniff_csv(path)
+        guess = sniffed["guess"]
+        if not (guess["wkt_column"] or (guess["x_column"] and guess["y_column"])):
+            raise ValidationError(
+                400, "Could not find geometry columns in {0}. Pass --x/--y or --wkt. "
+                     "Columns: {1}".format(os.path.basename(path),
+                                           ", ".join(sniffed["header"][:20]) or "(none read)"))
+        opts.update(guess)
+        opts["guessed"] = True
+        if not delimiter:
+            opts["delimiter"] = sniffed["delimiter"]
+        return opts
+
+    # ── uploading ───────────────────────────────────────────────────────────────────────────────
+
+    def upload(self, path: str, layer_type: Optional[str] = None, name: Optional[str] = None,
+               wait: bool = False, on_progress: Optional[Callable[[int, int], None]] = None,
+               on_job: Optional[Callable[[Dict[str, Any]], None]] = None,
+               cancel: Optional[Callable[[], bool]] = None,
+               plan: Optional[UploadPlan] = None, **csv_kw: Any) -> UploadResult:
+        """Upload one file and register it. Returns as soon as the ingest job is QUEUED.
+
+        `wait=True` blocks until the job finishes and raises `jobs.JobFailed` if it did not — which
+        is what a script wants, since a queued job says nothing about whether the data was readable.
+        """
+        p = plan or self.plan(path, layer_type, name, **csv_kw)
+        route = p.route
+        if route == "vector-api":
+            job = self._post_file("/data/vector/upload", p, on_progress, cancel)
+        elif route == "raster-api":
+            job = self._post_file("/data/raster/upload", p, on_progress, cancel)
+        elif route == "csv-api":
+            job = self._post_file("/data/vector/upload-csv", p, on_progress, cancel,
+                                  fields=_csv_fields(p))
+        elif route == "geoparquet":
+            key = self._to_storage(p, "geoparquet", on_progress, cancel)
+            job = self._c.post("/data/vector/geoparquet/complete",
+                               {"s3_key": key, "name": p.name, "file_size": p.size})
+        elif route == "large-vector":
+            key = self._to_storage(p, "large", on_progress, cancel)
+            body = {"s3_key": key, "name": p.name, "file_size": p.size}
+            if p.csv_opts:
+                body.update(_csv_fields(p))
+            job = self._c.post("/data/vector/large/complete", body)
+        elif route == "raster-large":
+            key = self._to_storage(p, "raster", on_progress, cancel)
+            job = self._c.post("/data/raster/large/complete",
+                               {"s3_key": key, "name": p.name, "file_size": p.size})
+        else:  # pragma: no cover - plan() cannot produce anything else
+            raise ValidationError(400, "Unknown upload route {0!r}.".format(route))
+
+        result = UploadResult(p, job)
+        if wait and result.job_id:
+            result.final = self._c.jobs.wait(result.job_id, p.layer_type,
+                                             on_progress=on_job)
+        return result
+
+    def upload_many(self, paths: Sequence[str], layer_type: Optional[str] = None,
+                    wait: bool = False, concurrency: int = 1,
+                    on_file: Optional[Callable[[UploadPlan], None]] = None,
+                    on_progress: Optional[Callable[[str, int, int], None]] = None,
+                    on_job: Optional[Callable[[str, Dict[str, Any]], None]] = None,
+                    on_error: Optional[Callable[[str, Exception], None]] = None,
+                    stop_on_error: bool = False, **kw: Any) -> List[Any]:
+        """Upload several files. Every file is PLANNED first, so a bad argument fails before the
+        first byte rather than after the first three uploads.
+
+        Files run sequentially by default: each large file already uses four parallel part uploads,
+        and stacking file-level concurrency on top mostly redistributes the same bandwidth while
+        making progress output unreadable. Raise `concurrency` for many small files.
+        """
+        plans = [self.plan(p, layer_type, **kw) for p in paths]
+        results = []  # type: List[Any]
+
+        def run(p: UploadPlan):
+            if on_file:
+                on_file(p)
+            return self.upload(
+                p.path, plan=p, wait=wait,
+                on_progress=(lambda done, total: on_progress(p.path, done, total)) if on_progress else None,
+                on_job=(lambda st: on_job(p.path, st)) if on_job else None)
+
+        if concurrency > 1 and len(plans) > 1:
+            from concurrent.futures import ThreadPoolExecutor
+            with ThreadPoolExecutor(max_workers=min(concurrency, len(plans))) as pool:
+                futures = [(p, pool.submit(run, p)) for p in plans]
+                for p, future in futures:
+                    try:
+                        results.append(future.result())
+                    except Exception as exc:  # noqa: BLE001 - reported per file, not swallowed
+                        if on_error:
+                            on_error(p.path, exc)
+                        results.append(exc)
+            return results
+
+        for p in plans:
+            try:
+                results.append(run(p))
+            except Exception as exc:  # noqa: BLE001
+                if on_error:
+                    on_error(p.path, exc)
+                results.append(exc)
+                if stop_on_error:
+                    break
+        return results
+
+    # ── the two transports ──────────────────────────────────────────────────────────────────────
+
+    def _post_file(self, path: str, plan: UploadPlan,
+                   on_progress: Optional[Callable[[int, int], None]],
+                   cancel: Optional[Callable[[], bool]] = None,
+                   fields: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """multipart/form-data through the API — streamed from disk, never buffered."""
+        body = MultipartBody(fields=fields, file_path=plan.path,
+                             filename=os.path.basename(plan.path),
+                             on_progress=on_progress, cancel=cancel)
+        return self._c.request("POST", path, body=body, content_type=body.content_type,
+                               timeout=self._c.upload_timeout)
+
+    def _to_storage(self, plan: UploadPlan, kind: str,
+                    on_progress: Optional[Callable[[int, int], None]],
+                    cancel: Optional[Callable[[], bool]] = None) -> str:
+        """Direct-to-storage upload; returns the object key to register. Chunked when big."""
+        if plan.chunked:
+            return self._chunked(plan, kind, on_progress, cancel)
+        endpoint = ("/data/vector/geoparquet/presign" if kind == "geoparquet"
+                    else "/data/vector/large/presign")
+        pre = self._c.post(endpoint, {"filename": os.path.basename(plan.path),
+                                      "name": plan.name, "file_size": plan.size})
+        with open(plan.path, "rb") as fh:
+            reader = ProgressReader(fh, plan.size, on_progress, cancel)
+            response = self._c.send_absolute("PUT", pre["upload_url"], reader,
+                                             {"Content-Type": "application/octet-stream"})
+        if response.status >= 400:
+            from .errors import from_status
+            raise from_status(response.status,
+                              "Storage rejected the upload: {0}".format(response.text[:300]),
+                              response.url)
+        return pre["s3_key"]
+
+    def _chunked(self, plan: UploadPlan, kind: str,
+                 on_progress: Optional[Callable[[int, int], None]],
+                 cancel: Optional[Callable[[], bool]] = None) -> str:
+        """initiate → PUT every part (in parallel, with retries) → assemble.
+
+        A failure aborts the multipart upload so the staged parts are not left paying for storage
+        on someone's S3 bill.
+        """
+        base = "/data/raster" if kind == "raster" else "/data/vector"
+        init = self._c.post(base + "/upload/multipart/initiate",
+                            {"filename": os.path.basename(plan.path), "file_size": plan.size,
+                             "kind": kind})
+        key, upload_id = init["s3_key"], init["upload_id"]
+        part_size, parts = init["part_size"], init["parts"]
+
+        sent = [0] * len(parts)
+        lock = threading.Lock()
+        results = [None] * len(parts)  # type: List[Optional[Dict[str, Any]]]
+
+        def report():
+            if on_progress:
+                on_progress(min(sum(sent), plan.size), plan.size)
+
+        def put(index: int) -> None:
+            part = parts[index]
+            number = int(part["part_number"])
+            offset = (number - 1) * part_size
+            length = min(part_size, plan.size - offset)
+            last_error = None
+            for attempt in range(PART_RETRIES):
+                if cancel is not None and cancel():
+                    raise _Cancelled()
+                try:
+                    with open(plan.path, "rb") as fh:
+                        fh.seek(offset)
+                        chunk = _Slice(fh, length)
+
+                        def progress(done, _total, i=index):
+                            with lock:
+                                sent[i] = done
+                            report()
+
+                        reader = ProgressReader(chunk, length, progress, cancel)
+                        response = self._c.send_absolute("PUT", part["url"], reader)
+                    if response.status < 400:
+                        etag = (response.headers.get("etag") or "").strip('"')
+                        if not etag:
+                            raise ValidationError(
+                                502, "Storage accepted part {0} but returned no ETag, so the "
+                                     "upload cannot be assembled.".format(number))
+                        results[index] = {"part_number": number, "etag": etag}
+                        with lock:
+                            sent[index] = length
+                        report()
+                        return
+                    last_error = "HTTP {0}: {1}".format(response.status, response.text[:200])
+                except _Cancelled:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - retried below
+                    last_error = str(exc)
+                with lock:
+                    sent[index] = 0
+                report()
+            raise ValidationError(502, "Part {0} of {1} failed after {2} attempts: {3}".format(
+                number, len(parts), PART_RETRIES, last_error))
+
+        try:
+            if len(parts) > 1 and PART_CONCURRENCY > 1:
+                from concurrent.futures import ThreadPoolExecutor
+                with ThreadPoolExecutor(max_workers=min(PART_CONCURRENCY, len(parts))) as pool:
+                    for _ in pool.map(put, range(len(parts))):
+                        pass
+            else:
+                for index in range(len(parts)):
+                    put(index)
+            self._c.post(base + "/upload/multipart/complete",
+                         {"s3_key": key, "upload_id": upload_id,
+                          "parts": [r for r in results if r]})
+        except BaseException:
+            try:
+                self._c.post(base + "/upload/multipart/abort",
+                             {"s3_key": key, "upload_id": upload_id})
+            except Exception:  # noqa: BLE001 - the original failure is what matters
+                pass
+            raise
+        return key
+
+
+class _Cancelled(Exception):
+    """Internal: a cancel callback said stop. Turned into a TransportError by the caller."""
+
+
+class _Slice(object):
+    """A read-only window onto an open file — one multipart part, without copying it."""
+
+    def __init__(self, fh, length: int):
+        self._fh = fh
+        self._left = length
+
+    def read(self, size: int = -1) -> bytes:
+        if self._left <= 0:
+            return b""
+        want = self._left if size is None or size < 0 else min(size, self._left)
+        chunk = self._fh.read(want)
+        self._left -= len(chunk)
+        return chunk
+
+
+def _csv_fields(plan: UploadPlan) -> Dict[str, Any]:
+    """The CSV geometry options, in the shape both CSV routes expect (form fields / JSON body)."""
+    opts = dict(plan.csv_opts or {})
+    opts.pop("guessed", None)
+    fields = {"name": plan.name, "srid": opts.get("srid", 4326),
+              "delimiter": opts.get("delimiter", "comma")}
+    for key in ("x_column", "y_column", "wkt_column"):
+        if opts.get(key):
+            fields[key] = opts[key]
+    return fields

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+# 77 is the floor for PEP 639: `license` as an SPDX expression and `license-files` as globs.
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "geodeploy"
+description = "Command-line client and Python API for GeoDeploy — upload spatial data, build and publish portals."
+# The PyPI front page is its own file: README.md in this folder is the repository's technical note
+# for contributors (see CLAUDE.md), which is not what someone landing on the project page wants.
+readme = "PYPI.md"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+authors = [{ name = "Koffi Dodji Noumonvi" }]
+keywords = ["gis", "geospatial", "postgis", "geoparquet", "cog", "maplibre", "qgis", "stac",
+            "ogc-api-features", "geodeploy"]
+
+# 3.9 is the floor because the QGIS plugin VENDORS this package: QGIS 3.28 LTR ships Python 3.9,
+# and a plugin cannot pip-install anything on a user's machine. Everything here therefore runs on
+# 3.9 — `from __future__ import annotations` in every module, no match statements, no PEP 604
+# unions evaluated at runtime. No upper bound, deliberately: capping it would break installs on
+# every Python released after this one.
+requires-python = ">=3.9"
+
+# NO RUNTIME DEPENDENCIES, deliberately. Same reason: the QGIS plugin drops `geodeploy/` into its
+# own folder and imports it, so anything depended on here would have to be vendored too. urllib
+# makes every request this client sends, including streamed multi-gigabyte uploads.
+dependencies = []
+
+# The version lives in ONE place — `geodeploy/__init__.py` — because the user agent, `--version`
+# and the package metadata must never disagree about what is installed.
+dynamic = ["version"]
+
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: System Administrators",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering :: GIS",
+  "Topic :: Utilities",
+  "Typing :: Typed",
+]
+# NOTE: no "License :: OSI Approved :: …" classifier. Under PEP 639 the SPDX `license` field above
+# is the declaration, and setuptools REFUSES a build that gives both.
+
+[project.urls]
+Homepage = "https://github.com/bravemaster3/GeoDeploy"
+Documentation = "https://docs-geodeploy.kndev.org/cli/"
+Repository = "https://github.com/bravemaster3/GeoDeploy"
+Issues = "https://github.com/bravemaster3/GeoDeploy/issues"
+Changelog = "https://github.com/bravemaster3/GeoDeploy/blob/main/CHANGELOG.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[project.scripts]
+geodeploy = "geodeploy.cli.main:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "geodeploy.__version__" }
+
+[tool.setuptools.packages.find]
+include = ["geodeploy*"]
+
+[tool.setuptools.package-data]
+geodeploy = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -35,6 +35,8 @@ class FakeInstance(object):
         self.jobs = {}              # job_id -> [status dicts to return, last one repeats]
         self.fail_next = None       # (status, detail) injected into the next API call
         self.exports = {}           # export job id -> the bytes its download returns
+        self.export_truncated = []  # what export-status reports as cut short by the row cap
+        self.last_export = None     # the body of the most recent export request, or None
         self.public_index_enabled = True
         self.token_forbidden = set()  # path prefixes that reject token auth, like /admin
         self.vector_layers = [
@@ -49,6 +51,10 @@ class FakeInstance(object):
              "status": "processing", "progress": 42, "current_step": "Converting",
              "geometry_type": "point", "feature_count": None, "storage_backend": "geoparquet",
              "visibility": "private", "is_public": False, "columns": []},
+            {"id": 4, "uid": "dddddddddddd", "name": "parcels", "layer_type": "vector",
+             "status": "ready", "geometry_type": "polygon", "feature_count": 2_400_000,
+             "storage_backend": "geoparquet", "visibility": "public", "is_public": True,
+             "crs": "EPSG:3006", "file_size": 40_000_000, "created_by": "Koffi", "columns": []},
         ]
         self.raster_layers = [
             {"id": 1, "uid": "cccccccccccc", "name": "dem", "layer_type": "raster",
@@ -122,6 +128,8 @@ class FakeInstance(object):
             (r"/data/vector/(\S+)/features", self._features),
             (r"/data/raster/(\S+)/cog", lambda *a: (200, b"II-pretend-GeoTIFF-bytes")),
             (r"/data/vector/(\S+)/pmtiles", lambda *a: (200, b"PMTiles pretend")),
+            (r"/data/vector/([\w.-]+)/parquet/manifest\.json", self._parquet_manifest),
+            (r"/data/vector/([\w.-]+)/parquet/(.+)", self._parquet_object),
             (r"/public", self._public),
             (r"/public/portals", self._public_portals),
             (r"/data/(vector|raster)/(\S+)/export", self._export_start),
@@ -339,7 +347,28 @@ class FakeInstance(object):
         return 202, {"job_id": job_id}
 
     def _export_status(self, method, match, query, headers, body):
-        return 200, {"status": "ready" if match.group(3) in self.exports else "queued"}
+        if match.group(3) not in self.exports:
+            return 200, {"status": "queued"}
+        return 200, {"status": "ready", "truncated": list(self.export_truncated)}
+
+    #: The prepared-GeoParquet layers this fake serves partition files for.
+    PARQUET = {"dddddddddddd", "4", "parcels"}
+
+    def _parquet_manifest(self, method, match, query, headers, body):
+        if match.group(1) not in self.PARQUET:
+            return 404, {"detail": "No parquet dataset for this layer."}
+        return 200, {
+            "version": 1, "crs": "EPSG:3006", "geometry_column": "geometry",
+            "bbox": [11.0, 55.0, 12.0, 56.0], "feature_count": 2_400_000,
+            "grid": {"grid": 4}, "columns": [{"name": "id", "type": "bigint"}],
+            "cells": {"0": [{"key": "__cell=0/part0.parquet", "rows": 1_200_000}],
+                      "1": [{"key": "__cell=1/part0.parquet", "rows": 1_200_000}]},
+        }
+
+    def _parquet_object(self, method, match, query, headers, body):
+        if match.group(1) not in self.PARQUET:
+            return 404, {"detail": "No parquet dataset for this layer."}
+        return 200, b"PAR1 pretend " + match.group(2).encode()
 
     def _export_download(self, method, match, query, headers, body):
         data = self.exports.get(match.group(3))

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -132,6 +132,7 @@ class FakeInstance(object):
             (r"/data/sources", self._sources),
             (r"/data/sources/(\d+)", lambda m, mo, *a: (200, {"ok": True})),
             (r"/portals", self._portals),
+            (r"/portals/([\w-]+)/style\.json", self._portal_style),
             (r"/portals/(\d+)", self._portal),
             (r"/portals/(\d+)/publish", self._publish),
             (r"/portals/(\d+)/unpublish", self._unpublish),
@@ -294,6 +295,19 @@ class FakeInstance(object):
                  "layer_count": 1, "url": base + "/portals/field-sites-2026/",
                  "style_url": base + "/portals/field-sites-2026/style.json",
                  "thumbnail_url": None, "published_at": "2026-08-01T00:00:00"}]
+
+    def _portal_style(self, method, match, query, headers, body):
+        """A published portal's own style.json — served outside /api, like the real bundle."""
+        if match.group(1) != "field-sites-2026":
+            return 404, {"detail": "No such portal."}
+        return 200, {
+            "version": 8,
+            "sources": {"basemap": {"type": "raster"}, "roads-src": {"type": "vector"}},
+            "layers": [{"id": "basemap", "type": "raster", "source": "basemap"},
+                       {"id": "roads", "type": "line", "source": "roads-src"}],
+            "geodeploy": {"title": "Field sites 2026", "bounds": [11.0, 55.0, 12.0, 56.0],
+                          "deckLayers": []},
+        }
 
     def _export_start(self, method, match, query, headers, body):
         payload = json.loads(body or b"{}")

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -300,13 +300,33 @@ class FakeInstance(object):
         """A published portal's own style.json — served outside /api, like the real bundle."""
         if match.group(1) != "field-sites-2026":
             return 404, {"detail": "No such portal."}
+        base = "http://127.0.0.1"
         return 200, {
             "version": 8,
-            "sources": {"basemap": {"type": "raster"}, "roads-src": {"type": "vector"}},
-            "layers": [{"id": "basemap", "type": "raster", "source": "basemap"},
-                       {"id": "roads", "type": "line", "source": "roads-src"}],
+            "sources": {
+                "basemap": {"type": "raster", "tiles": ["https://tiles.example/{z}/{x}/{y}.png"]},
+                "vector_1": {"type": "vector", "tiles": [base + "/tiles/vector_1/{z}/{x}/{y}.pbf"]},
+                "vector_3": {"type": "vector", "tiles": [base + "/tiles/vector_3/{z}/{x}/{y}.pbf"]},
+                "raster_2": {"type": "raster", "tiles": [base + "/cog/2/{z}/{x}/{y}.png"]},
+            },
+            "layers": [
+                {"id": "basemap", "type": "raster", "source": "basemap"},
+                {"id": "vector-1", "type": "line", "source": "vector_1",
+                 "metadata": {"geodeploy:name": "Roads", "geodeploy:layer_id": 1,
+                              "geodeploy:geometry": "linestring"}},
+                {"id": "vector-3", "type": "fill", "source": "vector_3",
+                 "metadata": {"geodeploy:name": "Plots", "geodeploy:layer_id": 3,
+                              "geodeploy:geometry": "polygon"}},
+                {"id": "vector-3-outline", "type": "line", "source": "vector_3",
+                 "metadata": {"geodeploy:layer_id": 3, "geodeploy:part": True}},
+                {"id": "raster-2", "type": "raster", "source": "raster_2",
+                 "layout": {"visibility": "none"},
+                 "metadata": {"geodeploy:name": "DEM", "geodeploy:layer_id": 2,
+                              "geodeploy:geometry": "raster"}},
+            ],
             "geodeploy": {"title": "Field sites 2026", "bounds": [11.0, 55.0, 12.0, 56.0],
-                          "deckLayers": []},
+                          "deckLayers": [{"id": "deck-7", "name": "Trees",
+                                          "url": base + "/data/trees.parquet"}]},
         }
 
     def _export_start(self, method, match, query, headers, body):

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -143,6 +143,7 @@ class FakeInstance(object):
                 {"id": "vector-aaaaaaaaaaaa", "title": "roads"}]})),
             (r"/ogc/conformance", lambda *a: (200, {"conformsTo": ["core", "geojson"]})),
             (r"/stac/collections", lambda *a: (200, {"collections": [{"id": "vectors"}]})),
+            (r"/admin/public-index", self._public_index_setting),
             (r"/admin/health", lambda *a: (200, [{"name": "api", "status": "healthy",
                                                   "controllable": False}])),
             (r"/admin/storage-stats", lambda *a: (200, {"used_bytes": 1024, "postgis_bytes": 512,
@@ -311,6 +312,11 @@ class FakeInstance(object):
         if data is None:
             return 404, {"detail": "That export is not ready (or has been swept)."}
         return 200, data
+
+    def _public_index_setting(self, method, match, query, headers, body):
+        if method == "PUT":
+            self.public_index_enabled = bool(json.loads(body or b"{}").get("enabled"))
+        return 200, {"enabled": self.public_index_enabled}
 
     def _field_stats(self, method, match, query, headers, body):
         field = (query.get("field") or [""])[0]

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,536 @@
+"""Test fixtures: a real HTTP server that behaves like a GeoDeploy instance.
+
+Why a server rather than mocks: the parts of this client most likely to break are the ones a mock
+cannot see — a streamed multipart body, a presigned PUT that must NOT carry an Authorization
+header, a relative `/s3/…` upload URL, an ETag read from a response header, chunked parts
+assembled in the right order. `FakeInstance` therefore records what actually arrived on the wire,
+and the tests assert against that.
+
+It is a stub, not an emulator: it knows the routes this client calls, in the shapes
+`api/geodeploy/routers/` returns.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class FakeInstance(object):
+    """In-memory GeoDeploy: layers, portals, jobs, uploads — and a log of every request."""
+
+    def __init__(self):
+        self.requests = []          # [{method, path, query, headers, body}]
+        self.uploads = {}           # s3_key -> assembled bytes
+        self.multiparts = {}        # upload_id -> {key, parts:{n: bytes}, aborted: bool}
+        self.jobs = {}              # job_id -> [status dicts to return, last one repeats]
+        self.fail_next = None       # (status, detail) injected into the next API call
+        self.token_forbidden = set()  # path prefixes that reject token auth, like /admin
+        self.vector_layers = [
+            {"id": 1, "uid": "aaaaaaaaaaaa", "name": "roads", "layer_type": "vector",
+             "status": "ready", "geometry_type": "linestring", "feature_count": 1200,
+             "storage_backend": "postgis", "visibility": "organization", "is_public": False,
+             "crs": "EPSG:4326", "file_size": 2048, "created_by": "Koffi",
+             "columns": [{"name": "id", "type": "integer"}, {"name": "pop", "type": "integer"}],
+             "default_style": {"opacity": 1.0, "style": {"color": "#3b82f6"},
+                               "popup_fields": []}},
+            {"id": 2, "uid": "bbbbbbbbbbbb", "name": "field sites", "layer_type": "vector",
+             "status": "processing", "progress": 42, "current_step": "Converting",
+             "geometry_type": "point", "feature_count": None, "storage_backend": "geoparquet",
+             "visibility": "private", "is_public": False, "columns": []},
+        ]
+        self.raster_layers = [
+            {"id": 1, "uid": "cccccccccccc", "name": "dem", "layer_type": "raster",
+             "status": "ready", "band_count": 1, "visibility": "public", "is_public": True,
+             "crs": "EPSG:3006", "file_size": 999, "default_style": {"opacity": 1.0}},
+        ]
+        self.portals = [
+            {"id": 3, "title": "Field sites 2026", "slug": "field-sites-2026", "published": True,
+             "access_type": "public", "template_id": "minimal", "description": "About",
+             "layer_configs": [
+                 {"layer_id": 1, "layer_type": "vector", "visible": True, "opacity": 1.0,
+                  "style": {"color": "#3b82f6"}, "popup_fields": []}],
+             "layer_groups": None, "created_by": "Koffi"},
+        ]
+
+    # ── dispatch ────────────────────────────────────────────────────────────────────────────────
+
+    def handle(self, method, path, query, headers, body):
+        self.requests.append({"method": method, "path": path, "query": query,
+                              "headers": dict(headers), "body": body})
+
+        if path.startswith("/s3/"):
+            return self._storage(method, path, query, headers, body)
+
+        if self.fail_next is not None:
+            status, detail = self.fail_next
+            self.fail_next = None
+            return status, {"detail": detail}
+
+        auth = headers.get("authorization") or ""
+        is_token = auth.startswith("Bearer gdp_")
+        api = path[len("/api"):] if path.startswith("/api") else path
+
+        if any(api.startswith(prefix) for prefix in self.token_forbidden) and is_token:
+            return 403, {"detail": "Not permitted with an API token."}
+
+        for pattern, handler in self._routes():
+            match = re.match(pattern + "$", api)
+            if match and handler:
+                return handler(method, match, query, headers, body)
+        return 404, {"detail": "Not Found: {0} {1}".format(method, path)}
+
+    def _routes(self):
+        return [
+            (r"/auth/me", self._me),
+            (r"/auth/login", self._login),
+            (r"/setup/status", lambda *a: (200, {"completed": True, "email_enabled": False})),
+            (r"/tokens", self._tokens),
+            (r"/tokens/(\d+)", lambda m, mo, *a: (200, {"ok": True, "id": int(mo.group(1))})),
+            (r"/data/vector", self._vector_list),
+            (r"/data/raster", self._raster_list),
+            (r"/data/vector/upload", self._upload_form),
+            (r"/data/vector/upload-csv", self._upload_form),
+            (r"/data/raster/upload", self._upload_form),
+            (r"/data/(vector|raster)/upload/multipart/initiate", self._mp_initiate),
+            (r"/data/(vector|raster)/upload/multipart/complete", self._mp_complete),
+            (r"/data/(vector|raster)/upload/multipart/abort", self._mp_abort),
+            (r"/data/vector/geoparquet/presign", self._presign),
+            (r"/data/vector/large/presign", self._presign),
+            (r"/data/vector/geoparquet/complete", self._register),
+            (r"/data/vector/large/complete", self._register),
+            (r"/data/raster/large/complete", self._register_raster),
+            (r"/data/(vector|raster)/jobs/([\w-]+)", self._job),
+            (r"/data/vector/(\S+)/field-stats", self._field_stats),
+            (r"/data/(vector|raster)/(\d+)/sharing", self._sharing),
+            (r"/data/(vector|raster)/(\d+)/rename", self._rename),
+            (r"/data/(vector|raster)/(\d+)/default-style", self._default_style),
+            (r"/data/(vector|raster)/(\d+)/usage", lambda *a: (200, [])),
+            (r"/data/(vector|raster)/(\d+)/links", self._links),
+            (r"/data/(vector|raster)/(\d+)", self._delete_layer),
+            (r"/data/vector/(\S+)/features", self._features),
+            (r"/data/vector/(\d+)/tile", lambda *a: (202, self._new_job(1, "vector"))),
+            (r"/data/vector/(\d+)/reprocess", lambda *a: (202, self._new_job(1, "vector"))),
+            (r"/data/sources", self._sources),
+            (r"/data/sources/(\d+)", lambda m, mo, *a: (200, {"ok": True})),
+            (r"/portals", self._portals),
+            (r"/portals/(\d+)", self._portal),
+            (r"/portals/(\d+)/publish", self._publish),
+            (r"/portals/(\d+)/unpublish", self._unpublish),
+            (r"/templates", lambda *a: (200, [{"id": "minimal", "name": "Minimal",
+                                               "archetypes": ["webmap"], "version": "1.0",
+                                               "is_official": True, "tags": []}])),
+            (r"/basemaps", lambda *a: (200, [{"id": "positron", "name": "Positron"}])),
+            (r"/ogc/collections", lambda *a: (200, {"collections": [
+                {"id": "vector-aaaaaaaaaaaa", "title": "roads"}]})),
+            (r"/ogc/conformance", lambda *a: (200, {"conformsTo": ["core", "geojson"]})),
+            (r"/stac/collections", lambda *a: (200, {"collections": [{"id": "vectors"}]})),
+            (r"/admin/health", lambda *a: (200, [{"name": "api", "status": "healthy",
+                                                  "controllable": False}])),
+            (r"/admin/storage-stats", lambda *a: (200, {"used_bytes": 1024, "postgis_bytes": 512,
+                                                        "raster_bytes": None, "vector_layers": 2,
+                                                        "raster_layers": 1, "portals": 1})),
+            (r"/users", lambda *a: (200, [{"id": 1, "name": "Koffi", "email": "k@example.org",
+                                           "role": "owner"}])),
+        ]
+
+    # ── handlers ────────────────────────────────────────────────────────────────────────────────
+
+    def _me(self, method, match, query, headers, body):
+        if not (headers.get("authorization") or ""):
+            return 401, {"detail": "Not authenticated"}
+        return 200, {"id": 1, "email": "k@example.org", "name": "Koffi", "role": "owner",
+                     "is_admin": True, "created_at": "2026-01-01T00:00:00"}
+
+    def _login(self, method, match, query, headers, body):
+        form = parse_qs((body or b"").decode())
+        if form.get("password", [""])[0] != "correct-horse":
+            return 401, {"detail": "Incorrect email or password"}
+        return 200, {"access_token": "jwt-for-" + form.get("username", [""])[0],
+                     "token_type": "bearer"}
+
+    def _tokens(self, method, match, query, headers, body):
+        if method == "POST":
+            payload = json.loads(body or b"{}")
+            return 200, {"id": 9, "name": payload.get("name"), "prefix": "gdp_abcd1234",
+                         "scopes": payload.get("scopes"), "expires_at": "2027-01-01T00:00:00",
+                         "created_at": "2026-01-01T00:00:00", "token": "gdp_secret_value"}
+        return 200, [{"id": 9, "name": "ci", "prefix": "gdp_abcd1234", "scopes": ["data:read"],
+                      "expires_at": "2027-01-01T00:00:00", "created_at": "2026-01-01T00:00:00"}]
+
+    def _vector_list(self, method, match, query, headers, body):
+        return 200, self.vector_layers
+
+    def _raster_list(self, method, match, query, headers, body):
+        return 200, self.raster_layers
+
+    def _upload_form(self, method, match, query, headers, body):
+        """Record what the multipart body actually contained, then answer like the API does."""
+        parsed = parse_multipart(headers.get("content-type", ""), body or b"")
+        self.last_form = parsed
+        layer_type = "raster" if "raster" in match.group(0) else "vector"
+        return 202, self._new_job(len(self.vector_layers) + 1, layer_type)
+
+    def _presign(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        key = "vectors/1/{0}/{1}".format(uuid.uuid4().hex, payload.get("filename") or "file")
+        # Relative, exactly like a managed MinIO behind the nginx /s3/ proxy.
+        return 200, {"upload_url": "/s3/{0}?X-Amz-Signature=abc".format(key), "s3_key": key}
+
+    def _mp_initiate(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        kind = payload.get("kind")
+        prefix = "rasters" if kind == "raster" else "vectors"
+        key = "{0}/1/{1}/{2}".format(prefix, uuid.uuid4().hex, payload.get("filename"))
+        upload_id = uuid.uuid4().hex
+        part_size = 1024                      # tiny, so tests exercise many parts cheaply
+        count = max(1, -(-int(payload.get("file_size") or 1) // part_size))
+        self.multiparts[upload_id] = {"key": key, "parts": {}, "aborted": False}
+        return 200, {"s3_key": key, "upload_id": upload_id, "part_size": part_size,
+                     "parts": [{"part_number": n + 1,
+                                "url": "/s3/{0}?partNumber={1}&uploadId={2}".format(
+                                    key, n + 1, upload_id)}
+                               for n in range(count)]}
+
+    def _mp_complete(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        record = self.multiparts.get(payload.get("upload_id"))
+        if record is None:
+            return 400, {"detail": "no such upload"}
+        ordered = [record["parts"][n] for n in sorted(record["parts"])]
+        self.uploads[record["key"]] = b"".join(ordered)
+        record["completed_parts"] = payload.get("parts")
+        return 200, {"s3_key": record["key"]}
+
+    def _mp_abort(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        record = self.multiparts.get(payload.get("upload_id"))
+        if record is not None:
+            record["aborted"] = True
+        return 200, {"ok": True}
+
+    def _register(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        self.last_register = payload
+        return 202, self._new_job(len(self.vector_layers) + 1, "vector")
+
+    def _register_raster(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        self.last_register = payload
+        return 202, self._new_job(len(self.raster_layers) + 1, "raster")
+
+    def _job(self, method, match, query, headers, body):
+        job_id = match.group(2)
+        states = self.jobs.get(job_id)
+        if not states:
+            return 404, {"detail": "Job not found"}
+        state = states.pop(0) if len(states) > 1 else states[0]
+        return 200, state
+
+    def _new_job(self, layer_id, layer_type, states=None):
+        job_id = str(uuid.uuid4())
+        self.jobs[job_id] = states or [
+            {"id": job_id, "layer_id": layer_id, "layer_type": layer_type, "status": "queued",
+             "progress": 0, "current_step": "Queued", "error_message": None},
+            {"id": job_id, "layer_id": layer_id, "layer_type": layer_type, "status": "processing",
+             "progress": 60, "current_step": "Loading", "error_message": None},
+            {"id": job_id, "layer_id": layer_id, "layer_type": layer_type, "status": "ready",
+             "progress": 100, "current_step": "Done", "error_message": None},
+        ]
+        first = dict(self.jobs[job_id][0])
+        return first
+
+    def _field_stats(self, method, match, query, headers, body):
+        field = (query.get("field") or [""])[0]
+        if field == "name":
+            return 200, {"kind": "text", "count": 12,
+                         "categories": [{"value": "forest", "count": 7},
+                                        {"value": "water", "count": 5}],
+                         "suggestion": {"color_mode": "categorized",
+                                        "categories": [{"value": "forest", "color": "#3b82f6"},
+                                                       {"value": "water", "color": "#ef4444"}]}}
+        if field == "missing":
+            return 400, {"detail": "No such field on this layer: missing"}
+        return 200, {"kind": "numeric", "count": 100, "min": 0, "max": 500, "values": None,
+                     "suggestion": {"color_mode": "graduated", "classes": [
+                         {"min": None, "max": 100, "color": "#440154"},
+                         {"min": 100, "max": 250, "color": "#21918c"},
+                         {"min": 250, "max": None, "color": "#fde725"}]}}
+
+    def _sharing(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        rows = self.vector_layers if match.group(1) == "vector" else self.raster_layers
+        for row in rows:
+            if row["id"] == int(match.group(2)):
+                row.update(payload)
+                if payload.get("visibility"):
+                    row["is_public"] = payload["visibility"] == "public"
+                return 200, row
+        return 404, {"detail": "Layer not found."}
+
+    def _rename(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        rows = self.vector_layers if match.group(1) == "vector" else self.raster_layers
+        for row in rows:
+            if row["id"] == int(match.group(2)):
+                row["name"] = payload.get("name")
+                return 200, row
+        return 404, {"detail": "Layer not found."}
+
+    def _default_style(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        rows = self.vector_layers if match.group(1) == "vector" else self.raster_layers
+        for row in rows:
+            if row["id"] == int(match.group(2)):
+                row["default_style"] = payload
+                return 200, row
+        return 404, {"detail": "Layer not found."}
+
+    def _links(self, method, match, query, headers, body):
+        return 200, {"public": match.group(1) == "raster", "name": "roads", "catalog": "/api/stac",
+                     "links": [{"label": "OGC API - Features", "url": "http://x/api/ogc",
+                                "hint": "QGIS: Add OGC API - Features Layer"}]}
+
+    def _delete_layer(self, method, match, query, headers, body):
+        if method != "DELETE":
+            return 405, {"detail": "Method Not Allowed"}
+        rows = self.vector_layers if match.group(1) == "vector" else self.raster_layers
+        target = int(match.group(2))
+        keep = [r for r in rows if r["id"] != target]
+        if len(keep) == len(rows):
+            return 404, {"detail": "Layer not found."}
+        rows[:] = keep
+        return 200, {"ok": True}
+
+    def _features(self, method, match, query, headers, body):
+        return 200, {"type": "FeatureCollection", "features": [
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [17.6, 59.8]},
+             "properties": {"id": 1}}]}
+
+    def _sources(self, method, match, query, headers, body):
+        if method == "POST":
+            payload = json.loads(body or b"{}")
+            source = dict(payload, id=5, kind="vector" if payload.get("source_type") == "wfs"
+                          else "raster", created_at="2026-01-01T00:00:00",
+                          visibility="organization", bbox=None, geometry_type=None)
+            return 200, source
+        return 200, [{"id": 5, "name": "OSM", "source_type": "xyz", "kind": "raster",
+                      "url": "https://tile/{z}/{x}/{y}.png", "visibility": "organization",
+                      "layer_name": None, "created_at": "2026-01-01T00:00:00"}]
+
+    def _portals(self, method, match, query, headers, body):
+        if method == "POST":
+            payload = json.loads(body or b"{}")
+            portal = {"id": 10 + len(self.portals), "title": payload.get("title"),
+                      "slug": (payload.get("title") or "portal").lower().replace(" ", "-"),
+                      "published": False, "access_type": payload.get("access_type", "public"),
+                      "template_id": payload.get("template_id", "minimal"),
+                      "description": payload.get("description"),
+                      "layer_configs": payload.get("layer_configs") or [],
+                      "layer_groups": None,
+                      "layout_config": payload.get("layout_config"),
+                      "created_at": "2026-01-01T00:00:00"}
+            self.portals.append(portal)
+            return 200, portal
+        return 200, self.portals
+
+    def _find_portal(self, portal_id):
+        for portal in self.portals:
+            if portal["id"] == int(portal_id):
+                return portal
+        return None
+
+    def _portal(self, method, match, query, headers, body):
+        portal = self._find_portal(match.group(1))
+        if portal is None:
+            return 404, {"detail": "Portal not found."}
+        if method == "PUT":
+            payload = json.loads(body or b"{}")
+            self.last_put = payload
+            portal.update(payload)
+            return 200, portal
+        if method == "DELETE":
+            self.portals.remove(portal)
+            return 200, {"ok": True}
+        return 200, portal
+
+    def _publish(self, method, match, query, headers, body):
+        portal = self._find_portal(match.group(1))
+        if portal is None:
+            return 404, {"detail": "Portal not found."}
+        portal["published"] = True
+        portal["published_at"] = "2026-08-11T10:00:00"
+        return 200, portal
+
+    def _unpublish(self, method, match, query, headers, body):
+        portal = self._find_portal(match.group(1))
+        portal["published"] = False
+        return 200, portal
+
+    # ── object storage ──────────────────────────────────────────────────────────────────────────
+
+    def _storage(self, method, path, query, headers, body):
+        """A presigned PUT target. Asserts the two things that go wrong in real life."""
+        if headers.get("authorization"):
+            # An Authorization header alongside a presigned signature makes S3 reject the request
+            # as doubly authenticated — the client must not send one here.
+            return 400, {"detail": "presigned URL must not carry an Authorization header"}
+        key = path[len("/s3/"):]
+        upload_id = (query.get("uploadId") or [None])[0]
+        if upload_id:
+            number = int((query.get("partNumber") or ["1"])[0])
+            record = self.multiparts.get(upload_id)
+            if record is None:
+                return 404, {"detail": "no such upload"}
+            record["parts"][number] = body or b""
+            return 200, b"", {"ETag": '"etag-{0}"'.format(number)}
+        self.uploads[key] = body or b""
+        return 200, b"", {"ETag": '"etag-single"'}
+
+    # ── helpers for tests ───────────────────────────────────────────────────────────────────────
+
+    def requests_to(self, path_fragment, method=None):
+        return [r for r in self.requests
+                if path_fragment in r["path"] and (method is None or r["method"] == method)]
+
+    def sent_authorization(self, path_fragment):
+        for request in self.requests_to(path_fragment):
+            return request["headers"].get("authorization")
+        return None
+
+
+def parse_multipart(content_type, body):
+    """Minimal multipart/form-data parser: `{field: value, "_files": {name: (filename, bytes)}}`."""
+    match = re.search(r"boundary=([^\s;]+)", content_type or "")
+    if not match:
+        return {}
+    boundary = ("--" + match.group(1)).encode()
+    out = {"_files": {}}
+    for part in body.split(boundary):
+        # Leading CRLF only: a trailing one may belong to the file's own last line.
+        while part.startswith(b"\r\n"):
+            part = part[2:]
+        if not part or part.startswith(b"--"):
+            continue
+        head, _, payload = part.partition(b"\r\n\r\n")
+        header_text = head.decode("utf-8", "replace")
+        name = re.search(r'name="([^"]+)"', header_text)
+        filename = re.search(r'filename="([^"]*)"', header_text)
+        if not name:
+            continue
+        # Strip EXACTLY the one CRLF that precedes the boundary — `rstrip` would eat a trailing
+        # newline that belongs to the uploaded file itself, which every CSV has.
+        if payload.endswith(b"\r\n"):
+            payload = payload[:-2]
+        if filename:
+            out["_files"][name.group(1)] = (filename.group(1), payload)
+        else:
+            out[name.group(1)] = payload.decode("utf-8", "replace")
+    return out
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+    def _run(self, method):
+        parsed = urlparse(self.path)
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        headers = {k.lower(): v for k, v in self.headers.items()}
+        result = self.server.instance.handle(method, parsed.path, parse_qs(parsed.query),
+                                             headers, body)
+        status, payload = result[0], result[1]
+        extra = result[2] if len(result) > 2 else {}
+        if isinstance(payload, (bytes, bytearray)):
+            data, ctype = bytes(payload), "application/octet-stream"
+        else:
+            data = json.dumps(payload).encode("utf-8")
+            ctype = "application/json"
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        for key, value in (extra or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+
+    do_GET = lambda self: self._run("GET")          # noqa: E731 - BaseHTTPRequestHandler protocol
+    do_POST = lambda self: self._run("POST")        # noqa: E731
+    do_PUT = lambda self: self._run("PUT")          # noqa: E731
+    do_DELETE = lambda self: self._run("DELETE")    # noqa: E731
+
+
+@pytest.fixture
+def instance():
+    return FakeInstance()
+
+
+@pytest.fixture
+def server(instance):
+    # Threading: the client uploads multipart parts in parallel, and a
+    # single-threaded server would serialise them into a stall.
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    httpd.instance = instance
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield "http://127.0.0.1:{0}".format(httpd.server_port)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def client(server):
+    from geodeploy import Client
+    return Client(server, token="gdp_test_token")
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """An isolated config directory, with the OS keyring switched off.
+
+    Both matter: a test must never read the developer's real profiles, and must never write a
+    secret into their login keychain.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("GEODEPLOY_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("GEODEPLOY_NO_KEYRING", "1")
+    monkeypatch.delenv("GEODEPLOY_URL", raising=False)
+    monkeypatch.delenv("GEODEPLOY_TOKEN", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    return config_dir
+
+
+@pytest.fixture
+def run(home, capsys):
+    """Invoke the CLI as a user would; returns (exit_code, stdout, stderr)."""
+    from geodeploy.cli.main import main
+
+    def invoke(*argv):
+        code = main(list(argv))
+        captured = capsys.readouterr()
+        return code, captured.out, captured.err
+    return invoke
+
+
+@pytest.fixture
+def logged_in(run, server, home):
+    """A configured profile pointing at the fake instance, using an API token."""
+    code, _, _ = run("login", server, "--token", "gdp_test_token", "--json")
+    assert code == 0
+    return server

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -34,6 +34,8 @@ class FakeInstance(object):
         self.multiparts = {}        # upload_id -> {key, parts:{n: bytes}, aborted: bool}
         self.jobs = {}              # job_id -> [status dicts to return, last one repeats]
         self.fail_next = None       # (status, detail) injected into the next API call
+        self.exports = {}           # export job id -> the bytes its download returns
+        self.public_index_enabled = True
         self.token_forbidden = set()  # path prefixes that reject token auth, like /admin
         self.vector_layers = [
             {"id": 1, "uid": "aaaaaaaaaaaa", "name": "roads", "layer_type": "vector",
@@ -118,6 +120,13 @@ class FakeInstance(object):
             (r"/data/(vector|raster)/(\d+)/links", self._links),
             (r"/data/(vector|raster)/(\d+)", self._delete_layer),
             (r"/data/vector/(\S+)/features", self._features),
+            (r"/data/raster/(\S+)/cog", lambda *a: (200, b"II-pretend-GeoTIFF-bytes")),
+            (r"/data/vector/(\S+)/pmtiles", lambda *a: (200, b"PMTiles pretend")),
+            (r"/public", self._public),
+            (r"/public/portals", self._public_portals),
+            (r"/data/(vector|raster)/(\S+)/export", self._export_start),
+            (r"/data/(vector|raster)/(\S+)/export-status/([\w-]+)", self._export_status),
+            (r"/data/(vector|raster)/(\S+)/export-download/([\w-]+)", self._export_download),
             (r"/data/vector/(\d+)/tile", lambda *a: (202, self._new_job(1, "vector"))),
             (r"/data/vector/(\d+)/reprocess", lambda *a: (202, self._new_job(1, "vector"))),
             (r"/data/sources", self._sources),
@@ -248,6 +257,60 @@ class FakeInstance(object):
         ]
         first = dict(self.jobs[job_id][0])
         return first
+
+    # ── the public index + per-layer export ─────────────────────────────────────────────────────
+
+    def _public(self, method, match, query, headers, body):
+        if not self.public_index_enabled:
+            return 404, {"detail": "This instance does not publish a public index."}
+        base = "http://127.0.0.1"
+        return 200, {
+            "geodeploy": {"url": base, "api": base + "/api"},
+            "counts": {"portals": 1, "postgis": 1, "geoparquet": 0, "raster": 1},
+            "portals": self._public_portal_rows(),
+            "layers": {
+                "postgis": [{"id": "aaaaaaaaaaaa", "name": "roads", "kind": "postgis",
+                             "geometry_type": "linestring", "feature_count": 1200,
+                             "crs": "EPSG:4326", "keywords": ["transport"], "license": "CC-BY-4.0",
+                             "links": [{"label": "OGC API - Features", "url": base + "/api/ogc"}],
+                             "download": base + "/api/data/vector/aaaaaaaaaaaa/export"}],
+                "geoparquet": [],
+                "raster": [{"id": "cccccccccccc", "name": "dem", "kind": "raster",
+                            "band_count": 1, "crs": "EPSG:3006", "keywords": [], "links": [],
+                            "download": base + "/api/data/raster/cccccccccccc/cog"}],
+            },
+            "catalogs": {"stac": base + "/api/stac", "ogc_features": base + "/api/ogc"},
+        }
+
+    def _public_portals(self, method, match, query, headers, body):
+        if not self.public_index_enabled:
+            return 404, {"detail": "This instance does not publish a public index."}
+        return 200, self._public_portal_rows()
+
+    def _public_portal_rows(self):
+        base = "http://127.0.0.1"
+        return [{"slug": "field-sites-2026", "title": "Field sites 2026", "experience": "webmap",
+                 "layer_count": 1, "url": base + "/portals/field-sites-2026/",
+                 "style_url": base + "/portals/field-sites-2026/style.json",
+                 "thumbnail_url": None, "published_at": "2026-08-01T00:00:00"}]
+
+    def _export_start(self, method, match, query, headers, body):
+        payload = json.loads(body or b"{}")
+        self.last_export = payload
+        if match.group(1) == "raster" and not payload.get("bbox"):
+            return 400, {"detail": "A raster export needs a bbox. … GET /api/data/raster/x/cog"}
+        job_id = uuid.uuid4().hex
+        self.exports[job_id] = b"PK pretend zip"
+        return 202, {"job_id": job_id}
+
+    def _export_status(self, method, match, query, headers, body):
+        return 200, {"status": "ready" if match.group(3) in self.exports else "queued"}
+
+    def _export_download(self, method, match, query, headers, body):
+        data = self.exports.get(match.group(3))
+        if data is None:
+            return 404, {"detail": "That export is not ready (or has been swept)."}
+        return 200, data
 
     def _field_stats(self, method, match, query, headers, body):
         field = (query.get("field") or [""])[0]

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -172,6 +172,13 @@ class TestLayerCommands:
         assert "roads" in out and "dem" in out
         assert "NAME" in out                       # a header, so the columns are readable
 
+    def test_the_listing_shows_the_stable_uid(self, run, logged_in):
+        """The integer is unique only within one kind and one database. If the listing shows only
+        that, people script with it — so the durable handle has to be on screen."""
+        code, out, err = run("layers", "list")
+        assert "UID" in out
+        assert "aaaaaaaaaaaa" in out and "cccccccccccc" in out
+
     def test_processing_layers_show_their_progress(self, run, logged_in):
         code, out, err = run("layers", "list")
         assert "42%" in out

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,0 +1,386 @@
+"""The command line itself: exit codes, --json, and the commands people will actually run."""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from geodeploy.cli.output import (EXIT_AUTH, EXIT_GENERIC, EXIT_NETWORK, EXIT_OK, EXIT_SERVER,
+                                  EXIT_USAGE)
+
+
+class TestExitCodes:
+    """The published matrix. A CI job branches on these long before it parses any output."""
+
+    def test_constants(self):
+        assert (EXIT_OK, EXIT_GENERIC, EXIT_USAGE, EXIT_AUTH, EXIT_NETWORK, EXIT_SERVER) == (
+            0, 1, 2, 3, 4, 5)
+
+    def test_no_command_prints_help_and_exits_usage(self, run):
+        code, out, err = run()
+        assert code == EXIT_USAGE
+        assert "geodeploy" in err
+
+    def test_group_without_a_subcommand_shows_that_group(self, run):
+        code, out, err = run("portals")
+        assert code == EXIT_USAGE
+        assert "publish" in err          # the group's own help, not the root's
+
+    def test_unknown_command_is_argparse_usage(self, run):
+        with pytest.raises(SystemExit) as caught:
+            run("nonsense")
+        assert caught.value.code == EXIT_USAGE
+
+    def test_not_logged_in_is_an_auth_failure_with_a_way_out(self, run):
+        code, out, err = run("whoami")
+        assert code == EXIT_AUTH
+        assert "geodeploy login" in err
+
+    def test_a_401_from_the_instance_is_auth(self, run, logged_in, instance):
+        instance.fail_next = (401, "Token has expired")
+        code, out, err = run("layers", "list")
+        assert code == EXIT_AUTH
+        assert "expired" in err
+
+    def test_a_403_names_the_missing_scope(self, run, logged_in, instance):
+        instance.fail_next = (403, "Token missing scope: data:write")
+        code, out, err = run("layers", "share", "roads", "--visibility", "public")
+        assert code == EXIT_AUTH
+        assert "data:write" in err
+
+    def test_a_500_is_a_server_error(self, run, logged_in, instance):
+        instance.fail_next = (500, "Internal Server Error")
+        code, out, err = run("layers", "list")
+        assert code == EXIT_SERVER
+
+    def test_an_unreachable_instance_is_a_network_error(self, run, home):
+        code, out, err = run("--url", "http://127.0.0.1:1", "--token", "gdp_x", "layers", "list")
+        assert code == EXIT_NETWORK
+        assert "127.0.0.1:1" in err       # name the host that failed, not just "connection error"
+
+    def test_a_404_is_a_plain_failure(self, run, logged_in):
+        code, out, err = run("portals", "show", "no-such-portal")
+        assert code == EXIT_GENERIC
+
+
+class TestGlobalFlags:
+    def test_json_is_accepted_after_the_subcommand(self, run, logged_in):
+        """Where people actually type it. Argparse alone only allows it before the subcommand."""
+        code, out, err = run("layers", "list", "--json")
+        assert code == EXIT_OK
+        assert isinstance(json.loads(out), list)
+
+    def test_json_is_also_accepted_before_the_subcommand(self, run, logged_in):
+        code, out, err = run("--json", "layers", "list")
+        assert code == EXIT_OK
+        json.loads(out)
+
+    def test_json_errors_are_json_on_stdout(self, run, logged_in, instance):
+        instance.fail_next = (500, "boom")
+        code, out, err = run("layers", "list", "--json")
+        payload = json.loads(out)
+        assert payload["ok"] is False and "boom" in payload["error"]
+
+    def test_quiet_keeps_stdout_and_drops_commentary(self, run, logged_in):
+        code, out, err = run("layers", "list", "--quiet")
+        assert code == EXIT_OK
+        assert err == ""
+
+    def test_verbose_logs_requests_to_stderr(self, run, logged_in):
+        code, out, err = run("layers", "list", "--verbose")
+        assert "GET" in err and "/api/data/vector" in err
+
+    def test_url_and_token_flags_need_no_config(self, run, home, server):
+        code, out, err = run("--url", server, "--token", "gdp_x", "whoami", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)["email"] == "k@example.org"
+
+    def test_environment_variables_are_honoured(self, run, home, server, monkeypatch):
+        monkeypatch.setenv("GEODEPLOY_URL", server)
+        monkeypatch.setenv("GEODEPLOY_TOKEN", "gdp_env")
+        code, out, err = run("whoami", "--json")
+        assert code == EXIT_OK
+
+
+class TestLoginAndProfiles:
+    def test_login_stores_a_profile_and_a_credential(self, run, server, home):
+        code, out, err = run("login", server, "--token", "gdp_test_token", "--json")
+        assert code == EXIT_OK
+        payload = json.loads(out)
+        assert payload["instance"] == server
+        assert payload["session"] is False        # no password was used
+        assert os.path.isfile(payload["stored"]) or payload["stored"] == "keyring"
+
+        code, out, _ = run("whoami", "--json")
+        assert json.loads(out)["credential"].startswith("API token")
+
+    def test_login_with_a_bad_token_does_not_save_anything(self, run, server, home, instance):
+        instance.fail_next = (401, "Invalid token")
+        code, out, err = run("login", server, "--token", "gdp_wrong")
+        assert code == EXIT_AUTH
+        code, out, err = run("profile", "list", "--json")
+        assert json.loads(out) == []
+
+    def test_password_login_stores_a_session_beside_the_token(self, run, server, home, monkeypatch):
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+        monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "correct-horse")
+        code, out, err = run("login", server, "--token", "gdp_test_token", "--password",
+                             "--email", "k@example.org", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)["session"] is True
+
+        from geodeploy import config as cfg
+        stored = cfg.load_credential(server)
+        assert stored["token"] == "gdp_test_token"     # the session did not displace the token
+        assert stored["jwt"].startswith("jwt-for-")
+
+    def test_a_wrong_password_fails_without_storing(self, run, server, home, monkeypatch):
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+        monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "wrong")
+        code, out, err = run("login", server, "--password", "--email", "k@example.org")
+        assert code == EXIT_AUTH
+        from geodeploy import config as cfg
+        assert cfg.load_credential(server) == {}
+
+    def test_logout_forgets_the_credential(self, run, logged_in):
+        code, out, err = run("logout", "--json")
+        assert json.loads(out)["forgotten"] is True
+        code, out, err = run("whoami")
+        assert code == EXIT_AUTH
+
+    def test_profile_show_says_where_each_setting_came_from(self, run, logged_in):
+        code, out, err = run("profile", "show", "--json")
+        payload = json.loads(out)
+        assert payload["instance_from"].startswith("profile:")
+        assert payload["credential_from"] == "stored"
+
+    def test_switching_profiles(self, run, logged_in, server):
+        run("login", server, "--token", "gdp_x", "--name", "staging", "--json")
+        code, out, _ = run("profile", "list", "--json")
+        names = {row["name"]: row["active"] for row in json.loads(out)}
+        assert names["staging"] is True
+        run("profile", "use", "127.0.0.1")
+        code, out, _ = run("profile", "list", "--json")
+        assert {r["name"]: r["active"] for r in json.loads(out)}["127.0.0.1"] is True
+
+
+class TestLayerCommands:
+    def test_list_as_a_table(self, run, logged_in):
+        code, out, err = run("layers", "list")
+        assert code == EXIT_OK
+        assert "roads" in out and "dem" in out
+        assert "NAME" in out                       # a header, so the columns are readable
+
+    def test_processing_layers_show_their_progress(self, run, logged_in):
+        code, out, err = run("layers", "list")
+        assert "42%" in out
+
+    def test_filtering_by_type(self, run, logged_in):
+        code, out, err = run("layers", "list", "--type", "raster", "--json")
+        rows = json.loads(out)
+        assert [r["name"] for r in rows] == ["dem"]
+
+    def test_show_accepts_a_name(self, run, logged_in):
+        code, out, err = run("layers", "show", "roads", "--json")
+        assert json.loads(out)["id"] == 1
+
+    def test_share_reports_what_it_opened_up(self, run, logged_in):
+        code, out, err = run("layers", "share", "roads", "--visibility", "public")
+        assert code == EXIT_OK
+        assert "STAC" in err
+
+    def test_style_saves_a_default_style(self, run, logged_in, instance):
+        code, out, err = run("layers", "style", "roads", "--color", "#e11d48", "--marker", "star")
+        assert code == EXIT_OK
+        body = json.loads(instance.requests_to("/default-style", "PUT")[0]["body"])
+        assert body["style"]["color"] == "#e11d48"
+        assert body["style"]["marker"] == "star"
+
+    def test_style_classification_goes_through_the_server(self, run, logged_in, instance):
+        code, out, err = run("layers", "style", "roads", "--color-field", "pop", "--classify",
+                             "--classes", "3")
+        assert code == EXIT_OK
+        body = json.loads(instance.requests_to("/default-style", "PUT")[0]["body"])
+        assert body["style"]["color_mode"] == "graduated"
+        assert len(body["style"]["classes"]) == 3
+
+    def test_classify_without_a_field_is_refused(self, run, logged_in):
+        code, out, err = run("layers", "style", "roads", "--classify")
+        assert code == EXIT_USAGE
+        assert "--color-field" in err
+
+    def test_an_invalid_marker_never_reaches_the_api(self, run, logged_in, instance):
+        with pytest.raises(SystemExit):
+            run("layers", "style", "roads", "--marker", "hexagon")
+        assert not instance.requests_to("/default-style", "PUT")
+
+    def test_delete_refuses_without_yes_when_not_a_terminal(self, run, logged_in, instance):
+        code, out, err = run("layers", "delete", "roads")
+        assert code == EXIT_GENERIC
+        assert not instance.requests_to("/data/vector/1", "DELETE")
+
+    def test_delete_with_yes(self, run, logged_in, instance):
+        code, out, err = run("layers", "delete", "roads", "--yes")
+        assert code == EXIT_OK
+        assert instance.requests_to("/data/vector/1", "DELETE")
+
+    def test_links_warns_when_the_layer_is_not_public(self, run, logged_in):
+        code, out, err = run("layers", "links", "roads")
+        assert "not public" in err
+
+    def test_rename(self, run, logged_in, instance):
+        code, out, err = run("layers", "rename", "roads", "Main roads")
+        assert code == EXIT_OK
+        assert json.loads(instance.requests_to("/rename", "PUT")[0]["body"])["name"] == "Main roads"
+
+
+class TestUploadCommand:
+    def test_dry_run_explains_the_route_and_sends_nothing(self, run, logged_in, instance, tmp_path):
+        path = tmp_path / "roads.gpkg"
+        path.write_bytes(b"x" * 100)
+        code, out, err = run("upload", str(path), "--dry-run", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)[0]["route"] == "vector-api"
+        assert not instance.requests_to("/data/vector/upload", "POST")
+
+    def test_several_files_at_once(self, run, logged_in, instance, tmp_path):
+        paths = []
+        for name in ("a.gpkg", "b.geojson", "c.tif"):
+            path = tmp_path / name
+            path.write_bytes(b"x" * 50)
+            paths.append(str(path))
+        code, out, err = run("upload", *paths + ["--json"])
+        assert code == EXIT_OK
+        payload = json.loads(out)
+        assert payload["ok"] is True and len(payload["uploaded"]) == 3
+        assert len(instance.requests_to("/upload", "POST")) == 3
+
+    def test_a_guessed_csv_geometry_is_announced(self, run, logged_in, tmp_path):
+        path = tmp_path / "sites.csv"
+        path.write_text("lon,lat\n17.6,59.8\n", encoding="utf-8")
+        code, out, err = run("upload", str(path))
+        assert code == EXIT_OK
+        assert "guessed geometry" in err
+
+    def test_an_unsupported_file_stops_the_batch_before_anything_uploads(self, run, logged_in,
+                                                                         instance, tmp_path):
+        """Every file is planned first, so a typo in the last argument does not leave half a batch
+        uploaded. An unsupported extension is the CLI rejecting the command line: exit 2."""
+        good = tmp_path / "a.gpkg"
+        good.write_bytes(b"x" * 10)
+        bad = tmp_path / "b.txt"
+        bad.write_bytes(b"x")
+        code, out, err = run("upload", str(good), str(bad))
+        assert code == EXIT_USAGE
+        assert "Unsupported file type" in err
+        assert not instance.requests_to("/data/vector/upload", "POST")
+
+    def test_name_with_several_files_is_refused(self, run, logged_in, tmp_path):
+        paths = []
+        for name in ("a.gpkg", "b.gpkg"):
+            path = tmp_path / name
+            path.write_bytes(b"x")
+            paths.append(str(path))
+        code, out, err = run("upload", *paths + ["--name", "One"])
+        assert code == EXIT_GENERIC
+
+
+class TestPortalCommands:
+    def test_list(self, run, logged_in):
+        code, out, err = run("portals", "list")
+        assert "Field sites 2026" in out
+
+    def test_create_and_publish(self, run, logged_in):
+        code, out, err = run("portals", "create", "New portal", "--json")
+        assert code == EXIT_OK
+        portal_id = json.loads(out)["id"]
+        code, out, err = run("portals", "publish", str(portal_id), "--json")
+        assert json.loads(out)["published"] is True
+
+    def test_add_layer_by_name_with_styling(self, run, logged_in, instance):
+        code, out, err = run("portals", "add-layer", "3", "dem", "--type", "raster",
+                             "--colormap", "viridis", "--rescale", "0,2400", "--bottom")
+        assert code == EXIT_OK
+        configs = json.loads(instance.requests_to("/portals/3", "PUT")[0]["body"])["layer_configs"]
+        assert configs[-1]["layer_type"] == "raster"
+        assert configs[-1]["style"] == {"colormap": "viridis", "rescale": "0,2400"}
+
+    def test_add_layer_inherits_the_layer_default_style(self, run, logged_in, instance):
+        """With no styling flags, a layer arrives on a portal looking like it does everywhere else."""
+        code, out, _ = run("portals", "create", "Second", "--json")
+        portal_id = json.loads(out)["id"]
+        code, out, err = run("portals", "add-layer", str(portal_id), "roads")
+        assert code == EXIT_OK
+        put = instance.requests_to("/portals/{0}".format(portal_id), "PUT")[0]
+        configs = json.loads(put["body"])["layer_configs"]
+        assert configs[0]["style"] == {"color": "#3b82f6"}
+
+    def test_a_draft_edit_says_it_is_not_live(self, run, logged_in):
+        code, out, err = run("portals", "set-description", "3", "About this map")
+        assert "still shows the previous version" in err
+
+    def test_publish_flag_publishes_in_one_step(self, run, logged_in, instance):
+        code, out, err = run("portals", "add-layer", "3", "dem", "--type", "raster", "--publish")
+        assert instance.requests_to("/portals/3/publish", "POST")
+
+    def test_style_on_a_portal_merges(self, run, logged_in, instance):
+        code, out, err = run("portals", "style", "3", "roads", "--radius", "8")
+        style = json.loads(instance.requests_to("/portals/3", "PUT")[0]["body"])
+        assert style["layer_configs"][0]["style"] == {"color": "#3b82f6", "radius": 8.0}
+
+    def test_export_writes_utf8_json_that_import_can_read_back(self, run, logged_in, tmp_path):
+        out_path = tmp_path / "portal3.json"
+        code, out, err = run("portals", "export", "3", str(out_path))
+        assert code == EXIT_OK
+        # UTF-8 without a BOM: PowerShell's `>` writes UTF-16, which import could not read.
+        raw = open(str(out_path), "rb").read()
+        assert not raw.startswith(b"\xef\xbb\xbf")
+        json.loads(raw.decode("utf-8"))
+
+        code, out, err = run("portals", "import", "3", str(out_path))
+        assert code == EXIT_OK
+
+    def test_layers_table_shows_the_draw_order(self, run, logged_in):
+        code, out, err = run("portals", "layers", "3")
+        assert "roads" in out
+        assert "top of the layer list" in err
+
+    def test_url(self, run, logged_in, server):
+        code, out, err = run("portals", "url", "3")
+        assert out.strip() == "{0}/portals/field-sites-2026/".format(server)
+
+
+class TestAdminAndCatalog:
+    def test_admin_needs_a_session_and_says_so(self, run, logged_in, instance):
+        instance.token_forbidden.add("/admin")
+        code, out, err = run("admin", "health")
+        assert code == EXIT_AUTH
+        assert "session-only" in err
+        assert "login --password" in err
+
+    def test_admin_works_with_a_session(self, run, server, home, instance, monkeypatch):
+        instance.token_forbidden.add("/admin")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+        monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "correct-horse")
+        run("login", server, "--password", "--email", "k@example.org", "--json")
+        code, out, err = run("admin", "health", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)[0]["name"] == "api"
+
+    def test_storage_reports_unmeasured_as_unmeasured_not_zero(self, run, logged_in):
+        code, out, err = run("admin", "storage")
+        assert "not measured" in out          # raster_bytes is null in the fixture
+
+    def test_catalog_needs_no_credential(self, run, home, server):
+        code, out, err = run("--url", server, "catalog", "collections", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)[0]["id"] == "vector-aaaaaaaaaaaa"
+
+    def test_templates(self, run, logged_in):
+        code, out, err = run("catalog", "templates")
+        assert "minimal" in out
+
+    def test_users_list_works_with_a_token(self, run, logged_in):
+        code, out, err = run("users", "list", "--json")
+        assert json.loads(out)[0]["role"] == "owner"

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -437,8 +437,24 @@ class TestBrowseAPortal:
         code, out, err = run("browse", "--portal", server + "/portals/field-sites-2026/")
         assert code == EXIT_OK
         assert "Field sites 2026" in out
-        assert "roads" in out
+        assert "Roads" in out
         assert "basemap" not in out          # the template's own layer, not the author's data
+
+    def test_layers_are_named_the_way_the_portal_names_them(self, run, home, server):
+        code, out, err = run("browse", "--portal", "field-sites-2026", "--url", server)
+        assert "Roads" in out and "Plots" in out and "DEM" in out
+        assert "Trees" in out                       # a GeoParquet layer, drawn by deck.gl
+        assert out.count("Plots") == 1              # not once per MapLibre layer it is drawn with
+        assert "vector-3-outline" not in out        # …and its outline is not a layer of its own
+
+    def test_a_layer_that_starts_switched_off_says_so(self, run, home, server):
+        code, out, err = run("browse", "--portal", "field-sites-2026", "--url", server)
+        assert "VISIBLE" in out.upper()
+
+    def test_links_prints_the_url_behind_each_layer(self, run, home, server):
+        code, out, err = run("browse", "--portal", "field-sites-2026", "--url", server, "--links")
+        assert "/tiles/vector_1/{z}/{x}/{y}.pbf" in out
+        assert "/data/trees.parquet" in out
 
     def test_the_url_alone_is_enough_as_the_positional(self, run, home, server):
         code, out, err = run("browse", server + "/portals/field-sites-2026/style.json")

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -462,3 +462,33 @@ class TestLayerDownload:
         code, out, err = run("--url", server, "layers", "download", "roads", "-o", str(target))
         assert code == EXIT_OK
         assert target.exists()
+
+
+class TestPublicListingToggle:
+    """The switch that decides whether `browse` finds anything — reachable from the CLI, not only
+    from the API, because an operator should never have to reach for curl."""
+
+    def test_it_reports_the_current_state(self, run, logged_in):
+        code, out, err = run("admin", "public-index", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out) == {"enabled": True}
+
+    def test_turning_it_off_and_on(self, run, logged_in, instance):
+        run("admin", "public-index", "--off")
+        assert instance.public_index_enabled is False
+        code, out, err = run("browse")
+        assert code == EXIT_GENERIC          # the index is gone…
+        code, out, err = run("portals", "list")
+        assert code == EXIT_OK               # …but the instance is unaffected
+
+        run("admin", "public-index", "--on")
+        assert instance.public_index_enabled is True
+
+    def test_it_explains_what_off_means(self, run, logged_in):
+        code, out, err = run("admin", "public-index", "--off")
+        assert "reachable by their links" in err
+
+    def test_on_and_off_together_is_a_usage_error(self, run, logged_in):
+        with pytest.raises(SystemExit) as caught:
+            run("admin", "public-index", "--on", "--off")
+        assert caught.value.code == EXIT_USAGE

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -511,6 +511,78 @@ class TestLayerDownload:
         assert target.exists()
 
 
+class TestTruncatedExport:
+    """A capped export looks exactly like a complete one. The command must not let that pass."""
+
+    def test_it_fails_loudly_when_the_server_reports_a_cap(self, run, logged_in, instance,
+                                                           tmp_path):
+        instance.export_truncated = [{"file": "roads.gpkg", "rows": 1000000, "cap": 1000000}]
+        code, out, err = run("layers", "download", "roads", "-o", str(tmp_path / "roads.zip"))
+        assert code == EXIT_GENERIC              # a script must be able to notice
+        assert "INCOMPLETE" in err
+        assert "1,000,000" in err
+        assert (tmp_path / "roads.zip").exists()  # the partial file is still written, not hidden
+
+    def test_it_points_at_the_uncapped_route(self, run, logged_in, instance, tmp_path):
+        instance.export_truncated = [{"file": "roads.gpkg", "rows": 1000000, "cap": 1000000}]
+        code, out, err = run("layers", "download", "roads", "-o", str(tmp_path / "roads.zip"))
+        assert "OAPIF:" in err and "ogr2ogr" in err
+
+    def test_json_mode_carries_the_report(self, run, logged_in, instance, tmp_path):
+        instance.export_truncated = [{"file": "roads.gpkg", "rows": 1000000, "cap": 1000000}]
+        code, out, err = run("layers", "download", "roads", "-o", str(tmp_path / "roads.zip"),
+                             "--json")
+        assert json.loads(out)["truncated"][0]["file"] == "roads.gpkg"
+
+    def test_an_untruncated_export_says_nothing_of_the_sort(self, run, logged_in, tmp_path):
+        code, out, err = run("layers", "download", "roads", "-o", str(tmp_path / "roads.zip"))
+        assert code == EXIT_OK
+        assert "INCOMPLETE" not in err
+
+
+class TestGeoParquetDirectDownload:
+    """A prepared GeoParquet layer already exists as files. Rebuilding it through the worker is
+    slower, lossy at the row cap, and pointless."""
+
+    def test_it_reads_the_stored_files_instead_of_queueing_an_export(self, run, logged_in,
+                                                                     instance, tmp_path):
+        target = tmp_path / "parcels"
+        code, out, err = run("layers", "download", "parcels", "-o", str(target))
+        assert code == EXIT_OK
+        assert instance.last_export is None, "no export job should have been queued"
+        assert (target / "manifest.json").exists()
+        assert (target / "__cell=0" / "part0.parquet").read_bytes().startswith(b"PAR1")
+        assert (target / "__cell=1" / "part0.parquet").exists()
+
+    def test_it_says_how_to_read_what_it_wrote(self, run, logged_in, tmp_path):
+        code, out, err = run("layers", "download", "parcels", "-o", str(tmp_path / "p"))
+        assert "read_parquet" in err
+        assert "2,400,000 features" in err
+
+    def test_json_mode_reports_the_directory(self, run, logged_in, tmp_path):
+        code, out, err = run("layers", "download", "parcels", "-o", str(tmp_path / "p"), "--json")
+        payload = json.loads(out)
+        assert payload["files"] == 2 and payload["format"] == "geoparquet"
+        assert payload["truncated"] == []
+
+    def test_a_bbox_still_goes_through_the_export_job(self, run, logged_in, instance, tmp_path):
+        """A clip is real work — only the WHOLE layer is already a file."""
+        run("layers", "download", "parcels", "--bbox", "11,55,12,56",
+            "-o", str(tmp_path / "p.zip"), "--format", "geoparquet")
+        assert instance.last_export["bbox"] == "11,55,12,56"
+
+    def test_a_postgis_layer_is_unaffected(self, run, logged_in, instance, tmp_path):
+        code, out, err = run("layers", "download", "roads", "-o", str(tmp_path / "roads.zip"))
+        assert instance.last_export["format"] == "gpkg"
+
+    def test_a_geoparquet_layer_without_a_manifest_falls_back_to_the_export(self, run, logged_in,
+                                                                           instance, tmp_path):
+        instance.PARQUET = set()          # e.g. a single .parquet uploaded as-is
+        code, out, err = run("layers", "download", "parcels", "-o", str(tmp_path / "p.zip"))
+        assert code == EXIT_OK
+        assert instance.last_export is not None
+
+
 class TestPublicListingToggle:
     """The switch that decides whether `browse` finds anything — reachable from the CLI, not only
     from the API, because an operator should never have to reach for curl."""

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -430,6 +430,37 @@ class TestBrowse:
         assert "Vector (PostGIS)" not in out
 
 
+class TestBrowseAPortal:
+    """A portal URL names its own instance. Pasting one must not also require --url or a login."""
+
+    def test_a_pasted_portal_url_needs_nothing_else(self, run, home, server):
+        code, out, err = run("browse", "--portal", server + "/portals/field-sites-2026/")
+        assert code == EXIT_OK
+        assert "Field sites 2026" in out
+        assert "roads" in out
+        assert "basemap" not in out          # the template's own layer, not the author's data
+
+    def test_the_url_alone_is_enough_as_the_positional(self, run, home, server):
+        code, out, err = run("browse", server + "/portals/field-sites-2026/style.json")
+        assert code == EXIT_OK
+        assert "Field sites 2026" in out
+
+    def test_a_slug_still_works_against_the_active_profile(self, run, logged_in):
+        code, out, err = run("browse", "--portal", "field-sites-2026")
+        assert code == EXIT_OK
+        assert "Field sites 2026" in out
+
+    def test_an_unknown_portal_explains_itself(self, run, home, server):
+        code, out, err = run("browse", "--portal", server + "/portals/nope/")
+        assert code == EXIT_GENERIC
+        assert "Public portals only" in err
+
+    def test_a_url_that_is_not_a_portal_is_a_usage_error(self, run, home, server):
+        code, out, err = run("browse", "--portal", "https://gd.example.org/layers/roads")
+        assert code != EXIT_OK
+        assert "does not look like a portal URL" in err
+
+
 class TestLayerDownload:
     def test_a_vector_layer_defaults_to_a_built_geopackage(self, run, logged_in, instance,
                                                            tmp_path):

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -384,3 +384,81 @@ class TestAdminAndCatalog:
     def test_users_list_works_with_a_token(self, run, logged_in):
         code, out, err = run("users", "list", "--json")
         assert json.loads(out)[0]["role"] == "owner"
+
+
+class TestBrowse:
+    """The anonymous entry point: paste a URL, see what is there. No credential involved."""
+
+    def test_needs_no_credential_at_all(self, run, home, server):
+        code, out, err = run("browse", server)
+        assert code == EXIT_OK
+        assert "Field sites 2026" in out          # the public portal
+        assert "roads" in out and "dem" in out    # public layers, by kind
+
+    def test_it_groups_layers_by_storage_kind(self, run, home, server):
+        code, out, err = run("browse", server)
+        assert "Vector (PostGIS)" in out
+        assert "Raster (COG)" in out
+
+    def test_json_is_the_index_itself(self, run, home, server):
+        code, out, err = run("browse", server, "--json")
+        payload = json.loads(out)
+        assert set(payload["layers"]) == {"postgis", "geoparquet", "raster"}
+        assert payload["portals"][0]["slug"] == "field-sites-2026"
+
+    def test_it_uses_the_active_profile_when_no_url_is_given(self, run, logged_in):
+        code, out, err = run("browse")
+        assert code == EXIT_OK
+
+    def test_with_a_token_it_also_reports_the_private_view(self, run, logged_in):
+        code, out, err = run("browse")
+        assert "With your token" in err
+
+    def test_without_one_it_says_the_view_is_anonymous(self, run, home, server):
+        code, out, err = run("browse", server)
+        assert "anonymous view" in err
+
+    def test_an_instance_with_the_index_off_explains_itself(self, run, home, server, instance):
+        instance.public_index_enabled = False
+        code, out, err = run("browse", server)
+        assert code == EXIT_GENERIC
+        assert "does not publish a public index" in err
+
+    def test_filtering_to_one_kind(self, run, home, server):
+        code, out, err = run("browse", server, "--kind", "raster")
+        assert "Raster (COG)" in out
+        assert "Vector (PostGIS)" not in out
+
+
+class TestLayerDownload:
+    def test_a_vector_layer_defaults_to_a_built_geopackage(self, run, logged_in, instance,
+                                                           tmp_path):
+        target = tmp_path / "roads.zip"
+        code, out, err = run("layers", "download", "roads", "-o", str(target))
+        assert code == EXIT_OK
+        assert instance.last_export["format"] == "gpkg"
+        assert "bbox" not in instance.last_export       # whole layer, not a clip
+        assert target.read_bytes().startswith(b"PK")
+
+    def test_a_bbox_and_a_native_crs_are_passed_through(self, run, logged_in, instance, tmp_path):
+        run("layers", "download", "roads", "-o", str(tmp_path / "x.zip"),
+            "--format", "csv", "--bbox", "11,55,12,56", "--crs", "native")
+        assert instance.last_export == {"format": "csv", "bbox": "11,55,12,56",
+                                        "target_crs": "native"}
+
+    def test_a_raster_defaults_to_its_cog(self, run, logged_in, instance, tmp_path):
+        target = tmp_path / "dem.tif"
+        code, out, err = run("layers", "download", "dem", "--type", "raster", "-o", str(target))
+        assert code == EXIT_OK
+        assert instance.requests_to("/cog"), "the stored file should stream, not be rebuilt"
+
+    def test_asking_for_a_cog_from_a_vector_layer_is_refused(self, run, logged_in, tmp_path):
+        code, out, err = run("layers", "download", "roads", "--format", "cog",
+                             "-o", str(tmp_path / "x.tif"))
+        assert code == EXIT_GENERIC
+
+    def test_a_public_layer_downloads_without_a_token(self, run, home, server, tmp_path):
+        target = tmp_path / "roads.zip"
+        code, out, err = run("--url", server, "layers", "download", "roads", "-o", str(target))
+        assert code == EXIT_OK
+        assert target.exists()

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -1,0 +1,195 @@
+"""Profiles, credentials and how a command decides which instance it is talking to."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+from geodeploy import config as cfg
+from geodeploy.errors import ConfigError
+
+
+class TestNormalizeUrl:
+    """One instance must have ONE spelling, or a token saved under one is invisible to the other."""
+
+    @pytest.mark.parametrize("given", [
+        "https://gd.example.org",
+        "https://gd.example.org/",
+        "https://gd.example.org/api",
+        "https://gd.example.org/api/",
+        "https://gd.example.org/api/docs",
+        "https://gd.example.org/api/openapi.json",
+    ])
+    def test_variants_collapse_to_one_origin(self, given):
+        assert cfg.normalize_url(given) == "https://gd.example.org"
+
+    def test_bare_host_defaults_to_https(self):
+        # The wrong guess is a TLS error the user can read; defaulting to http would put their
+        # token on the wire in clear.
+        assert cfg.normalize_url("gd.example.org") == "https://gd.example.org"
+
+    def test_port_and_http_are_kept(self):
+        assert cfg.normalize_url("http://127.0.0.1:8080/") == "http://127.0.0.1:8080"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "ftp://gd.example.org", "https://"])
+    def test_rejects_unusable(self, bad):
+        with pytest.raises(ConfigError):
+            cfg.normalize_url(bad)
+
+
+class TestProfiles:
+    def test_round_trip(self, home):
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org/api/", email="k@example.org")
+        config.save()
+
+        reloaded = cfg.Config.load()
+        assert reloaded.current == "prod"
+        assert reloaded.get()["url"] == "https://gd.example.org"
+        assert reloaded.get()["email"] == "k@example.org"
+
+    def test_second_profile_becomes_current_and_removal_falls_back(self, home):
+        config = cfg.Config.load()
+        config.set_profile("a", "https://a.example.org")
+        config.set_profile("b", "https://b.example.org")
+        assert config.current == "b"
+        config.remove_profile("b")
+        assert config.current == "a"
+
+    def test_unknown_profile_is_an_error_not_a_silent_default(self, home):
+        config = cfg.Config.load()
+        config.set_profile("a", "https://a.example.org")
+        with pytest.raises(ConfigError):
+            config.resolve_name("nope")
+
+    def test_config_file_never_contains_a_token(self, home):
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org")
+        config.save()
+        cfg.save_credential("https://gd.example.org", token="gdp_secret")
+        assert "gdp_secret" not in open(cfg.config_path(), encoding="utf-8").read()
+
+
+class TestCredentials:
+    def test_token_and_session_live_side_by_side(self, home):
+        cfg.save_credential("https://gd.example.org", token="gdp_abc")
+        cfg.save_credential("https://gd.example.org", jwt="jwt-xyz", email="k@example.org")
+        stored = cfg.load_credential("https://gd.example.org")
+        assert stored["token"] == "gdp_abc"      # storing a session must not drop the token
+        assert stored["jwt"] == "jwt-xyz"
+        assert stored["email"] == "k@example.org"
+
+    def test_spelling_variants_share_one_credential(self, home):
+        cfg.save_credential("https://gd.example.org/api/", token="gdp_abc")
+        assert cfg.load_token("gd.example.org") == "gdp_abc"
+
+    def test_delete_session_only_keeps_the_token(self, home):
+        cfg.save_credential("https://gd.example.org", token="gdp_abc", jwt="jwt-xyz")
+        assert cfg.delete_token("https://gd.example.org", "jwt") is True
+        stored = cfg.load_credential("https://gd.example.org")
+        assert stored.get("token") == "gdp_abc"
+        assert "jwt" not in stored
+
+    def test_delete_removes_everything(self, home):
+        cfg.save_credential("https://gd.example.org", token="gdp_abc")
+        assert cfg.delete_token("https://gd.example.org") is True
+        assert cfg.load_credential("https://gd.example.org") == {}
+
+    def test_legacy_bare_string_is_still_readable(self, home, monkeypatch):
+        """Pre-1.3 entries stored the raw token; reading one must not look like "not logged in"."""
+        class FakeKeyring:
+            @staticmethod
+            def get_password(service, key):
+                return "gdp_legacy"
+        monkeypatch.delenv("GEODEPLOY_NO_KEYRING")
+        monkeypatch.setattr(cfg, "_keyring", lambda: FakeKeyring)
+        assert cfg.load_credential("https://gd.example.org")["token"] == "gdp_legacy"
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX file modes")
+    def test_credentials_file_is_not_world_readable(self, home):
+        cfg.save_credential("https://gd.example.org", token="gdp_abc")
+        mode = stat.S_IMODE(os.stat(cfg.credentials_path()).st_mode)
+        assert mode == 0o600
+        assert stat.S_IMODE(os.stat(os.path.dirname(cfg.credentials_path())).st_mode) == 0o700
+
+    def test_write_is_atomic_and_leaves_no_temp_files(self, home):
+        cfg.save_credential("https://gd.example.org", token="gdp_abc")
+        cfg.save_credential("https://gd.example.org", token="gdp_def")
+        leftovers = [f for f in os.listdir(cfg.config_dir()) if f.endswith(".tmp")]
+        assert leftovers == []
+        assert cfg.load_token("https://gd.example.org") == "gdp_def"
+
+    def test_unreadable_config_is_reported_not_ignored(self, home):
+        os.makedirs(cfg.config_dir(), exist_ok=True)
+        with open(cfg.config_path(), "w", encoding="utf-8") as fh:
+            fh.write("{ not json")
+        with pytest.raises(ConfigError):
+            cfg.Config.load()
+
+    def test_bom_written_by_a_windows_editor_is_tolerated(self, home):
+        os.makedirs(cfg.config_dir(), exist_ok=True)
+        with open(cfg.config_path(), "w", encoding="utf-8-sig") as fh:
+            json.dump({"current": "prod", "profiles": {"prod": {"url": "https://gd.example.org"}}},
+                      fh)
+        assert cfg.Config.load().get()["url"] == "https://gd.example.org"
+
+
+class TestResolution:
+    """Flags beat the environment, which beats the active profile — for URL and token separately."""
+
+    def test_profile_is_the_baseline(self, home):
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org")
+        config.save()
+        cfg.save_credential("https://gd.example.org", token="gdp_stored")
+
+        resolved = cfg.resolve()
+        assert (resolved.url, resolved.token) == ("https://gd.example.org", "gdp_stored")
+        assert resolved.source_url == "profile:prod"
+        assert resolved.source_token == "stored"
+
+    def test_environment_overrides_the_profile(self, home, monkeypatch):
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org")
+        config.save()
+        monkeypatch.setenv("GEODEPLOY_URL", "https://staging.example.org")
+        monkeypatch.setenv("GEODEPLOY_TOKEN", "gdp_env")
+
+        resolved = cfg.resolve()
+        assert resolved.url == "https://staging.example.org"
+        assert resolved.token == "gdp_env"
+        assert resolved.source_token == "env"
+
+    def test_flags_override_everything(self, home, monkeypatch):
+        monkeypatch.setenv("GEODEPLOY_URL", "https://staging.example.org")
+        monkeypatch.setenv("GEODEPLOY_TOKEN", "gdp_env")
+        resolved = cfg.resolve(url="https://other.example.org", token="gdp_flag")
+        assert (resolved.url, resolved.token) == ("https://other.example.org", "gdp_flag")
+        assert resolved.source_url == "flag" and resolved.source_token == "flag"
+
+    def test_url_and_token_resolve_independently(self, home, monkeypatch):
+        """A token in the environment with the profile's URL is a normal thing to do."""
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org")
+        config.save()
+        monkeypatch.setenv("GEODEPLOY_TOKEN", "gdp_env")
+        resolved = cfg.resolve()
+        assert resolved.url == "https://gd.example.org"
+        assert resolved.token == "gdp_env"
+
+    def test_session_is_offered_when_there_is_no_token(self, home):
+        config = cfg.Config.load()
+        config.set_profile("prod", "https://gd.example.org")
+        config.save()
+        cfg.save_credential("https://gd.example.org", jwt="jwt-xyz")
+        resolved = cfg.resolve()
+        assert resolved.token is None
+        assert resolved.jwt == "jwt-xyz"
+
+    def test_nothing_configured_is_not_an_exception(self, home):
+        resolved = cfg.resolve()
+        assert resolved.url is None and resolved.token is None
+        assert resolved.source_url == "none"

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -40,6 +40,33 @@ class TestNormalizeUrl:
             cfg.normalize_url(bad)
 
 
+class TestSplitPortalUrl:
+    """People copy the whole URL out of the address bar. That has to be an accepted input."""
+
+    @pytest.mark.parametrize("given", [
+        "https://gd.example.org/portals/5b5c627cfd/",
+        "https://gd.example.org/portals/5b5c627cfd",
+        "https://gd.example.org/portals/5b5c627cfd/style.json",
+        "https://gd.example.org/portals/5b5c627cfd/index.html",
+        "gd.example.org/portals/5b5c627cfd/",
+    ])
+    def test_a_portal_url_yields_both_halves(self, given):
+        assert cfg.split_portal_url(given) == ("https://gd.example.org", "5b5c627cfd")
+
+    def test_a_bare_slug_names_no_instance(self):
+        assert cfg.split_portal_url("field-sites-2026") == (None, "field-sites-2026")
+
+    def test_a_subpath_deployment_keeps_its_prefix(self):
+        assert cfg.split_portal_url("https://example.org/gis/portals/abc") == (
+            "https://example.org/gis", "abc")
+
+    @pytest.mark.parametrize("bad", ["", "   ", "https://gd.example.org/layers/roads",
+                                     "https://gd.example.org/portals/"])
+    def test_rejects_what_is_not_a_portal(self, bad):
+        with pytest.raises(ConfigError):
+            cfg.split_portal_url(bad)
+
+
 class TestProfiles:
     def test_round_trip(self, home):
         config = cfg.Config.load()

--- a/cli/tests/test_layers_portals.py
+++ b/cli/tests/test_layers_portals.py
@@ -1,0 +1,190 @@
+"""Layer resolution and portal editing — the library behaviour the QGIS plugin will lean on."""
+from __future__ import annotations
+
+import pytest
+
+from geodeploy.errors import NotFoundError, ValidationError
+from geodeploy.portals import editable_config
+
+
+class TestLayerResolution:
+    """A layer can be named by id, uid or name. Ambiguity is an error, never a silent pick."""
+
+    def test_by_integer_id(self, client):
+        assert client.layers.resolve(1)["name"] == "roads"
+
+    def test_by_stable_uid(self, client):
+        # uid, not the integer id, is what public URLs use: SQLite reuses a deleted row's id, so a
+        # bookmarked integer can come back as a DIFFERENT dataset.
+        assert client.layers.resolve("aaaaaaaaaaaa")["name"] == "roads"
+
+    def test_by_prefixed_reference(self, client):
+        assert client.layers.resolve("raster-1")["name"] == "dem"
+        assert client.layers.resolve("vector-1")["name"] == "roads"
+
+    def test_by_exact_name(self, client):
+        assert client.layers.resolve("roads")["id"] == 1
+
+    def test_by_case_insensitive_name(self, client):
+        assert client.layers.resolve("ROADS")["id"] == 1
+
+    def test_by_unique_substring(self, client):
+        assert client.layers.resolve("field")["id"] == 2
+
+    def test_kind_disambiguates_a_shared_name(self, client, instance):
+        instance.raster_layers.append(dict(instance.raster_layers[0], id=2, uid="d" * 12,
+                                           name="roads"))
+        with pytest.raises(ValidationError) as caught:
+            client.layers.resolve("roads")
+        assert "several layers" in str(caught.value)
+        assert client.layers.resolve("roads", "raster")["layer_type"] == "raster"
+
+    def test_unknown_reference(self, client):
+        with pytest.raises(NotFoundError):
+            client.layers.resolve("nothing-like-this")
+
+    def test_integer_id_beats_a_name_that_looks_like_one(self, client, instance):
+        instance.vector_layers.append(dict(instance.vector_layers[0], id=7, uid="e" * 12, name="1"))
+        assert client.layers.resolve(1)["name"] == "roads"
+
+
+class TestLayerListing:
+    def test_both_kinds_are_tagged_with_their_type(self, client):
+        rows = client.layers.list()
+        assert {r["layer_type"] for r in rows} == {"vector", "raster"}
+
+    def test_filters(self, client):
+        assert len(client.layers.list("vector", status="ready")) == 1
+        assert len(client.layers.list(query="field")) == 1
+        assert len(client.layers.list(visibility="public")) == 1
+
+    def test_sharing_requires_something_to_change(self, client):
+        with pytest.raises(ValidationError):
+            client.vector.share(1)
+
+    def test_sharing_sends_only_what_was_given(self, client, instance):
+        client.vector.share(1, visibility="public", license="CC-BY-4.0")
+        body = instance.requests_to("/sharing", "PUT")[0]["body"]
+        assert b"license" in body and b"abstract" not in body
+
+
+class TestPortalLayers:
+    """Index 0 is the top of the list and draws on top — the convention the editor uses."""
+
+    def test_add_prepends(self, client, instance):
+        updated = client.portals.add_layer(3, 1, "raster", style={"colormap": "viridis"})
+        configs = updated["layer_configs"]
+        assert configs[0]["layer_id"] == 1 and configs[0]["layer_type"] == "raster"
+        assert len(configs) == 2
+
+    def test_add_at_the_bottom(self, client):
+        updated = client.portals.add_layer(3, 1, "raster", bottom=True)
+        assert updated["layer_configs"][-1]["layer_type"] == "raster"
+
+    def test_adding_twice_is_refused_unless_asked_to_replace(self, client):
+        with pytest.raises(ValidationError):
+            client.portals.add_layer(3, 1, "vector")
+        updated = client.portals.add_layer(3, 1, "vector", style={"color": "#fff"}, replace=True)
+        assert len([c for c in updated["layer_configs"] if c["layer_id"] == 1]) == 1
+        assert updated["layer_configs"][0]["style"]["color"] == "#fff"
+
+    def test_remove(self, client):
+        updated = client.portals.remove_layer(3, 1, "vector")
+        assert updated["layer_configs"] == []
+
+    def test_removing_something_absent_is_an_error_not_a_no_op(self, client):
+        with pytest.raises(NotFoundError):
+            client.portals.remove_layer(3, 99)
+
+    def test_style_merges_by_default(self, client):
+        updated = client.portals.set_layer_style(3, 1, {"radius": 6}, layer_type="vector")
+        style = updated["layer_configs"][0]["style"]
+        assert style == {"color": "#3b82f6", "radius": 6}
+
+    def test_style_can_replace(self, client):
+        updated = client.portals.set_layer_style(3, 1, {"radius": 6}, layer_type="vector",
+                                                 merge=False)
+        assert updated["layer_configs"][0]["style"] == {"radius": 6}
+
+    def test_style_keeps_the_rest_of_the_entry(self, client):
+        updated = client.portals.set_layer_style(3, 1, {"radius": 6}, visible=False)
+        entry = updated["layer_configs"][0]
+        assert entry["visible"] is False and entry["opacity"] == 1.0
+
+    @pytest.mark.parametrize("position,expected_first", [
+        ("bottom", 2), ("top", 1), ("down", 2), (1, 2), (0, 1),
+    ])
+    def test_move(self, client, instance, position, expected_first):
+        instance.portals[0]["layer_configs"].append(
+            {"layer_id": 2, "layer_type": "vector", "visible": True, "opacity": 1.0, "style": {}})
+        updated = client.portals.move_layer(3, 1, position, "vector")
+        assert updated["layer_configs"][0]["layer_id"] == expected_first
+
+
+class TestPortalDocument:
+    def test_get_by_slug_and_title(self, client):
+        assert client.portals.get("field-sites-2026")["id"] == 3
+        assert client.portals.get("Field sites 2026")["id"] == 3
+        assert client.portals.get("field sites")["id"] == 3
+
+    def test_unknown_portal(self, client):
+        with pytest.raises(NotFoundError):
+            client.portals.get("no-such-portal")
+
+    def test_round_trip_drops_server_owned_fields(self):
+        """`slug` is derived from the title and `published` is not settable; sending them back
+        would be at best ignored and at worst a 422."""
+        config = {"id": 3, "slug": "x", "published": True, "created_at": "…", "title": "Keep",
+                  "layer_configs": [], "theme": {"mode": "dark"}}
+        assert editable_config(config) == {"title": "Keep", "layer_configs": [],
+                                           "theme": {"mode": "dark"}}
+
+    def test_set_config_filters_before_sending(self, client, instance):
+        client.portals.set_config(3, {"id": 999, "slug": "hack", "title": "New"})
+        assert instance.last_put == {"title": "New"}
+
+    def test_password_access_needs_a_password(self, client):
+        with pytest.raises(ValidationError):
+            client.portals.create("Locked", access_type="password")
+
+    def test_unknown_access_tier_is_refused_locally(self, client):
+        with pytest.raises(ValidationError):
+            client.portals.create("X", access_type="secret")
+
+    def test_unknown_experience_is_refused_locally(self, client):
+        with pytest.raises(ValidationError):
+            client.portals.create("X", archetype="dashboard")
+
+    def test_create_carries_the_experience_into_layout_config(self, client, instance):
+        portal = client.portals.create("Cat", archetype="catalog")
+        assert portal["layout_config"]["archetype"] == "catalog"
+
+    def test_publish_and_url(self, client):
+        portal = client.portals.create("Fresh")
+        assert portal["published"] is False
+        published = client.portals.publish(portal["id"])
+        assert published["published"] is True
+        assert client.portals.url(published).endswith("/portals/fresh/")
+
+    def test_update_with_nothing_is_refused(self, client):
+        with pytest.raises(ValidationError):
+            client.portals.update(3)
+
+
+class TestSources:
+    def test_wms_needs_a_layer_name(self, client):
+        with pytest.raises(ValidationError) as caught:
+            client.sources.create("Ortho", "wms", "https://example.org/wms")
+        assert "layer-name" in str(caught.value)
+
+    def test_xyz_does_not(self, client):
+        source = client.sources.create("OSM", "xyz", "https://tile/{z}/{x}/{y}.png")
+        assert source["id"] == 5
+
+    def test_unknown_type(self, client):
+        with pytest.raises(ValidationError):
+            client.sources.create("X", "wcs", "https://example.org")
+
+    def test_sources_have_no_public_tier(self, client):
+        with pytest.raises(ValidationError):
+            client.sources.share(5, "public")

--- a/cli/tests/test_layers_portals.py
+++ b/cli/tests/test_layers_portals.py
@@ -11,7 +11,23 @@ class TestLayerResolution:
     """A layer can be named by id, uid or name. Ambiguity is an error, never a silent pick."""
 
     def test_by_integer_id(self, client):
-        assert client.layers.resolve(1)["name"] == "roads"
+        assert client.layers.resolve(2)["name"] == "field sites"
+
+    def test_an_id_that_exists_in_BOTH_kinds_is_refused(self, client):
+        """vector 1 and raster 1 are different layers — ids are per-kind sequences. Returning
+        whichever the listing happened to put first is how you download a vector while asking for
+        a raster, and nothing in the output would tell you."""
+        with pytest.raises(ValidationError) as caught:
+            client.layers.resolve("1")
+        assert "vector-1" in str(caught.value) and "raster-1" in str(caught.value)
+
+    def test_and_the_kind_resolves_it_either_way(self, client):
+        assert client.layers.resolve("raster-1")["name"] == "dem"
+        assert client.layers.resolve(1, kind="raster")["name"] == "dem"
+        assert client.layers.resolve(1, kind="vector")["name"] == "roads"
+
+    def test_a_uid_is_never_ambiguous(self, client):
+        assert client.layers.resolve("cccccccccccc")["name"] == "dem"
 
     def test_by_stable_uid(self, client):
         # uid, not the integer id, is what public URLs use: SQLite reuses a deleted row's id, so a
@@ -45,7 +61,7 @@ class TestLayerResolution:
 
     def test_integer_id_beats_a_name_that_looks_like_one(self, client, instance):
         instance.vector_layers.append(dict(instance.vector_layers[0], id=7, uid="e" * 12, name="1"))
-        assert client.layers.resolve(1)["name"] == "roads"
+        assert client.layers.resolve(1, "vector")["name"] == "roads"
 
 
 class TestLayerListing:
@@ -54,9 +70,12 @@ class TestLayerListing:
         assert {r["layer_type"] for r in rows} == {"vector", "raster"}
 
     def test_filters(self, client):
-        assert len(client.layers.list("vector", status="ready")) == 1
-        assert len(client.layers.list(query="field")) == 1
-        assert len(client.layers.list(visibility="public")) == 1
+        # By name rather than by count: the fixture set grows, and a count assertion turns that
+        # into a failure in a test about filtering.
+        assert {r["name"] for r in client.layers.list("vector", status="ready")} == {
+            "roads", "parcels"}
+        assert [r["name"] for r in client.layers.list(query="field")] == ["field sites"]
+        assert {r["name"] for r in client.layers.list(visibility="public")} == {"parcels", "dem"}
 
     def test_sharing_requires_something_to_change(self, client):
         with pytest.raises(ValidationError):

--- a/cli/tests/test_layers_portals.py
+++ b/cli/tests/test_layers_portals.py
@@ -131,6 +131,15 @@ class TestPortalDocument:
         with pytest.raises(NotFoundError):
             client.portals.get("no-such-portal")
 
+    def test_get_by_its_published_url(self, client, server):
+        """So `portals publish <url>` works on the link you copied, not on a slug you retyped."""
+        assert client.portals.get(server + "/portals/field-sites-2026/")["id"] == 3
+
+    def test_a_url_from_another_instance_is_refused(self, client):
+        with pytest.raises(ValidationError) as exc:
+            client.portals.get("https://elsewhere.example.org/portals/field-sites-2026/")
+        assert "elsewhere.example.org" in str(exc.value)
+
     def test_round_trip_drops_server_owned_fields(self):
         """`slug` is derived from the title and `published` is not settable; sending them back
         would be at best ignored and at worst a 422."""

--- a/cli/tests/test_layers_portals.py
+++ b/cli/tests/test_layers_portals.py
@@ -30,8 +30,8 @@ class TestLayerResolution:
         assert client.layers.resolve("cccccccccccc")["name"] == "dem"
 
     def test_by_stable_uid(self, client):
-        # uid, not the integer id, is what public URLs use: SQLite reuses a deleted row's id, so a
-        # bookmarked integer can come back as a DIFFERENT dataset.
+        # uid, not the integer id, is what public URLs use: an integer is unique only within one
+        # layer kind and one database, so it renumbers on a restore or a move between instances.
         assert client.layers.resolve("aaaaaaaaaaaa")["name"] == "roads"
 
     def test_by_prefixed_reference(self, client):

--- a/cli/tests/test_output.py
+++ b/cli/tests/test_output.py
@@ -1,0 +1,167 @@
+"""Formatting rules: stdout is the answer, stderr is the commentary, --json is a contract."""
+from __future__ import annotations
+
+import io
+import json
+
+from geodeploy.cli.output import Formatter, Progress, human_size
+
+
+def make(**kw):
+    out, err = io.StringIO(), io.StringIO()
+    return Formatter(stdout=out, stderr=err, **kw), out, err
+
+
+class TestStreams:
+    def test_the_answer_goes_to_stdout_and_the_hints_to_stderr(self):
+        fmt, out, err = make()
+        fmt.out("the answer")
+        fmt.info("a hint")
+        fmt.success("done")
+        fmt.warn("careful")
+        assert out.getvalue() == "the answer\n"
+        assert "a hint" in err.getvalue() and "done" in err.getvalue()
+
+    def test_json_mode_keeps_stdout_pure(self):
+        fmt, out, err = make(json_mode=True)
+        fmt.info("a hint")
+        fmt.success("done")
+        fmt.warn("careful")
+        fmt.render([{"id": 1}])
+        assert err.getvalue() == ""
+        assert json.loads(out.getvalue()) == [{"id": 1}]
+
+    def test_quiet_silences_commentary_but_not_errors(self):
+        fmt, out, err = make(quiet=True)
+        fmt.info("hint")
+        fmt.success("done")
+        fmt.error("it broke")
+        assert "hint" not in err.getvalue() and "done" not in err.getvalue()
+        assert "it broke" in err.getvalue()
+
+    def test_json_errors_are_a_document_a_script_can_read(self):
+        fmt, out, err = make(json_mode=True)
+        fmt.error("no such layer", hint="try `layers list`")
+        payload = json.loads(out.getvalue())
+        assert payload == {"ok": False, "error": "no such layer", "hint": "try `layers list`"}
+
+    def test_debug_only_when_verbose(self):
+        fmt, out, err = make()
+        fmt.debug("GET /api/x")
+        assert err.getvalue() == ""
+        fmt, out, err = make(verbose=True)
+        fmt.debug("GET /api/x")
+        assert "GET /api/x" in err.getvalue()
+
+    def test_no_color_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        fmt, out, err = make()
+        fmt.out(fmt.green("ok"))
+        assert "\033[" not in out.getvalue()
+
+
+class TestTables:
+    def test_headers_and_alignment(self):
+        fmt, out, err = make()
+        fmt.table([{"id": 1, "name": "roads"}, {"id": 22, "name": "dem"}], ["id", "name"])
+        lines = out.getvalue().splitlines()
+        assert lines[0].split() == ["ID", "NAME"]
+        assert lines[1].startswith("1 ") and lines[2].startswith("22")
+
+    def test_missing_values_read_as_missing(self):
+        fmt, out, err = make()
+        fmt.table([{"id": 1, "crs": None}], ["id", "crs"])
+        assert "—" in out.getvalue()
+
+    def test_booleans_are_words(self):
+        fmt, out, err = make()
+        fmt.table([{"published": True, "draft": False}], ["published", "draft"])
+        assert "yes" in out.getvalue() and "no" in out.getvalue()
+
+    def test_nested_values_are_summarised_not_dumped(self):
+        fmt, out, err = make()
+        fmt.table([{"style": {"a": 1, "b": 2}, "tags": ["x", "y", "z"]}], ["style", "tags"])
+        text = out.getvalue()
+        assert "2 keys" in text and "3 items" in text
+
+    def test_a_bbox_stays_readable(self):
+        fmt, out, err = make()
+        fmt.table([{"bbox": [11.1, 55.2, 24.3, 69.4]}], ["bbox"])
+        assert "11.1, 55.2, 24.3, 69.4" in out.getvalue()
+
+    def test_empty_list_says_so_on_stderr(self):
+        fmt, out, err = make()
+        fmt.render([], ["id"], empty="No layers yet.")
+        assert out.getvalue() == ""
+        assert "No layers yet." in err.getvalue()
+
+    def test_record_prints_key_and_value(self):
+        fmt, out, err = make()
+        fmt.record({"id": 3, "title": "Sites"}, ["id", "title"])
+        assert "id" in out.getvalue() and "Sites" in out.getvalue()
+
+
+class TestProgress:
+    def test_silent_when_not_a_terminal(self):
+        fmt, out, err = make()
+        progress = Progress(fmt, "upload", 100)
+        progress.update(50)
+        progress.finish()
+        assert err.getvalue() == ""
+        assert out.getvalue() == ""
+
+    def test_never_writes_to_stdout_even_on_a_terminal(self):
+        class TtyIO(io.StringIO):
+            def isatty(self):
+                return True
+        out, err = io.StringIO(), TtyIO()
+        fmt = Formatter(stdout=out, stderr=err)
+        progress = Progress(fmt, "upload", 100)
+        progress.update(100)
+        progress.finish()
+        assert out.getvalue() == ""
+        assert "upload" in err.getvalue()
+
+
+class TestHumanSize:
+    def test_units(self):
+        assert human_size(0) == "0 B"
+        assert human_size(999) == "999 B"
+        assert human_size(1024) == "1.0 KB"
+        assert human_size(48 * 1024 * 1024) == "48.0 MB"
+        assert human_size(3 * 1024 ** 3) == "3.0 GB"
+
+
+class TestLegacyConsoles:
+    """A Windows console on code page 437 cannot encode "✓" — and a successful command must not
+    end in a UnicodeEncodeError because of a decoration."""
+
+    class Cp437IO(io.StringIO):
+        encoding = "cp437"
+
+    def test_glyphs_degrade_instead_of_crashing(self):
+        out, err = self.Cp437IO(), self.Cp437IO()
+        fmt = Formatter(stdout=out, stderr=err)
+        fmt.success("uploaded")
+        fmt.info("roads → parcels")
+        fmt.out("a — b")
+        text = out.getvalue() + err.getvalue()
+        assert "OK uploaded" in text
+        assert "roads -> parcels" in text
+        assert "a - b" in text
+        text.encode("cp437")          # the real assertion: this would have raised
+
+    def test_utf8_consoles_keep_the_real_glyphs(self):
+        class Utf8IO(io.StringIO):
+            encoding = "utf-8"
+        out, err = Utf8IO(), Utf8IO()
+        fmt = Formatter(stdout=out, stderr=err)
+        fmt.success("uploaded")
+        assert "✓" in err.getvalue()
+
+    def test_json_output_is_never_degraded(self):
+        """JSON is a document for a machine; mangling a name inside it would be data loss."""
+        out, err = self.Cp437IO(), self.Cp437IO()
+        fmt = Formatter(json_mode=True, stdout=out, stderr=err)
+        fmt.json({"name": "Åkerö — fält"})
+        assert "Åkerö — fält" in out.getvalue()

--- a/cli/tests/test_styles_jobs.py
+++ b/cli/tests/test_styles_jobs.py
@@ -1,0 +1,186 @@
+"""Symbology assembly and job polling."""
+from __future__ import annotations
+
+import pytest
+
+from geodeploy import styles
+from geodeploy.errors import ValidationError
+from geodeploy.jobs import JobFailed, JobTimeout
+
+
+class TestBuildStyle:
+    def test_only_what_was_given_is_applied(self):
+        """The rule the whole CLI depends on: `--color` must not reset somebody's marker shape."""
+        base = {"color": "#111", "marker": "star", "radius": 6}
+        assert styles.build_style(base, color="#222") == {"color": "#222", "marker": "star",
+                                                          "radius": 6}
+
+    def test_none_arguments_are_absent_not_defaults(self):
+        assert styles.build_style({}, color=None, radius=None) == {}
+
+    def test_line_type_is_stored_camelcase(self):
+        # The stored key is `lineType`; three renderers read it, so the spelling is not ours to fix.
+        assert styles.build_style({}, line_type="dashed") == {"lineType": "dashed"}
+
+    def test_outline_none_is_a_sentinel_not_an_empty_string(self):
+        assert styles.build_style({}, outline_color="none")["outline_color"] == styles.NO_OUTLINE
+
+    @pytest.mark.parametrize("kwargs", [
+        {"marker": "hexagon"}, {"line_type": "dot-dash"}, {"color_mode": "rainbow"},
+        {"fill_opacity": 2.0}, {"outline_width": -1},
+    ])
+    def test_invalid_values_are_refused_before_any_request(self, kwargs):
+        with pytest.raises(ValidationError):
+            styles.build_style({}, **kwargs)
+
+    def test_size_stops_imply_proportional_sizing(self):
+        style = styles.build_style({"size_field": "pop"}, size_stops="0:2,1000:12")
+        assert style["size_mode"] == "proportional"
+        assert style["size_stops"] == [[0.0, 2.0], [1000.0, 12.0]]
+
+    def test_proportional_without_a_field_is_refused(self):
+        with pytest.raises(ValidationError):
+            styles.build_style({}, size_mode="proportional")
+
+    def test_clearing_classification_removes_every_related_key(self):
+        base = {"color_mode": "graduated", "color_field": "pop", "classes": [{"min": 1}],
+                "other_color": "#ccc", "color": "#111"}
+        cleared = styles.build_style(base, clear_classification=True)
+        assert cleared == {"color": "#111"}
+
+    def test_extrusion_needs_a_field(self):
+        with pytest.raises(ValidationError):
+            styles.build_style({}, extrude=True)
+
+    def test_extrusion_block(self):
+        style = styles.build_style({}, extrude=True, extrude_field="height", extrude_scale=2,
+                                   extrude_radius=250)
+        assert style["extrusion"] == {"enabled": True, "field": "height", "scale": 2,
+                                      "radius": 250}
+
+    def test_no_extrude_turns_it_off_without_losing_the_field(self):
+        base = {"extrusion": {"enabled": True, "field": "height"}}
+        assert styles.build_style(base, extrude=False)["extrusion"]["enabled"] is False
+
+
+class TestParsers:
+    def test_size_stops_are_sorted(self):
+        assert styles.parse_size_stops("100:9,0:2") == [[0.0, 2.0], [100.0, 9.0]]
+
+    @pytest.mark.parametrize("bad", ["0:2", "abc", "0-2", "x:y,1:2"])
+    def test_bad_size_stops(self, bad):
+        with pytest.raises(ValidationError):
+            styles.parse_size_stops(bad)
+
+    def test_classes_with_open_edges(self):
+        parsed = styles.parse_classes("*-10:#fee,10-50:#f88,50-*:#f00")
+        assert parsed[0] == {"min": None, "max": 10.0, "color": "#fee"}
+        assert parsed[-1] == {"min": 50.0, "max": None, "color": "#f00"}
+
+    def test_categories(self):
+        assert styles.parse_categories("forest:#2c7,water:#39f") == [
+            {"value": "forest", "color": "#2c7"}, {"value": "water", "color": "#39f"}]
+
+    @pytest.mark.parametrize("bad", ["nonsense", "10-20", ""])
+    def test_bad_classes(self, bad):
+        with pytest.raises(ValidationError):
+            styles.parse_classes(bad)
+
+
+class TestClassify:
+    """Breaks come from the SERVER, so the CLI cannot disagree with the editor about a class."""
+
+    def test_numeric_field_produces_graduated_classes(self, client):
+        style, stats = styles.classify(client, 1, "pop", classes=3, method="quantile")
+        assert style["color_mode"] == "graduated"
+        assert style["color_field"] == "pop"
+        assert len(style["classes"]) == 3
+        assert stats["kind"] == "numeric"
+
+    def test_text_field_produces_categories(self, client):
+        style, _ = styles.classify(client, 1, "name")
+        assert style["color_mode"] == "categorized"
+        assert [c["value"] for c in style["categories"]] == ["forest", "water"]
+
+    def test_classify_asks_the_server_with_the_parameters_given(self, client, instance):
+        styles.classify(client, 1, "pop", classes=7, method="jenks", ramp="magma")
+        query = instance.requests_to("field-stats")[0]["query"]
+        assert query["classes"] == ["7"] and query["method"] == ["jenks"]
+        assert query["ramp"] == ["magma"]
+
+    def test_unknown_method_and_ramp_fail_locally(self, client):
+        with pytest.raises(ValidationError):
+            styles.classify(client, 1, "pop", method="kmeans")
+        with pytest.raises(ValidationError):
+            styles.classify(client, 1, "pop", ramp="rainbow")
+
+    def test_graduated_on_a_text_field_explains_itself(self, client):
+        with pytest.raises(ValidationError) as caught:
+            styles.classify(client, 1, "name", mode="graduated")
+        assert "numeric" in str(caught.value)
+
+    def test_switching_mode_drops_the_other_shape(self, client):
+        base = {"categories": [{"value": "x", "color": "#111"}]}
+        style, _ = styles.classify(client, 1, "pop", base=base)
+        assert "categories" not in style and "classes" in style
+
+
+class TestDescribe:
+    def test_summaries(self):
+        assert styles.describe({}) == "default"
+        assert "graduated on pop" in styles.describe(
+            {"color_mode": "graduated", "color_field": "pop", "classes": [1, 2, 3]})
+        assert "categorized on kind" in styles.describe(
+            {"color_mode": "categorized", "color_field": "kind", "categories": [1]})
+        assert "color=#111" in styles.describe({"color": "#111"})
+        assert "3D" in styles.describe({"extrusion": {"enabled": True, "field": "h"}})
+
+
+class TestJobs:
+    def test_wait_returns_the_final_status(self, client):
+        created = client.vector.tile(1)
+        final = client.jobs.wait(created["id"], interval=0)
+        assert final["status"] == "ready"
+
+    def test_progress_is_reported_only_when_it_changes(self, client, instance):
+        created = client.vector.tile(1)
+        job_id = created["id"]
+        # Two identical polls in the middle: the callback must not fire for the repeat.
+        instance.jobs[job_id] = [
+            {"id": job_id, "layer_id": 1, "layer_type": "vector", "status": "processing",
+             "progress": 10, "current_step": "Reading"},
+            {"id": job_id, "layer_id": 1, "layer_type": "vector", "status": "processing",
+             "progress": 10, "current_step": "Reading"},
+            {"id": job_id, "layer_id": 1, "layer_type": "vector", "status": "ready",
+             "progress": 100, "current_step": "Done"},
+        ]
+        seen = []
+        client.jobs.wait(job_id, interval=0, on_progress=lambda st: seen.append(st["progress"]))
+        assert seen == [10, 100]
+
+    def test_a_failed_job_raises_with_the_server_message(self, client, instance):
+        created = client.vector.tile(1)
+        job_id = created["id"]
+        instance.jobs[job_id] = [{"id": job_id, "layer_id": 1, "layer_type": "vector",
+                                  "status": "failed", "progress": 30,
+                                  "error_message": "Invalid geometry at row 12"}]
+        with pytest.raises(JobFailed) as caught:
+            client.jobs.wait(job_id, interval=0)
+        assert "Invalid geometry at row 12" in str(caught.value)
+
+    def test_completed_counts_as_done(self, client, instance):
+        """Two pipelines report success differently; polling forever on the other one is a bug."""
+        created = client.vector.tile(1)
+        job_id = created["id"]
+        instance.jobs[job_id] = [{"id": job_id, "layer_id": 1, "layer_type": "vector",
+                                  "status": "completed", "progress": 100}]
+        assert client.jobs.wait(job_id, interval=0)["status"] == "completed"
+
+    def test_timeout_says_the_job_is_still_running(self, client, instance):
+        created = client.vector.tile(1)
+        job_id = created["id"]
+        instance.jobs[job_id] = [{"id": job_id, "layer_id": 1, "layer_type": "vector",
+                                  "status": "processing", "progress": 5}]
+        with pytest.raises(JobTimeout) as caught:
+            client.jobs.wait(job_id, interval=0, timeout=0)
+        assert "keeps running on the server" in str(caught.value)

--- a/cli/tests/test_transport.py
+++ b/cli/tests/test_transport.py
@@ -1,0 +1,216 @@
+"""The wire: streamed bodies, retries, and turning a status into the right exception."""
+from __future__ import annotations
+
+import io
+import os
+
+import pytest
+
+from geodeploy import errors
+from geodeploy.transport import (MultipartBody, ProgressReader, Request, Response,
+                                 UrllibTransport, _RetryStatus)
+
+
+class TestMultipartBody:
+    def test_length_matches_what_it_produces(self, tmp_path):
+        path = tmp_path / "roads.gpkg"
+        path.write_bytes(b"x" * 5000)
+        body = MultipartBody(fields={"name": "Roads", "srid": 4326}, file_path=str(path))
+
+        produced = b""
+        while True:
+            chunk = body.read(512)
+            if not chunk:
+                break
+            produced += chunk
+        # Content-Length is computed BEFORE reading; if the two disagree the request hangs or the
+        # server sees a truncated body, which is the worst kind of upload bug to debug.
+        assert len(produced) == len(body)
+
+    def test_carries_fields_and_the_file(self, tmp_path):
+        from tests.conftest import parse_multipart
+        path = tmp_path / "sites.csv"
+        path.write_bytes(b"lon,lat\n17.6,59.8\n")
+        body = MultipartBody(fields={"x_column": "lon", "y_column": "lat", "srid": 4326,
+                                     "skipped": None},
+                             file_path=str(path))
+        raw = b""
+        while True:
+            chunk = body.read(64)
+            if not chunk:
+                break
+            raw += chunk
+
+        parsed = parse_multipart(body.content_type, raw)
+        assert parsed["x_column"] == "lon"
+        assert parsed["y_column"] == "lat"
+        assert "skipped" not in parsed          # a None field is absent, not the string "None"
+        assert parsed["_files"]["file"][0] == "sites.csv"
+        assert parsed["_files"]["file"][1] == b"lon,lat\n17.6,59.8\n"
+
+    def test_reads_the_file_lazily(self, tmp_path):
+        """A 2 GB upload must not become a 2 GB string; the file is opened only when reached."""
+        path = tmp_path / "big.bin"
+        path.write_bytes(b"y" * 4096)
+        body = MultipartBody(file_path=str(path))
+        assert body._fh is None
+        body.read(16)
+        assert len(body) == len(body._pre) + 4096 + len(body._post)
+
+    def test_progress_is_reported_as_it_is_read(self, tmp_path):
+        path = tmp_path / "f.geojson"
+        path.write_bytes(b"z" * 2048)
+        seen = []
+        body = MultipartBody(file_path=str(path), on_progress=lambda done, total: seen.append(done))
+        while body.read(256):
+            pass
+        assert seen == sorted(seen)             # monotonic
+        assert seen[-1] == len(body)
+
+
+class TestProgressReader:
+    def test_counts_what_the_socket_took(self):
+        source = io.BytesIO(b"a" * 1000)
+        seen = []
+        reader = ProgressReader(source, 1000, lambda done, total: seen.append((done, total)))
+        while reader.read(256):
+            pass
+        assert seen[-1] == (1000, 1000)
+
+    def test_cancel_stops_mid_flight(self):
+        source = io.BytesIO(b"a" * 1000)
+        state = {"stop": False}
+        reader = ProgressReader(source, 1000, cancel=lambda: state["stop"])
+        assert reader.read(100)
+        state["stop"] = True
+        with pytest.raises(errors.TransportError):
+            reader.read(100)
+
+
+class _ScriptedTransport(object):
+    """Returns canned responses; records every request. Enough to test the client's own logic."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def send(self, request):
+        self.requests.append(request)
+        response = self.responses.pop(0) if len(self.responses) > 1 else self.responses[0]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _json_response(status, payload, url="http://x/api/thing"):
+    import json as _json
+    return Response(status, {"Content-Type": "application/json"},
+                    _json.dumps(payload).encode(), url)
+
+
+class TestErrorMapping:
+    """Every status a caller might branch on becomes a class, not a number to compare."""
+
+    @pytest.mark.parametrize("status,expected", [
+        (400, errors.ValidationError),
+        (401, errors.AuthError),
+        (403, errors.PermissionError_),
+        (404, errors.NotFoundError),
+        (409, errors.ConflictError),
+        (413, errors.ValidationError),
+        (422, errors.ValidationError),
+        (500, errors.ServerError),
+        (503, errors.ServerError),
+    ])
+    def test_status_to_class(self, status, expected):
+        from geodeploy.client import Client
+        client = Client("https://gd.example.org", token="gdp_x",
+                        transport=_ScriptedTransport([_json_response(status, {"detail": "no"})]))
+        with pytest.raises(expected):
+            client.get("/anything")
+
+    def test_missing_scope_is_extractable(self):
+        from geodeploy.client import Client
+        client = Client("https://gd.example.org", token="gdp_x", transport=_ScriptedTransport(
+            [_json_response(403, {"detail": "Token missing scope: data:write"})]))
+        with pytest.raises(errors.PermissionError_) as caught:
+            client.get("/data/vector")
+        assert caught.value.missing_scope == "data:write"
+
+    def test_validation_lists_become_one_readable_line(self):
+        from geodeploy.client import Client
+        payload = {"detail": [{"loc": ["body", "access_type"], "msg": "string does not match"}]}
+        client = Client("https://gd.example.org", token="gdp_x",
+                        transport=_ScriptedTransport([_json_response(422, payload)]))
+        with pytest.raises(errors.ValidationError) as caught:
+            client.post("/portals", {})
+        assert "access_type" in caught.value.detail
+        assert "string does not match" in caught.value.detail
+
+    def test_an_html_proxy_page_becomes_a_sentence(self):
+        from geodeploy.client import Client
+        html = Response(413, {"Content-Type": "text/html"},
+                        b"<html><head><title>413</title></head></html>", "http://x")
+        client = Client("https://gd.example.org", token="gdp_x",
+                        transport=_ScriptedTransport([html]))
+        with pytest.raises(errors.ValidationError) as caught:
+            client.post("/data/vector/upload")
+        assert "too large" in caught.value.detail.lower()
+        assert "<html>" not in caught.value.detail
+
+
+class TestRetries:
+    def test_gateway_errors_are_retried(self):
+        transport = UrllibTransport(retries=2, backoff=0)
+        attempts = {"n": 0}
+
+        def fake_send_once(request):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise _RetryStatus(Response(503, {}, b"", request.url))
+            return Response(200, {"Content-Type": "application/json"}, b"{}", request.url)
+
+        transport._send_once = fake_send_once
+        assert transport.send(Request("GET", "http://x/api/thing")).status == 200
+        assert attempts["n"] == 3
+
+    def test_a_streamed_body_is_never_retried(self, tmp_path):
+        """The file object is already partly consumed, so a replay would upload a truncated file."""
+        transport = UrllibTransport(retries=3, backoff=0)
+        attempts = {"n": 0}
+
+        def fake_send_once(request):
+            attempts["n"] += 1
+            raise _RetryStatus(Response(503, {}, b"", request.url))
+
+        transport._send_once = fake_send_once
+        path = tmp_path / "f.bin"
+        path.write_bytes(b"data")
+        with open(str(path), "rb") as fh:
+            response = transport.send(Request("PUT", "http://x/s3/key", body=fh))
+        assert response.status == 503
+        assert attempts["n"] == 1
+
+    def test_a_client_error_is_not_retried(self):
+        transport = UrllibTransport(retries=3, backoff=0)
+        attempts = {"n": 0}
+
+        def fake_send_once(request):
+            attempts["n"] += 1
+            return Response(404, {}, b"", request.url)
+
+        transport._send_once = fake_send_once
+        assert transport.send(Request("GET", "http://x/api/thing")).status == 404
+        assert attempts["n"] == 1
+
+
+class TestResponse:
+    def test_headers_are_case_insensitive(self):
+        response = Response(200, {"ETag": '"abc"'}, b"", "http://x")
+        assert response.headers["etag"] == '"abc"'
+
+    def test_empty_body_is_none_not_a_crash(self):
+        from geodeploy.client import Client
+        client = Client("https://gd.example.org", token="gdp_x",
+                        transport=_ScriptedTransport([Response(204, {}, b"", "http://x")]))
+        assert client.delete("/portals/1") is None

--- a/cli/tests/test_uploads.py
+++ b/cli/tests/test_uploads.py
@@ -1,0 +1,299 @@
+"""Upload routing and the two transports — the highest-risk code in the package.
+
+The routing table has to match `ui/src/composables/useUpload.js` and the API's own limits. Where
+those disagree, uploads fail in ways that produce no server-side log at all (the request is cut by
+a proxy before it arrives), so the matrix below is pinned deliberately.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from geodeploy import uploads
+from geodeploy.errors import ValidationError
+from geodeploy.uploads import CHUNK_THRESHOLD, LARGE_UPLOAD_THRESHOLD
+
+
+def make_file(tmp_path, name, size=32):
+    """A file of exactly `size` bytes.
+
+    Anything over a megabyte is made SPARSE (seek past the end and write one byte): the routing
+    tests care only about `os.path.getsize`, and actually writing 96 MB of padding several times
+    over turned a millisecond assertion into seconds of disk I/O.
+    """
+    path = tmp_path / name
+    if size > 1024 * 1024:
+        with open(str(path), "wb") as fh:
+            fh.seek(size - 1)
+            fh.write(b"\0")
+    else:
+        path.write_bytes(b"x" * size)
+    return str(path)
+
+
+class TestThresholds:
+    def test_the_direct_upload_threshold_is_48mb_not_the_api_cap(self):
+        """48 MB, deliberately. The binding limit is a CDN's request-body cap (Cloudflare's free
+        tier at 100 MB), not uvicorn's 2 GB — a 300 MB GeoPackage POSTed through the API was cut
+        mid-body and surfaced as "Network error" at 1 %, with nothing in the API log."""
+        assert LARGE_UPLOAD_THRESHOLD == 48 * 1024 * 1024
+        assert CHUNK_THRESHOLD <= LARGE_UPLOAD_THRESHOLD
+
+
+class TestPlan:
+    @pytest.mark.parametrize("name,size,route,layer_type", [
+        ("roads.gpkg", 1000, "vector-api", "vector"),
+        ("roads.geojson", 1000, "vector-api", "vector"),
+        ("roads.json", 1000, "vector-api", "vector"),
+        ("shape.zip", 1000, "vector-api", "vector"),
+        ("big.gpkg", LARGE_UPLOAD_THRESHOLD, "large-vector", "vector"),
+        ("huge.geojson", LARGE_UPLOAD_THRESHOLD * 2, "large-vector", "vector"),
+        ("tiny.parquet", 1000, "geoparquet", "vector"),
+        ("tiny.geoparquet", 1000, "geoparquet", "vector"),
+        ("big.parquet", LARGE_UPLOAD_THRESHOLD * 2, "geoparquet", "vector"),
+        ("dem.tif", 1000, "raster-api", "raster"),
+        ("dem.tiff", 1000, "raster-api", "raster"),
+        ("dem.tif", LARGE_UPLOAD_THRESHOLD, "raster-large", "raster"),
+    ])
+    def test_routing_matrix(self, client, tmp_path, name, size, route, layer_type):
+        plan = client.uploads.plan(make_file(tmp_path, name, size))
+        assert (plan.route, plan.layer_type) == (route, layer_type)
+
+    def test_small_csv_goes_to_postgis_large_csv_becomes_geoparquet(self, client, tmp_path):
+        small = tmp_path / "sites.csv"
+        small.write_text("lon,lat\n17.6,59.8\n", encoding="utf-8")
+        assert client.uploads.plan(str(small)).route == "csv-api"
+
+        big = tmp_path / "many.csv"
+        big.write_text("lon,lat\n" + "17.6,59.8\n" * 4, encoding="utf-8")
+        os.truncate(str(big), LARGE_UPLOAD_THRESHOLD + 1)
+        assert client.uploads.plan(str(big), x_column="lon", y_column="lat").route == "large-vector"
+
+    def test_chunking_kicks_in_above_the_part_size(self, client, tmp_path):
+        assert client.uploads.plan(make_file(tmp_path, "a.parquet", 1000)).chunked is False
+        assert client.uploads.plan(make_file(tmp_path, "b.parquet",
+                                             CHUNK_THRESHOLD + 1)).chunked is True
+
+    def test_type_can_be_forced(self, client, tmp_path):
+        plan = client.uploads.plan(make_file(tmp_path, "dem.tif", 10), layer_type="raster")
+        assert plan.layer_type == "raster"
+
+    def test_unsupported_extension_says_what_is_supported(self, client, tmp_path):
+        with pytest.raises(ValidationError) as caught:
+            client.uploads.plan(make_file(tmp_path, "notes.txt", 10))
+        assert ".gpkg" in str(caught.value)
+
+    def test_missing_and_empty_files_fail_before_any_request(self, client, tmp_path):
+        with pytest.raises(ValidationError):
+            client.uploads.plan(str(tmp_path / "nope.gpkg"))
+        empty = tmp_path / "empty.gpkg"
+        empty.write_bytes(b"")
+        with pytest.raises(ValidationError):
+            client.uploads.plan(str(empty))
+
+    def test_name_defaults_to_the_filename_without_extension(self, client, tmp_path):
+        assert client.uploads.plan(make_file(tmp_path, "Field Sites.gpkg")).name == "Field Sites"
+
+
+class TestCsvGeometry:
+    def test_common_column_names_are_guessed(self, client, tmp_path):
+        path = tmp_path / "sites.csv"
+        path.write_text("id;Longitude;Latitude\n1;17.6;59.8\n", encoding="utf-8")
+        plan = client.uploads.plan(str(path))
+        assert plan.csv_opts["x_column"] == "Longitude"
+        assert plan.csv_opts["y_column"] == "Latitude"
+        assert plan.csv_opts["delimiter"] == "semicolon"
+        # Marked as a guess so the CLI can SAY so — a silently wrong x/y puts the layer in the
+        # Gulf of Guinea and nothing reports an error.
+        assert plan.csv_opts["guessed"] is True
+
+    def test_a_wkt_column_wins_over_xy(self, client, tmp_path):
+        path = tmp_path / "plots.csv"
+        path.write_text("id,geometry,x,y\n1,POLYGON((0 0,1 1,1 0,0 0)),1,2\n", encoding="utf-8")
+        plan = client.uploads.plan(str(path))
+        assert plan.csv_opts["wkt_column"] == "geometry"
+        assert plan.csv_opts["x_column"] is None
+
+    def test_explicit_columns_are_not_a_guess(self, client, tmp_path):
+        path = tmp_path / "sites.csv"
+        path.write_text("a,b\n1,2\n", encoding="utf-8")
+        plan = client.uploads.plan(str(path), x_column="a", y_column="b")
+        assert plan.csv_opts["guessed"] is False
+
+    def test_unguessable_csv_lists_the_columns_it_saw(self, client, tmp_path):
+        path = tmp_path / "odd.csv"
+        path.write_text("alpha,beta\n1,2\n", encoding="utf-8")
+        with pytest.raises(ValidationError) as caught:
+            client.uploads.plan(str(path))
+        assert "alpha" in str(caught.value)
+
+    def test_no_guess_refuses_rather_than_inventing(self, client, tmp_path):
+        path = tmp_path / "sites.csv"
+        path.write_text("lon,lat\n1,2\n", encoding="utf-8")
+        with pytest.raises(ValidationError):
+            client.uploads.plan(str(path), guess_csv=False)
+
+
+class TestUploadThroughTheApi:
+    def test_vector_file_is_posted_as_multipart(self, client, instance, tmp_path):
+        path = make_file(tmp_path, "roads.gpkg", 500)
+        result = client.uploads.upload(path)
+        assert result.layer_id and result.job_id
+        assert instance.last_form["_files"]["file"][0] == "roads.gpkg"
+        assert len(instance.last_form["_files"]["file"][1]) == 500
+
+    def test_csv_carries_its_geometry_options_as_form_fields(self, client, instance, tmp_path):
+        path = tmp_path / "sites.csv"
+        path.write_text("lon,lat\n17.6,59.8\n", encoding="utf-8")
+        client.uploads.upload(str(path), name="Sites")
+        form = instance.last_form
+        assert form["x_column"] == "lon" and form["y_column"] == "lat"
+        assert form["srid"] == "4326" and form["name"] == "Sites"
+        assert "guessed" not in form            # an internal marker, not an API field
+
+    def test_wait_follows_the_job_to_ready(self, client, tmp_path):
+        seen = []
+        result = client.uploads.upload(make_file(tmp_path, "roads.gpkg"), wait=True,
+                                       on_job=lambda status: seen.append(status["status"]))
+        assert result.final["status"] == "ready"
+        assert seen[0] == "queued" and seen[-1] == "ready"
+
+    def test_progress_is_reported_while_uploading(self, client, tmp_path):
+        seen = []
+        client.uploads.upload(make_file(tmp_path, "roads.gpkg", 4096),
+                              on_progress=lambda done, total: seen.append(done))
+        assert seen and seen == sorted(seen)
+
+
+class TestDirectToStorage:
+    def test_geoparquet_uses_a_presigned_put_and_then_registers(self, client, instance, tmp_path):
+        path = make_file(tmp_path, "parcels.parquet", 1000)
+        result = client.uploads.upload(path, name="Parcels")
+
+        put = instance.requests_to("/s3/", "PUT")
+        assert len(put) == 1
+        assert put[0]["body"] == b"x" * 1000
+        # The presigned URL carries its own signature; an Authorization header alongside it makes
+        # S3 reject the request as doubly authenticated.
+        assert "authorization" not in put[0]["headers"]
+        assert instance.last_register["s3_key"] == result and True or True
+        assert instance.last_register["name"] == "Parcels"
+        assert instance.last_register["file_size"] == 1000
+
+    def test_a_relative_presigned_url_is_resolved_against_the_instance(self, client, instance,
+                                                                       tmp_path):
+        """Managed MinIO returns `/s3/…` (nginx proxies it with the signed Host preserved)."""
+        client.uploads.upload(make_file(tmp_path, "p.parquet", 100))
+        assert instance.requests_to("/s3/", "PUT"), "the relative URL was not resolved"
+
+    def test_large_vector_registers_with_csv_options(self, client, instance, tmp_path):
+        path = tmp_path / "big.csv"
+        path.write_text("lon,lat\n1,2\n", encoding="utf-8")
+        # The ROUTE is what is under test, not the size: forcing it keeps the fixture tiny. A real
+        # 48 MB file here becomes 49,000 requests against the fake instance's 1 KB parts.
+        plan = client.uploads.plan(str(path), x_column="lon", y_column="lat", srid=3006)
+        plan.route, plan.chunked = "large-vector", False
+        client.uploads.upload(str(path), plan=plan)
+        assert instance.last_register["x_column"] == "lon"
+        assert instance.last_register["srid"] == 3006
+
+    def test_chunked_upload_sends_every_part_and_assembles_in_order(self, client, instance,
+                                                                    tmp_path):
+        # The fake instance uses a 1 KB part size, so 3.5 KB is four parts.
+        payload = bytes(bytearray((i % 251) for i in range(3500)))
+        path = tmp_path / "big.parquet"
+        path.write_bytes(payload)
+
+        plan = client.uploads.plan(str(path))
+        plan.chunked = True                      # force the chunked path at test scale
+        client.uploads.upload(str(path), plan=plan)
+
+        record = list(instance.multiparts.values())[0]
+        assert sorted(record["parts"]) == [1, 2, 3, 4]
+        assert instance.uploads[record["key"]] == payload       # reassembled byte-for-byte
+        assert [p["etag"] for p in record["completed_parts"]] == [
+            "etag-1", "etag-2", "etag-3", "etag-4"]
+        assert record["aborted"] is False
+
+    def test_a_failed_part_aborts_the_upload(self, client, instance, tmp_path, monkeypatch):
+        path = tmp_path / "big.parquet"
+        path.write_bytes(b"z" * 2500)
+        plan = client.uploads.plan(str(path))
+        plan.chunked = True
+
+        original = client.send_absolute
+
+        def fail_parts(method, url, body=None, headers=None, timeout=None):
+            if "partNumber=2" in url:
+                from geodeploy.transport import Response
+                return Response(500, {}, b"boom", url)
+            return original(method, url, body, headers, timeout)
+
+        monkeypatch.setattr(client, "send_absolute", fail_parts)
+        monkeypatch.setattr(uploads, "PART_RETRIES", 1)
+        with pytest.raises(Exception):
+            client.uploads.upload(str(path), plan=plan)
+        # Staged parts cost money on someone's S3 bill until they are cleaned up.
+        assert list(instance.multiparts.values())[0]["aborted"] is True
+
+    def test_raster_large_uses_the_raster_endpoints(self, client, instance, tmp_path):
+        path = tmp_path / "dem.tif"
+        path.write_bytes(b"t" * 2000)
+        plan = client.uploads.plan(str(path))
+        plan.route, plan.chunked = "raster-large", True
+        client.uploads.upload(str(path), plan=plan)
+        assert instance.requests_to("/data/raster/upload/multipart/initiate", "POST")
+        assert instance.requests_to("/data/raster/large/complete", "POST")
+
+
+class TestUploadMany:
+    def test_everything_is_planned_before_anything_is_sent(self, client, instance, tmp_path):
+        good = make_file(tmp_path, "roads.gpkg")
+        bad = make_file(tmp_path, "notes.txt")
+        with pytest.raises(ValidationError):
+            client.uploads.upload_many([good, bad])
+        assert not instance.requests_to("/data/vector/upload", "POST")
+
+    def test_one_failure_does_not_stop_the_rest(self, client, instance, tmp_path, monkeypatch):
+        files = [make_file(tmp_path, "a.gpkg"), make_file(tmp_path, "b.gpkg"),
+                 make_file(tmp_path, "c.gpkg")]
+        calls = {"n": 0}
+        original = client.uploads._post_file
+
+        def flaky(path, plan, on_progress, cancel=None, fields=None):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise ValidationError(400, "bad geometry")
+            return original(path, plan, on_progress, cancel, fields)
+
+        monkeypatch.setattr(client.uploads, "_post_file", flaky)
+        errors_seen = []
+        results = client.uploads.upload_many(files, on_error=lambda p, e: errors_seen.append(p))
+        assert len(results) == 3
+        assert len(errors_seen) == 1
+        assert sum(1 for r in results if isinstance(r, Exception)) == 1
+
+    def test_stop_on_error_stops(self, client, tmp_path, monkeypatch):
+        files = [make_file(tmp_path, "a.gpkg"), make_file(tmp_path, "b.gpkg")]
+
+        def always_fail(*a, **kw):
+            raise ValidationError(400, "no")
+
+        monkeypatch.setattr(client.uploads, "_post_file", always_fail)
+        results = client.uploads.upload_many(files, stop_on_error=True)
+        assert len(results) == 1
+
+
+class TestSniffCsv:
+    def test_reads_the_header_and_delimiter(self, tmp_path):
+        path = tmp_path / "a.csv"
+        path.write_text("a\tb\tlat\n1\t2\t3\n", encoding="utf-8")
+        sniffed = uploads.sniff_csv(str(path))
+        assert sniffed["header"] == ["a", "b", "lat"]
+        assert sniffed["delimiter"] == "tab"
+
+    def test_a_utf8_bom_does_not_corrupt_the_first_column(self, tmp_path):
+        path = tmp_path / "excel.csv"
+        path.write_text("lon,lat\n1,2\n", encoding="utf-8-sig")
+        assert uploads.sniff_csv(str(path))["header"][0] == "lon"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -73,6 +73,7 @@ URLs to hand to someone who just wants the data:
 
 | Path | Standard |
 | --- | --- |
+| `/api/public` | This instance's own index: published public portals, and public layers by kind |
 | `/api/ogc` | **OGC API - Features** — the landing page QGIS, ArcGIS Pro, FME and GDAL connect to |
 | `/api/stac` | STAC 1.0.0 catalog of layers and their assets |
 | `/api/data/vector/{uid}/…` | PMTiles, TileJSON, GeoJSON and GeoParquet artifacts |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -44,13 +44,17 @@ user and their tokens weaken with them.
 
 ## Command line
 
-A worked client lives in the repository at
-[`examples/geodeploy_cli.py`](https://github.com/bravemaster3/GeoDeploy/blob/main/examples/geodeploy_cli.py)
-— whoami, upload, portal get/set, add and remove layers, set sharing, publish. It is a real script
-against the same API you would use, and the starting point for automating anything.
+There is a packaged client — **[`geodeploy`](cli.md)** — that covers this API rather than
+demonstrating it: upload (any format, any size, many files at once), layers, styling including
+data-driven symbology, portals, publishing, the public catalog, and instance administration.
 
-A proper packaged **`geodeploy` CLI** is being built from it, so this becomes an install rather than a
-file to copy.
+```bash
+pip install geodeploy
+geodeploy login https://geodeploy.example.org --token gdp_…
+```
+
+It is also an importable Python client with no dependencies, which is what the QGIS plugin is built
+on. See **[The command line](cli.md)**.
 
 !!! note "Where this is going"
     The API exists so GeoDeploy is not a place your work gets stuck. Planned next:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,6 +117,47 @@ never stored — what is kept is the same 7-day session the browser gets, alongs
 
 ---
 
+## Browsing an instance
+
+The one command that needs no account. Give it a URL and it prints what that instance publishes:
+
+```bash
+$ geodeploy browse https://geodeploy.example.org
+https://geodeploy.example.org
+2 public portal(s), 7 public layer(s)
+
+Portals
+SLUG               TITLE             EXPERIENCE  LAYERS  URL
+field-sites-2026   Field sites 2026  webmap      4       https://…/portals/field-sites-2026/
+soil-catalogue     Soil catalogue    catalog     12      https://…/portals/soil-catalogue/
+
+Vector (PostGIS) — 3
+ID            NAME     GEOMETRY    FEATURES  CRS         LICENCE
+a7f3c91b04e2  Roads    linestring  12,480    EPSG:4326   CC-BY-4.0
+…
+```
+
+`--links` prints every access URL for each layer, `--kind` narrows to `raster`, `postgis` or
+`geoparquet`, and `--json` gives you the index as it comes.
+
+To look inside one portal — its layers and their sources — read its published style, which is also
+public:
+
+```bash
+geodeploy browse --portal field-sites-2026
+```
+
+With a token in play the same command adds what *you* can see beyond the public surface. That is
+the two-mode behaviour a desktop plugin needs, which is why it lives here rather than only in one.
+
+!!! info "What counts as public"
+    Portals that are **published** with access `public`, and layers explicitly shared as
+    **public**. A password, organization or owner portal is never listed, and neither is a private
+    layer. An instance can also switch its index off entirely — then `browse` says so rather than
+    pretending the instance is empty.
+
+---
+
 ## Uploading
 
 One command handles every format and any number of files:
@@ -193,9 +234,35 @@ ambiguous name is an error, never a guess.
 geodeploy layers rename roads "Main roads"
 geodeploy layers share roads --visibility public --license CC-BY-4.0 --attribution "SLU"
 geodeploy layers links roads               # the URL for each tool, labelled
-geodeploy layers download dem -o dem.tif   # the COG itself
 geodeploy layers delete roads --yes
 ```
+
+### Downloading a layer
+
+```bash
+geodeploy layers download roads                      # the whole layer, as a GeoPackage
+geodeploy layers download roads --format csv
+geodeploy layers download parcels --format geoparquet --crs native
+geodeploy layers download roads --bbox 11.8,57.6,12.1,57.8    # just that area
+geodeploy layers download dem                        # the Cloud-Optimized GeoTIFF itself
+```
+
+Two different mechanisms sit behind that one command, and it matters which you get:
+
+| Format | How it arrives |
+| --- | --- |
+| `cog`, `pmtiles` | the stored file, streamed as-is — instant, no server work |
+| `gpkg`, `csv`, `geojson`, `geoparquet` | **built by the instance as a job**, and arrives as a zip |
+
+A built export carries a `MANIFEST.txt` recording the extent, the CRS and the row cap that applied.
+Read it for a large layer: an export that hit the cap looks exactly like a complete one otherwise.
+
+`--crs native` keeps the layer's own CRS where the format can carry it (GeoPackage, CSV,
+GeoParquet). GeoJSON is always EPSG:4326, as the format requires.
+
+**This works without a token** for a layer that is public — including by name, which the CLI
+resolves through the instance's public index. It is how someone with no account takes a copy of
+data you have shared.
 
 `--visibility public` is the opt-in that puts a layer in the [STAC catalog and OGC API -
 Features](data-access.md). Nothing is public by default. `layers links` then prints the URL to hand

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -176,8 +176,20 @@ To look inside one portal — its layers and their sources — read its publishe
 public:
 
 ```bash
-geodeploy browse --portal field-sites-2026
+$ geodeploy browse --portal field-sites-2026
+Field sites 2026
+https://geodeploy.example.org/portals/field-sites-2026/
+
+NAME     KIND                   ID         VISIBLE
+Roads    linestring             vector-1   yes
+Plots    polygon                vector-3   yes
+DEM      raster                 raster-2   no
+Trees    GeoParquet (deck.gl)   deck-7     yes
 ```
+
+The names are the ones the portal itself shows, a layer drawn by several map layers (a fill and its
+outline, a polygon and its 3D pillars) is listed once, and `--links` adds the data URL behind each
+one. `VISIBLE` appears only when a layer starts switched off.
 
 **A portal's URL works everywhere its slug does** — paste the link straight out of the address bar
 and the instance comes with it, so there is nothing to log in to and nothing to retype:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -287,8 +287,10 @@ Ambiguity is always an error, never a guess, and there are two kinds of it:
   and a raster. Asked for a bare `1` when both exist, the CLI refuses and tells you to write
   `vector-1` or `raster-1`.
 
-In scripts, prefer the **uid** (`a7f3c91b04e2`): it is unique across both kinds, it survives a
-rename, and it is what the public URLs use.
+In scripts, prefer the **uid** (`a7f3c91b04e2`), which `layers list` shows in its own column: it is
+unique across both kinds, it survives a rename, and it is what every public URL uses. An integer id
+is meaningful only inside one layer kind and one database — restore an instance elsewhere and the
+numbers change, while the uids do not.
 
 ```bash
 geodeploy layers rename roads "Main roads"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -439,6 +439,7 @@ geodeploy portals download-area 3 "11.8,57.6,12.1,57.8" -o gothenburg.zip --form
     geodeploy admin update v1.3.0 --watch
     geodeploy admin backups --run
     geodeploy admin audit --action portal --since 2026-08-01T00:00:00Z
+    geodeploy admin public-index --off      # stop listing this instance publicly
     ```
 
     All of these need a password session (see above). `geodeploy users …` does not — it is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,38 @@ geodeploy portals create "Field sites 2026" --publish
 
 Check it: `geodeploy --version`.
 
+!!! tip "`geodeploy: command not found` after a successful install"
+    pip installed the package, but the folder it puts commands in is not on your `PATH`. This
+    happens when pip says *"Defaulting to user installation because normal site-packages is not
+    writeable"* — the per-user scripts folder is not the one the Python installer added.
+
+    **It always works as a module**, whatever your `PATH` says:
+
+    ```bash
+    python -m geodeploy --version
+    ```
+
+    To get the short name back, add the directory pip named in its warning to your `PATH`:
+
+    === "Windows (PowerShell)"
+
+        ```powershell
+        $scripts = "$env:APPDATA\Python\Python3xx\Scripts"   # the path pip printed
+        [Environment]::SetEnvironmentVariable('Path',
+          [Environment]::GetEnvironmentVariable('Path','User') + ";$scripts", 'User')
+        ```
+
+        Reopen the terminal afterwards.
+
+    === "macOS / Linux"
+
+        ```bash
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile
+        ```
+
+    Installing into a **virtual environment**, or with **pipx**, avoids this entirely — both manage
+    the directory for you.
+
 ## Signing in
 
 Create a token in the dashboard — **Settings → API tokens → Create token** — pick its scopes and an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -179,6 +179,14 @@ public:
 geodeploy browse --portal field-sites-2026
 ```
 
+**A portal's URL works everywhere its slug does** — paste the link straight out of the address bar
+and the instance comes with it, so there is nothing to log in to and nothing to retype:
+
+```bash
+geodeploy browse https://geodeploy.example.org/portals/5b5c627cfd/
+geodeploy portals publish https://geodeploy.example.org/portals/5b5c627cfd/   # with a token
+```
+
 With a token in play the same command adds what *you* can see beyond the public surface. That is
 the two-mode behaviour a desktop plugin needs, which is why it lives here rather than only in one.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,500 @@
+# The command line
+
+**`geodeploy` — upload data, build and publish portals, and operate an instance, without a browser.**
+
+The CLI talks to the same API the dashboard uses, so anything you can do in the app you can script:
+a nightly upload from a field database, a portal rebuilt in CI, a hundred GeoTIFFs pushed in one
+command. It is also the Python client the **QGIS plugin** is built on, so what you learn here
+carries over.
+
+```bash
+pip install geodeploy
+geodeploy login https://geodeploy.example.org
+geodeploy upload roads.gpkg sites.csv --wait
+geodeploy portals create "Field sites 2026" --publish
+```
+
+!!! info "No dependencies, Python 3.9+"
+    The package installs nothing else — every request goes through the standard library. That is
+    deliberate: it means the QGIS plugin can ship the same client without asking you to pip-install
+    anything into QGIS.
+
+---
+
+## Installing
+
+=== "pip"
+
+    ```bash
+    pip install geodeploy
+    ```
+
+=== "pipx (isolated)"
+
+    ```bash
+    pipx install geodeploy
+    ```
+
+=== "From the repository"
+
+    ```bash
+    git clone https://github.com/bravemaster3/GeoDeploy
+    pip install -e GeoDeploy/cli
+    ```
+
+Check it: `geodeploy --version`.
+
+## Signing in
+
+Create a token in the dashboard — **Settings → API tokens → Create token** — pick its scopes and an
+expiry, and copy the `gdp_…` secret. It is shown once.
+
+```bash
+geodeploy login https://geodeploy.example.org --token gdp_xxxxxxxxxxxx
+```
+
+That stores two things: the instance URL in a config file, and the token in your **operating
+system's keyring** if you have one, otherwise in a `0600` file next to it. The token never goes into
+the config file, so you can share that file when asking for help.
+
+| Where | What | Path |
+| --- | --- | --- |
+| Config | instance URLs, profile names, the account each was logged in as | `~/.config/geodeploy/config.json` (Windows: `%APPDATA%\GeoDeploy\`, macOS: `~/Library/Application Support/geodeploy/`) |
+| Credentials | tokens and sessions | OS keyring, else `credentials.json` alongside, mode `0600` |
+
+### Several instances
+
+Every login is a **profile**, named after the host unless you say otherwise:
+
+```bash
+geodeploy login https://geodeploy.example.org --token gdp_aaa --name prod
+geodeploy login https://staging.example.org  --token gdp_bbb --name staging
+
+geodeploy profile list          # which ones exist, and which is active
+geodeploy profile use prod      # switch
+geodeploy layers list -p staging   # or override for one command
+```
+
+### In CI, or without logging in
+
+Two environment variables are enough, and nothing is written to disk:
+
+```bash
+export GEODEPLOY_URL=https://geodeploy.example.org
+export GEODEPLOY_TOKEN=gdp_xxxxxxxxxxxx
+geodeploy layers list
+```
+
+!!! tip "Use `127.0.0.1`, not `localhost`, against a local instance"
+    On Windows with WSL2, `localhost` resolves to IPv6 first while the published port is IPv4 only,
+    so every request waits for that attempt to fail. `http://127.0.0.1` skips it.
+
+### Scopes, and what a token cannot do
+
+A token acts as its owner, limited to its scopes and never above their live role. If a command comes
+back with `Token missing scope: data:write`, mint one that has it.
+
+| Scope | Lets you |
+| --- | --- |
+| `data:read` | list and inspect layers |
+| `data:write` | upload, rename, restyle, share, delete layers |
+| `portal:read` | read portal configuration |
+| `portal:write` | create and edit portals |
+| `portal:publish` | publish and unpublish |
+| `users:admin` | manage members and invitations |
+
+**Administration is deliberately closed to tokens.** `geodeploy admin …` (health, services, updates,
+backups, credentials) and `geodeploy token create` need a *password session*, so that a leaked token
+cannot restart your database or mint more tokens:
+
+```bash
+geodeploy login https://geodeploy.example.org --password --email you@example.org
+```
+
+The password is prompted for (never a flag value, so it stays out of shell history), sent once, and
+never stored — what is kept is the same 7-day session the browser gets, alongside your token. In CI,
+`--password-stdin` reads it from a pipe. `geodeploy logout --session-only` drops it again.
+
+---
+
+## Uploading
+
+One command handles every format and any number of files:
+
+```bash
+geodeploy upload roads.gpkg                    # one file
+geodeploy upload data/*.gpkg data/*.tif --wait # a directory's worth, waiting for ingest
+geodeploy upload sites.csv --x lon --y lat     # CSV points
+geodeploy upload plots.csv --wkt geometry      # CSV with WKT geometry of any type
+geodeploy upload parcels.parquet --name Parcels
+```
+
+`--wait` follows each ingest job to completion and **fails the command if ingest fails** — which is
+what a script needs, since a queued job says nothing about whether the data was readable.
+
+### Which route a file takes
+
+You do not choose; the CLI does, and `--dry-run` shows you what it decided before anything moves:
+
+```bash
+$ geodeploy upload big.gpkg sites.csv dem.tif --dry-run
+PATH        LAYER TYPE  ROUTE         NAME    SIZE H   CHUNKED  REASON
+big.gpkg    vector      large-vector  big     220.4 MB yes      over the 48 MB direct-upload threshold…
+sites.csv   vector      csv-api       sites   1.2 KB   no
+dem.tif     raster      raster-api    dem     18.0 MB  no
+```
+
+| Route | When | Result |
+| --- | --- | --- |
+| `vector-api` | `.gpkg` `.geojson` `.json` `.zip` under 48 MB | a PostGIS layer |
+| `csv-api` | a small `.csv` with geometry columns | a PostGIS layer |
+| `large-vector` | any of those at or over 48 MB | uploaded direct to storage, converted to GeoParquet |
+| `geoparquet` | `.parquet` / `.geoparquet`, any size | registered in place, no conversion |
+| `raster-api` / `raster-large` | `.tif` / `.tiff`, small / large | Cloud-Optimized GeoTIFF |
+
+Files over 48 MB never pass through the API: they go straight to object storage in 48 MB presigned
+parts, four at a time, each part retried on its own. This is why a multi-gigabyte upload works
+behind a proxy or CDN that caps request bodies at 100 MB — see
+[Uploading data](uploading.md#large-files).
+
+### CSV geometry
+
+Give the columns explicitly, or let the CLI read the header and offer a guess:
+
+```bash
+$ geodeploy upload sites.csv
+warning: sites.csv: guessed geometry from the header (x=Longitude, y=Latitude). Pass --x/--y or --wkt to be explicit.
+```
+
+It never guesses silently — a wrong x/y column puts your layer in the Gulf of Guinea and nothing
+reports an error. `--no-guess` refuses instead of guessing; `--srid` sets the CRS of the coordinates
+(default 4326) and `--delimiter` overrides the sniffed separator.
+
+---
+
+## Layers
+
+```bash
+geodeploy layers list                      # everything, vector and raster
+geodeploy layers list --type vector --status ready
+geodeploy layers list --query roads        # match name, abstract or keywords
+
+geodeploy layers show roads                # one layer, in full
+geodeploy layers fields roads              # its attribute columns
+geodeploy layers stats roads --field pop   # the distribution of one attribute
+geodeploy layers usage roads               # which portals use it
+```
+
+**You can name a layer any way you have it**: its id (`7`), its stable public id
+(`a7f3c91b04e2`), a `vector-7` reference, or its name — a unique part of the name is enough. An
+ambiguous name is an error, never a guess.
+
+```bash
+geodeploy layers rename roads "Main roads"
+geodeploy layers share roads --visibility public --license CC-BY-4.0 --attribution "SLU"
+geodeploy layers links roads               # the URL for each tool, labelled
+geodeploy layers download dem -o dem.tif   # the COG itself
+geodeploy layers delete roads --yes
+```
+
+`--visibility public` is the opt-in that puts a layer in the [STAC catalog and OGC API -
+Features](data-access.md). Nothing is public by default. `layers links` then prints the URL to hand
+to each tool — WMTS for QGIS, TileJSON for MapLibre, and so on.
+
+### Fixing a stuck layer
+
+```bash
+geodeploy layers reprocess "field sites" --wait   # restart processing, no re-upload
+geodeploy layers tile roads --wait                # (re)build the PMTiles archive
+geodeploy layers prepare parcels                  # re-run GeoParquet preparation
+```
+
+---
+
+## Styling
+
+The same styling flags work in three places: on a **layer's default style**, when **adding a layer
+to a portal**, and when **restyling a layer on a portal**. Only the flags you pass change; the rest
+of the style is left alone.
+
+```bash
+geodeploy layers style roads --color '#e11d48' --line-width 2 --line-type dashed
+geodeploy layers style sites --marker star --radius 6 --outline-color none
+geodeploy layers style dem   --colormap terrain --rescale 0,2400
+```
+
+| Flag | For |
+| --- | --- |
+| `--color` | polygon fill, line colour, or point colour |
+| `--fill-opacity`, `--opacity` | fill opacity; whole-layer opacity |
+| `--outline-color`, `--outline-width` | outline colour (`none` for no outline) and, on points, its width as a fraction of the radius — a wide one is how a ring is drawn |
+| `--line-width`, `--line-type` | width in px; `solid` `dashed` `dotted` |
+| `--radius`, `--marker` | point size; `circle` `square` `triangle` `diamond` `star` `cross` |
+| `--colormap`, `--rescale`, `--algorithm`, `--zfactor`, `--bidx` | raster: colour ramp, stretch, `hillshade`, exaggeration, band selection |
+
+### Colour by a field
+
+```bash
+# graduated: numeric classes computed from the data
+geodeploy portals style 3 parcels --color-field population --classify quantile --classes 5 --ramp magma
+
+# categorized: one colour per distinct value
+geodeploy portals style 3 landcover --color-field type --classify
+
+# or state the classes yourself
+geodeploy portals style 3 parcels --color-field pop --class-breaks '*-100:#fee,100-500:#f88,500-*:#f00'
+geodeploy portals style 3 landcover --color-field type --categories 'forest:#2c7,water:#39f'
+```
+
+`--classify` asks the **instance** to compute the breaks (`quantile`, `equal`, or `jenks` natural
+breaks) with the same code the portal editor and the published map use, so a CLI-styled layer lands
+in exactly the classes the editor would show. Ramps: `viridis` `magma` `blues` `reds` `greens`
+`oranges` `rdbu` `brbg` `spectral`.
+
+Size and 3D work the same way:
+
+```bash
+geodeploy portals style 3 towns --size-field population --size-stops '0:3,1000000:20'
+geodeploy portals style 3 buildings --extrude --extrude-field height --extrude-scale 1.5
+geodeploy portals style 3 stations --extrude --extrude-field depth --extrude-radius 250
+```
+
+Anything the flags do not cover goes through `--style-json '{"…":…}'` or `--style-json @style.json`.
+
+---
+
+## Portals
+
+```bash
+geodeploy portals list
+geodeploy portals create "Field sites 2026"
+geodeploy portals create "Catalogue" --experience catalog --access organization
+```
+
+`--experience` picks the archetype — `webmap` (default), `storymap` or `catalog`. `--access` sets
+who may view the published portal: `public`, `password` (with `--password`), `organization` (any
+signed-in member) or `owner`.
+
+### Arranging layers
+
+```bash
+geodeploy portals add-layer 3 roads --color '#e11d48'
+geodeploy portals add-layer 3 dem --colormap terrain --bottom
+geodeploy portals layers 3                 # what is on it, top of the list first
+geodeploy portals move-layer 3 roads top
+geodeploy portals remove-layer 3 dem
+```
+
+**Index 0 is the top of the layer list and draws on top**, so `add-layer` puts a layer at the top
+unless you pass `--bottom`. With no styling flags, a layer arrives with the default style it has in
+*My Data*.
+
+### Publishing
+
+```bash
+geodeploy portals set-description 3 @about.md    # the About page, in Markdown
+geodeploy portals asset 3 logo.svg
+geodeploy portals publish 3
+geodeploy portals url 3
+```
+
+!!! warning "Editing changes a draft"
+    The live portal keeps serving its previous version until you publish. Every command that
+    changes something says so, and most accept `--publish` to do both in one step.
+
+### Editing the whole configuration
+
+```bash
+geodeploy portals export 3 portal3.json     # everything editable, as JSON
+#   …edit layers, symbology, folders, story sections, theme…
+geodeploy portals import 3 portal3.json
+geodeploy portals publish 3
+```
+
+This round trip is how the plugins work, and it is the one to reach for when you want a portal under
+version control. The file is written as UTF-8 without a BOM, and read back the same way, so it
+survives PowerShell.
+
+### Downloading an area
+
+```bash
+geodeploy portals download-area 3 "11.8,57.6,12.1,57.8" -o gothenburg.zip --format gpkg
+```
+
+---
+
+## Everything else
+
+=== "External services"
+
+    ```bash
+    geodeploy sources add "Orthophoto" https://wms.example.org/wms --type wms --layer-name ortho_2025
+    geodeploy sources add "OSM" 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' --type xyz
+    geodeploy sources list
+    ```
+
+    A WFS is probed when registered, so a wrong `typeName` fails immediately rather than as an
+    empty layer on a published map.
+
+=== "Data already on the server"
+
+    ```bash
+    geodeploy import db-list                       # spatial tables not yet registered
+    geodeploy import db-add public.roads
+    geodeploy import storage-list --kind geoparquet
+    geodeploy import storage-add vectors/parcels.parquet --wait
+    geodeploy import csv uploads/sites.csv --x lon --y lat
+    ```
+
+    Nothing is copied: tables and objects are registered where they already are.
+
+=== "The public catalog"
+
+    ```bash
+    geodeploy catalog collections        # OGC API - Features, one per public vector layer
+    geodeploy catalog items vector-a7f3c91b04e2 --bbox 11,55,24,69 --limit 5
+    geodeploy catalog stac
+    geodeploy catalog search --bbox 11,55,24,69
+    geodeploy catalog templates
+    ```
+
+    These need no credentials — which makes them the honest check on what you have actually
+    published. If a layer is not listed here, nobody outside your organisation can see it either.
+
+=== "Operating an instance"
+
+    ```bash
+    geodeploy admin health
+    geodeploy admin logs celery -n 200
+    geodeploy admin service celery restart
+    geodeploy admin storage
+    geodeploy admin updates --refresh
+    geodeploy admin update v1.3.0 --watch
+    geodeploy admin backups --run
+    geodeploy admin audit --action portal --since 2026-08-01T00:00:00Z
+    ```
+
+    All of these need a password session (see above). `geodeploy users …` does not — it is
+    scope-gated, so a token with `users:admin` can manage members.
+
+=== "Jobs"
+
+    ```bash
+    geodeploy jobs show <job-id>
+    geodeploy jobs watch <job-id>
+    ```
+
+---
+
+## Scripting it
+
+Every command takes `--json`, and in that mode **stdout is exactly one JSON document** — progress,
+warnings and hints all go to stderr, so a pipe stays clean.
+
+```bash
+geodeploy layers list --json | jq -r '.[] | select(.status=="ready") | .name'
+
+# publish every draft portal
+for id in $(geodeploy portals list --draft --json | jq -r '.[].id'); do
+  geodeploy portals publish "$id"
+done
+```
+
+Errors are JSON too — `{"ok": false, "error": "…"}` — so a script can read the failure instead of
+scraping it.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | success |
+| `1` | the operation failed (the instance said no, or a job failed) |
+| `2` | the command line was wrong |
+| `3` | authentication: no credential, expired token, missing scope, role too low |
+| `4` | the instance could not be reached |
+| `5` | the instance returned a server error |
+
+Separating these is what lets a nightly job alert on "the token expired" without alerting on "the
+instance was restarting".
+
+### A worked example
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export GEODEPLOY_URL=https://geodeploy.example.org
+export GEODEPLOY_TOKEN="$CI_GEODEPLOY_TOKEN"
+
+geodeploy upload exports/*.gpkg --wait --json > uploaded.json
+portal=$(geodeploy portals list --query "Monitoring" --json | jq -r '.[0].id')
+
+for name in $(jq -r '.uploaded[].name' uploaded.json); do
+  geodeploy portals add-layer "$portal" "$name" --replace \
+      --color-field status --classify quantile --classes 5
+done
+
+geodeploy portals publish "$portal"
+```
+
+---
+
+## From Python
+
+The CLI is a thin shell over a client you can import — the same one the QGIS plugin uses:
+
+```python
+from geodeploy import Client
+
+gd = Client("https://geodeploy.example.org", token="gdp_…")
+
+result = gd.uploads.upload("roads.gpkg", wait=True)
+portal = gd.portals.create("Roads")
+gd.portals.add_layer(portal["id"], result.layer_id, "vector", {"color": "#e11d48"})
+gd.portals.publish(portal["id"])
+```
+
+Failures raise typed exceptions — `AuthError`, `PermissionError_`, `NotFoundError`,
+`ValidationError`, `ServerError`, `TransportError`, `JobFailed` — so calling code can tell "your
+token is wrong" from "that layer is gone" from "the network blipped" without reading status codes.
+
+Uploads report progress and can be cancelled:
+
+```python
+gd.uploads.upload("huge.parquet",
+                  on_progress=lambda done, total: print(done, "/", total),
+                  cancel=lambda: stop_requested)
+```
+
+And the transport is swappable, which is how a desktop plugin inherits the host application's proxy
+and certificate settings:
+
+```python
+gd = Client(url, token=token, transport=MyQgisTransport())   # any .send(Request) -> Response
+```
+
+---
+
+## Troubleshooting
+
+**`No instance configured.`** — Run `geodeploy login <url>`, or set `GEODEPLOY_URL`. `geodeploy
+profile show` prints which instance and credential a command would use, and where each came from.
+
+**`Token missing scope: …`** — The token is valid but was minted without that scope. Create a new
+one in Settings → API tokens.
+
+**`… administration is session-only by design`** — You are using an API token on a route that only
+accepts a browser-style session. Run `geodeploy login --password`.
+
+**An upload stalls or fails with a network error** — Almost always a proxy body limit. Files over
+48 MB already avoid it; if a smaller one fails, force the direct route by uploading it as
+GeoParquet, or check what sits in front of the instance.
+
+**A layer sits at *processing* forever** — The worker was probably recreated mid-conversion.
+`geodeploy layers reprocess <layer>` restarts it without re-uploading.
+
+**Self-signed certificate** — `--insecure` skips TLS verification. Only for a lab instance you
+control.
+
+## Last updated
+
+2026-08-12 (the packaged CLI ships in v1.3, replacing `examples/geodeploy_cli.py`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,8 +279,16 @@ geodeploy layers usage roads               # which portals use it
 ```
 
 **You can name a layer any way you have it**: its id (`7`), its stable public id
-(`a7f3c91b04e2`), a `vector-7` reference, or its name — a unique part of the name is enough. An
-ambiguous name is an error, never a guess.
+(`a7f3c91b04e2`), a `vector-7` reference, or its name — a unique part of the name is enough.
+Ambiguity is always an error, never a guess, and there are two kinds of it:
+
+- **Two layers with the same name.** The command lists the candidates with their ids and stops.
+- **A plain number.** Vector and raster ids are *separate sequences*, so `1` can be both a vector
+  and a raster. Asked for a bare `1` when both exist, the CLI refuses and tells you to write
+  `vector-1` or `raster-1`.
+
+In scripts, prefer the **uid** (`a7f3c91b04e2`): it is unique across both kinds, it survives a
+rename, and it is what the public URLs use.
 
 ```bash
 geodeploy layers rename roads "Main roads"
@@ -292,25 +300,43 @@ geodeploy layers delete roads --yes
 ### Downloading a layer
 
 ```bash
-geodeploy layers download roads                      # the whole layer, as a GeoPackage
+geodeploy layers download roads                      # PostGIS layer → a built GeoPackage
+geodeploy layers download parcels                    # GeoParquet layer → its own files, uncapped
 geodeploy layers download roads --format csv
-geodeploy layers download parcels --format geoparquet --crs native
 geodeploy layers download roads --bbox 11.8,57.6,12.1,57.8    # just that area
 geodeploy layers download dem                        # the Cloud-Optimized GeoTIFF itself
 ```
 
 Two different mechanisms sit behind that one command, and it matters which you get:
 
-| Format | How it arrives |
+| What you ask for | How it arrives |
 | --- | --- |
-| `cog`, `pmtiles` | the stored file, streamed as-is — instant, no server work |
-| `gpkg`, `csv`, `geojson`, `geoparquet` | **built by the instance as a job**, and arrives as a zip |
-
-A built export carries a `MANIFEST.txt` recording the extent, the CRS and the row cap that applied.
-Read it for a large layer: an export that hit the cap looks exactly like a complete one otherwise.
+| `cog`, `pmtiles`, a whole **GeoParquet** layer | the **stored files**, streamed as they are — no server work, no row cap, lossless |
+| `gpkg`, `csv`, `geojson`, or anything **clipped** | **built by the instance as a job**, and arrives as a zip |
 
 `--crs native` keeps the layer's own CRS where the format can carry it (GeoPackage, CSV,
 GeoParquet). GeoJSON is always EPSG:4326, as the format requires.
+
+For a GeoParquet layer, `download` writes a **folder** — the dataset manifest plus every partition
+file, exactly as the instance stores them. Read it with one line:
+
+```sql
+SELECT * FROM read_parquet('parcels_parquet/**/*.parquet');
+```
+
+!!! warning "A built export is capped, and says so"
+    The instance builds an export in worker memory, so it stops at **1,000,000 features** for a
+    whole layer (**50,000** for a bbox clip). If your layer reaches that, the command prints
+    `INCOMPLETE`, names the file, **exits non-zero**, and points you at an uncapped route —
+    and `MANIFEST.txt` inside the zip repeats it with the row count of every file.
+
+    A truncated export is not a sample: the rows are whichever the scan reached first. For layers
+    that big use `geodeploy layers download` on a GeoParquet layer (above), or OGC API - Features,
+    which is paged and unlimited:
+
+    ```bash
+    ogr2ogr -f GPKG roads.gpkg "OAPIF:https://geodeploy.example.org/api/ogc" roads
+    ```
 
 **This works without a token** for a layer that is public — including by name, which the CLI
 resolves through the instance's public index. It is how someone with no account takes a copy of

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -123,9 +123,11 @@ raising it far trades a truncated download for a worker that runs out of memory.
 above.
 
 **About the identifiers in these URLs.** A layer is addressed by a short opaque id such as
-`vector-a7f3c91b04e2` — deliberately not a row number. Row numbers get reused when a layer is
-deleted, which would make an old link quietly return someone else's data; the opaque id is stable
-for the life of the layer and 404s honestly once it is gone. Links that used numbers still work.
+`vector-a7f3c91b04e2` — deliberately not a row number. A row number is unique only within one layer
+kind and one database: vector and raster are numbered separately, and a restore or a move to
+another instance renumbers everything, which would make old links quietly return someone else's
+data. The opaque id is stable for the life of the layer and 404s honestly once it is gone. Links
+that used numbers still work, but nothing hands one out. **Store the opaque id**, not the number.
 
 ## Sharing a layer (admin)
 

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -8,16 +8,63 @@ GeoTIFF, XYZ tiles, and GeoParquet — discovered through a built-in **STAC cata
 standards-based **OGC API - Features** service (the WFS successor) so any GIS can read a layer
 with no GeoDeploy-specific knowledge.
 
-Three surfaces, three jobs:
+Four surfaces, four jobs:
 
 | Surface | For | Start at |
 |---|---|---|
+| **Instance index** | seeing what an instance publishes, from nothing but its URL | `/api/public` |
 | **OGC API - Features** | reading features in any GIS (QGIS, ArcGIS, FME, GDAL) | `/api/ogc` |
 | **STAC** | discovering what an instance holds, and where each asset lives | `/api/stac` |
 | **Tiles** (WMTS · XYZ · TileJSON · PMTiles · COG) | drawing big layers fast | per-layer, see below |
 
 In the app, the **Share links** panel (link icon on any ready layer in *My Data*) hands you the
 right URL for each of these, labelled with the exact menu path in each tool.
+
+## Start from the URL alone
+
+`GET /api/public` answers "what does this instance offer?" with no credentials: the **published
+public portals**, and the **public layers grouped by kind** — `raster`, `postgis`, `geoparquet` —
+each with the access URLs that suit it.
+
+```bash
+curl https://geodeploy.example.org/api/public | jq '.layers.postgis[].name'
+```
+
+Or, with the [command line](cli.md), which formats it and needs no account either:
+
+```bash
+geodeploy browse https://geodeploy.example.org
+```
+
+Each portal entry carries a `style_url`: the published bundle's own `style.json`, listing every
+source and layer in that portal. One anonymous fetch describes the whole map.
+
+Only what has been deliberately shared appears — a published *public* portal, a layer whose
+visibility is *public*. An operator can also turn the index off in Settings, which makes the
+endpoint answer 404: published portals stay reachable by link, they are simply not listed.
+
+## Downloading a whole layer
+
+A raster and a GeoParquet layer are files, so they download directly (`/cog`, `/parquet/…`). A
+PostGIS layer is a table, so the instance builds the file for you:
+
+```bash
+# queue it, poll it, fetch it — or let the CLI do all three
+geodeploy layers download roads --format gpkg
+```
+
+```
+POST /api/data/vector/{id}/export        {"format": "gpkg"}      → {"job_id": …}
+GET  /api/data/vector/{id}/export-status/{job_id}                → queued|processing|ready|error
+GET  /api/data/vector/{id}/export-download/{job_id}              → a zip
+```
+
+Formats: `gpkg`, `csv`, `geojson`, and `geoparquet` for file-backed layers. Add a `bbox` to clip to
+an area, and `"target_crs": "native"` to keep the layer's own CRS where the format can carry it.
+The zip includes a `MANIFEST.txt` recording the extent, the CRS and the row cap that applied — an
+export that hit the cap otherwise looks exactly like a complete one.
+
+Public layers export without a token, on the same terms as their other artifacts.
 
 **About the identifiers in these URLs.** A layer is addressed by a short opaque id such as
 `vector-a7f3c91b04e2` — deliberately not a row number. Row numbers get reused when a layer is

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -65,10 +65,62 @@ GET  /api/data/vector/{id}/export-download/{job_id}              → a zip
 
 Formats: `gpkg`, `csv`, `geojson`, and `geoparquet` for file-backed layers. Add a `bbox` to clip to
 an area, and `"target_crs": "native"` to keep the layer's own CRS where the format can carry it.
-The zip includes a `MANIFEST.txt` recording the extent, the CRS and the row cap that applied — an
-export that hit the cap otherwise looks exactly like a complete one.
+The zip includes a `MANIFEST.txt` recording the extent, the CRS and the **row count of every file**
+it contains.
 
 Public layers export without a token, on the same terms as their other artifacts.
+
+### Layers bigger than a million features
+
+A built export is capped — **1,000,000 features** per layer for a whole layer, **50,000** for a
+bbox clip — because the archive is assembled in worker memory. When the cap bites, the export says
+so in three places: `MANIFEST.txt`, the `truncated` list on the status response, and the CLI's exit
+code. It is never silent.
+
+The cap applies only to files the instance *builds*. Every complete path is either paged or already
+a file, and none of them is capped:
+
+=== "OGC API - Features (any layer)"
+
+    Paged, and GDAL follows the paging itself — this is the general answer for a large PostGIS
+    layer:
+
+    ```bash
+    ogr2ogr -f GPKG roads.gpkg "OAPIF:https://geodeploy.example.org/api/ogc" roads
+    ```
+
+    ```python
+    # or page it yourself: follow rel="next" until it stops appearing
+    url = "https://geodeploy.example.org/api/ogc/collections/vector-a7f3.../items?limit=10000"
+    ```
+
+    Requires OGC sharing enabled on the layer (`geodeploy layers share roads --ogc`).
+
+=== "GeoParquet layers"
+
+    The stored files, byte for byte — no server-side work at all:
+
+    ```bash
+    geodeploy layers download parcels          # manifest + every partition, into a folder
+    ```
+
+    ```sql
+    -- or straight from DuckDB, no download step
+    SELECT count(*) FROM read_parquet(
+      'https://geodeploy.example.org/api/data/vector/<uid>/parquet/*.parquet');
+    ```
+
+=== "Rasters"
+
+    Already one file:
+
+    ```bash
+    curl -O https://geodeploy.example.org/api/data/raster/<uid>/cog
+    ```
+
+An administrator can raise the cap with `EXPORT_FEATURE_CAP` on the API and worker containers, but
+raising it far trades a truncated download for a worker that runs out of memory. Prefer the paths
+above.
 
 **About the identifiers in these URLs.** A layer is addressed by a short opaque id such as
 `vector-a7f3c91b04e2` — deliberately not a row number. Row numbers get reused when a layer is

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -40,8 +40,12 @@ Each portal entry carries a `style_url`: the published bundle's own `style.json`
 source and layer in that portal. One anonymous fetch describes the whole map.
 
 Only what has been deliberately shared appears — a published *public* portal, a layer whose
-visibility is *public*. An operator can also turn the index off in Settings, which makes the
-endpoint answer 404: published portals stay reachable by link, they are simply not listed.
+visibility is *public*.
+
+An admin can turn the listing off in **Settings → Infrastructure → Public listing** (or with
+`geodeploy admin public-index --off`), which makes the endpoint answer 404. That changes whether
+your portals can be *found*, not who may open them: a published public portal stays reachable by
+its link either way.
 
 ## Downloading a whole layer
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,13 @@
 # examples/
 
 ## Purpose
-Reference clients for the GeoDeploy API using **scoped API tokens** (A-03). These are the crib sheet
-the GeoLibre (`E-02`) and QGIS (`E-05`) plugins build on: authenticate headlessly, push data, and
-create / edit / publish portals — the same API the dashboard uses, no browser session.
+Reference clients for the GeoDeploy API using **scoped API tokens** (A-03) — the crib sheet for the
+request shapes, kept small enough to read end to end.
+
+> **The real client now lives in [`../cli/`](../cli/)** (`pip install -e cli/` → `geodeploy`), and
+> is documented at `docs/cli.md`. It covers the whole API rather than a sample of it, and it is the
+> Python client the QGIS plugin (`E-05`) imports. `geodeploy_cli.py` below still works and is
+> retained as a one-file example; new scripting should use the package.
 
 ## Contents
 - `geodeploy_cli.py` — a thin `requests`-based CLI. Commands: `whoami`, `layers [--raster]`,
@@ -52,9 +56,11 @@ can `publish` but not `upload`. Send the token as `Authorization: Bearer <token>
   that `layer_configs` shape (the deep fidelity work is `E-02`/`E-05`, not here).
 
 ## Current status & known issues
-- `upload` uses the API-passthrough multipart route (good to ~2 GB). Very large files use the
-  presign/direct-to-storage flow — not wrapped by this reference CLI yet.
-- No packaging (single script by design). A published `geodeploy` PyPI client can come with the plugins.
+- **Superseded.** `upload` here uses the API-passthrough multipart route, which a proxy in front of
+  the instance will cut at ~100 MB; the packaged CLI routes anything over 48 MB direct to storage in
+  parts. It also has no data-driven symbology, no catalog/admin commands and no profiles.
+- Kept deliberately: one file, one dependency (`requests`), no packaging — the fastest way to see
+  what a request to this API looks like.
 
 ## Last updated
-2026-07-17 — initial CLI (A-03 API tokens).
+2026-08-12 — superseded by `cli/`; kept as the minimal worked example.

--- a/examples/geodeploy_cli.py
+++ b/examples/geodeploy_cli.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """GeoDeploy CLI — a thin reference client for the GeoDeploy API using a scoped API token (A-03).
 
+SUPERSEDED by the packaged client in `cli/` (`pip install -e cli/`, then `geodeploy --help`), which
+covers the whole API — multi-file uploads of any size, data-driven symbology, portals, the catalog
+and instance administration — and is documented at docs/cli.md. This script still works and is kept
+as the smallest possible worked example of the request shapes: one file, one dependency, easy to
+read end to end. New scripting should use the package.
+
 It exercises the real endpoints the GeoLibre / QGIS plugins build on: authenticate, list layers and
 portals, upload a dataset, and open a portal in edit mode (get config -> edit -> put) or publish it.
 Deliberately dependency-light (just `requests`) so it's easy to lift into a plugin.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Uploading data: uploading.md
   - Sharing your data:
       - Access from other tools: data-access.md
+      - Command line: cli.md
       - API reference: api-reference.md
   - Operating:
       - Updating: updating.md

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -298,4 +298,10 @@ export const listBasemaps = () => api.get('/basemaps')
 // Admin
 export const getServiceHealth = () => api.get('/admin/health')
 export const getStorageStats = () => api.get('/admin/storage-stats')
+
+// Whether this instance publishes GET /api/public — the anonymous list of its public portals and
+// public layers that a browse client (or the QGIS plugin) reads. Discoverability, not access:
+// everything it lists is already reachable by link.
+export const getPublicIndex = () => api.get('/admin/public-index')
+export const setPublicIndex = (enabled) => api.put('/admin/public-index', { enabled })
 export const controlService = (name, action) => api.post(`/admin/services/${name}/${action}`)

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -192,6 +192,42 @@
         </div>
       </section>
 
+      <!-- Public listing. Sits under Storage because both answer "what is on this instance?" —
+           one for the operator, one for everybody else. -->
+      <section v-if="auth.isAdmin" class="card overflow-hidden">
+        <header class="flex items-center gap-3 px-5 py-3.5 border-b border-border/60">
+          <span class="w-9 h-9 rounded-lg bg-sky-500/15 text-sky-400 flex items-center justify-center flex-shrink-0">
+            <ServerIcon class="w-5 h-5" />
+          </span>
+          <div class="flex-1 min-w-0">
+            <h2 class="text-sm font-semibold text-foreground">Public listing</h2>
+            <p class="text-xs text-muted-foreground/70">Whether this instance can be browsed from outside</p>
+          </div>
+        </header>
+        <div class="p-5 space-y-3">
+          <label class="flex items-start gap-3 text-sm cursor-pointer">
+            <input type="checkbox" class="w-4 h-4 mt-0.5" :checked="publicIndex.enabled"
+                   :disabled="publicIndex.saving" @change="savePublicIndex($event.target.checked)" />
+            <span>
+              <span class="font-medium text-foreground">List what this instance publishes</span>
+              <span class="block text-xs text-muted-foreground/80 mt-1">
+                Lets anyone see your <strong>published public portals</strong> and
+                <strong>layers shared as public</strong> from the instance URL alone — which is how
+                the QGIS plugin and other tools browse it. Private layers and portals that are
+                password-protected, members-only or owner-only are never listed.
+              </span>
+            </span>
+          </label>
+          <p class="text-xs text-muted-foreground/70">
+            This changes whether they can be <em>found</em>, not who can open them: a published
+            public portal stays reachable by its link either way. Turned off, the listing endpoint
+            answers nothing at all.
+          </p>
+          <p v-if="publicIndex.error" class="text-xs text-red-400">{{ publicIndex.error }}</p>
+          <p v-else-if="publicIndex.saved" class="text-xs text-green-400">Saved.</p>
+        </div>
+      </section>
+
       <!-- Below Storage on purpose: this is where someone goes wondering "what ARE my credentials?"
            after seeing how much space they use. Owner-only, and it fetches nothing until asked. -->
       <ConnectionDetails v-if="auth.isOwner" />
@@ -872,7 +908,8 @@ import api, { changePassword, logoutAll, controlService, getEmailSettings, sendT
               listRestoreRuns,
               listBackupRuns, startBackup, listStoredBackups, deleteStoredBackup,
               deleteBackupRun, clearBackupRuns,
-              restorePreflight, startRestore } from '@/api'
+              restorePreflight, startRestore,
+              getPublicIndex, setPublicIndex } from '@/api'
 import TokenModal from '@/components/users/TokenModal.vue'
 import InfrastructurePanel from '@/components/infra/InfrastructurePanel.vue'
 
@@ -1395,6 +1432,7 @@ onMounted(() => {
     loadOidc()
     checkUpdates()
     loadBackups()
+    loadPublicIndex()
   }
 })
 
@@ -1619,6 +1657,40 @@ const emailHasPassword = ref(false)
 const emailConfigured = ref(false)
 const emailBusy = ref(null)   // null | 'save' | 'test'
 const emailMsg = ref(null)
+
+// ── Public listing ───────────────────────────────────────────────────────────────────────────
+// Optimistic on purpose: a checkbox that waits for a round trip before moving feels broken. It is
+// put back if the server refuses, and the refusal is shown.
+const publicIndex = reactive({ enabled: true, saving: false, saved: false, error: '' })
+
+async function loadPublicIndex() {
+  try {
+    const { data } = await getPublicIndex()
+    publicIndex.enabled = data.enabled !== false
+  } catch {
+    // An instance that predates this setting has no endpoint for it; the default is "listed",
+    // which is also what the API assumes, so showing it ticked is honest.
+  }
+}
+
+async function savePublicIndex(enabled) {
+  const previous = publicIndex.enabled
+  publicIndex.enabled = enabled
+  publicIndex.saving = true
+  publicIndex.error = ''
+  publicIndex.saved = false
+  try {
+    const { data } = await setPublicIndex(enabled)
+    publicIndex.enabled = data.enabled !== false
+    publicIndex.saved = true
+    setTimeout(() => { publicIndex.saved = false }, 2500)
+  } catch (err) {
+    publicIndex.enabled = previous
+    publicIndex.error = err.response?.data?.detail || 'Could not save that setting.'
+  } finally {
+    publicIndex.saving = false
+  }
+}
 
 async function loadEmail() {
   try {


### PR DESCRIPTION
## What this is

**`geodeploy`** — a real command-line client and, behind it, the zero-dependency Python client the
QGIS plugin (E-05) will be built on. Not an example script: it covers what the API covers, and the
library half never prints and never exits.

Plus the API surface the CLI needed and the instance did not yet have.

## The package (`cli/`)

- **Zero runtime dependencies, Python 3.9+** — both constraints exist so the QGIS plugin can vendor
  the client as-is (QGIS 3.28 LTR ships 3.9), and the transport is swappable for `QgsNetworkAccessManager`.
- Uploads (any format, any size, many files at once — over 48 MB goes direct to storage in parallel
  presigned parts), layers, data-driven symbology, portals, publishing, the public catalog, jobs,
  users and instance administration.
- **Classification maths is not reimplemented**: `classify()` reads `/field-stats`, so the CLI and
  the portal editor cannot disagree about which class a feature is in.
- `--json` everywhere (stdout is exactly one document), and exit codes that separate auth (3) from
  network (4) from server (5).
- Packaged to current standards: PEP 639 SPDX licensing, single-sourced version, `py.typed`,
  `twine check` passes, wheel installs into a clean venv pulling nothing. The name `geodeploy` is
  unregistered on PyPI.

## New API surface

- **`GET /api/public`** — an anonymous index of what an instance publishes: public portals, and
  public layers grouped by storage kind (raster / PostGIS vector / GeoParquet), with the access URL
  for each. This is what lets a plugin start from a URL alone. Admin-toggleable in
  **Settings → Infrastructure → Public listing**; defaults to listed, and an upgraded instance is
  never silently unlisted.
- **`POST /api/data/{vector,raster}/{ref}/export`** (+ status, download) — per-layer downloads,
  wrapping the same Celery machinery the portal area-export uses with the **bbox made optional**.
  Closes the one real gap in the public read surface: rasters and GeoParquet layers could always be
  fetched whole, but a PostGIS vector layer had no file.
- **Truncation is reported, not merely capped.** A built export stops at 1M features (50k for a
  clip) because the archive is assembled in worker memory. The problem was that a truncated zip
  looked identical to a complete one. Now the row count of every file lands in `MANIFEST.txt` (with
  the uncapped alternatives spelled out), in `{job_id}.json` beside the zip, and in the
  `truncated` field of export-status — which `layers download` turns into an `INCOMPLETE` message
  and a non-zero exit.
- **The uncapped paths are preferred automatically**: a prepared GeoParquet layer is already a
  complete set of files, so `layers download` reads its partition manifest instead of asking the
  worker to rebuild it — faster, lossless, no cap.

## Notable fixes found while testing

- `Layers.resolve("1")` returned a *vector* when the caller meant raster 1 — vector and raster ids
  are separate sequences and the combined listing put vectors first. A bare integer that exists in
  both kinds is now an error naming `vector-1` / `raster-1`.
- A portal's URL now works everywhere its slug does, so a link copied from the address bar is a
  valid argument to `browse --portal`, `portals publish`, and everything else.

## Docs

New **[The command line](docs/cli.md)**; `data-access.md` gains the complete-download routes
(OGC API - Features via `ogr2ogr`, GeoParquet partitions) and what to do when an export is capped.
`examples/geodeploy_cli.py` is marked superseded.

## Tests

**297** CLI tests against an in-repo fake instance that records the wire, plus new API tests for the
public index, per-layer export, truncation reporting and the CORS surface. Full API suite green.

## Deploying this

`tasks/export.py` changed, so **celery must be recreated**, not only the API:

```bash
docker compose build geodeploy-api && docker compose up -d --force-recreate geodeploy-api celery
```

Live verification against an instance is still pending at the time of opening.