### PR TITLE
feat(api,cli): serve the legend, and give the client a way to read a style

### DIFF
--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -359,13 +359,13 @@ _PUBLIC_CORS = re.compile(
     # 488c2c7f55d7) since 2026-07-29 — a digits-only pattern silently stopped matching them, so
     # the header was never added and every browser client (GeoLibre, web maps) rejected a response
     # the server had served perfectly (206 with no ACAO). Pinned by test_cors_public_surface.
-    r"|data/vector/[\w.-]+/(pmtiles|features\.geojson|features\.arrow|tilejson|identify)"
+    r"|data/vector/[\w.-]+/(pmtiles|features\.geojson|features\.arrow|tilejson|identify|legend)"
     r"|data/vector/[\w.-]+/parquet/.*"     # duckdb-wasm / GDAL read partition files cross-origin
     # Whole-layer / clipped downloads: same public terms as the artifacts above, and a browser
     # client polls the status endpoint cross-origin while the export runs.
     r"|data/(vector|raster)/[\w.-]+/export"
     r"|data/(vector|raster)/[\w.-]+/export-(status|download)/[\w-]+"
-    r"|data/raster/[\w.-]+/(cog|tilejson|statistics))$"
+    r"|data/raster/[\w.-]+/(cog|tilejson|statistics|legend))$"
 )
 
 

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -253,6 +253,17 @@ deliberately NOT visibility-filtered (published portals depend on them).
   missing nginx's `/raster` prefix). Bakes the layer's saved styling into the tile template and
   carries **`bounds`** (from the stored EPSG:4326 bbox; TiTiler `/cog/info` only as a fallback for
   legacy rows) — bounds are the whole point: a bare XYZ URL has none, so "zoom to layer" fails.
+- **`GET /data/{vector,raster}/{ref}/legend`** — **PUBLIC** legend for the layer's default style
+  (2026-08-13), on the same terms as the other artifacts. Vector returns
+  `{color_mode, field, entries[{color,label}], size}` straight from
+  `services.symbology.legend_entries` — the function the published portal and the About page
+  already read, exposed so that a THIRD renderer (the QGIS plugin) does not re-derive class labels
+  and drift on where a break falls or how a number rounds. Same argument as `/field-stats`: ask,
+  do not recompute. Two deliberate details: a **single-symbol** layer gets a one-entry legend here
+  (`legend_entries` returns `[]`, but a caller drawing a legend still needs a swatch), and a
+  **raster** answers `{ramp: true, colormap, rescale, algorithm, bidx}` — a continuous ramp has no
+  swatches, and pretending otherwise would invent buckets nobody chose. `rescale` comes back as
+  numbers though it is stored as TiTiler's `"min,max"`. Tests: `test_legend_endpoint.py`.
 - **Sharing endpoints** (authed, editor+): `PUT /data/vector/{id}/sharing` + `PUT /data/raster/{id}/sharing`
   (`SharingUpdate`: partial `{visibility, abstract, keywords, license, attribution}` — legacy
   `is_public` bool still accepted, mapped to visibility). `PUT /data/sources/{id}/sharing` takes

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -375,6 +375,49 @@ async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depend
                              media_type="image/tiff", headers=headers)
 
 
+@router.get("/{layer_ref}/legend")
+async def raster_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
+    """PUBLIC legend for a shared raster: the colormap and the value range it is stretched over.
+
+    A raster legend is a continuous ramp, not a list of swatches, so this reports the ingredients a
+    renderer needs to draw one — `colormap`, `rescale` and the band — rather than pretending to be
+    the vector legend. The point is the same as the vector route: the numbers on a QGIS legend
+    should be the numbers the portal used, and the only way to guarantee that is to read them from
+    the layer rather than re-derive them from the file.
+    """
+    import json
+
+    result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    if not layer or layer.status != "ready" or not layer.is_public:
+        raise HTTPException(404, "No shared raster for this layer.")
+
+    style = {}
+    if layer.default_style:
+        try:
+            style = json.loads(layer.default_style).get("style") or {}
+        except ValueError:
+            style = {}
+    rescale = style.get("rescale")
+    if isinstance(rescale, str):
+        # Stored as TiTiler wants it ("min,max"); a client wants numbers.
+        try:
+            rescale = [float(v) for v in rescale.split(",")]
+        except ValueError:
+            rescale = None
+    return {
+        "layer": layer.name,
+        "ref": layer.uid or str(layer.id),
+        "kind": "raster",
+        "ramp": True,                       # continuous, so `entries` would be a lie
+        "colormap": style.get("colormap"),
+        "rescale": rescale,
+        "algorithm": style.get("algorithm"),
+        "bidx": style.get("bidx"),
+        "band_count": layer.band_count,
+    }
+
+
 @router.get("/{layer_ref}/tilejson")
 async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
     """PUBLIC TileJSON (3.0.0) for a shared raster — the ONE URL other tools add directly.

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -574,6 +574,51 @@ async def vector_features_public(
     return await _viewport_geojson(layer, bbox, limit)
 
 
+@router.get("/{layer_ref}/legend")
+async def vector_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
+    """PUBLIC legend for a vector layer's default style — the swatches and labels, computed once.
+
+    `services.symbology.legend_entries` already decides what a legend shows, and the portal and the
+    About page read it. Nothing exposed it, so any OTHER renderer — the QGIS plugin above all — had
+    to re-derive class labels from `default_style` and would eventually disagree with the map about
+    where a break falls or how a number is rounded. Same argument as `/field-stats`: the client asks
+    rather than recomputes.
+
+    Single-symbol layers get a one-entry legend here (using the layer's own name), where
+    `legend_entries` returns `[]` — a caller drawing a legend still needs a swatch, and inventing
+    one per renderer is how they drift.
+    """
+    from ...services import symbology
+
+    result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
+    layer = result.scalar_one_or_none()
+    if not await _publicly_readable(layer, db):
+        raise HTTPException(404, "Layer not found.")
+
+    style = {}
+    if layer.default_style:
+        try:
+            style = json.loads(layer.default_style).get("style") or {}
+        except ValueError:
+            style = {}
+    entries = symbology.legend_entries(style)
+    mode = style.get("color_mode") or "single"
+    if not entries:
+        entries = [{"color": style.get("color") or symbology.DEFAULT_COLOR, "label": layer.name}]
+    return {
+        "layer": layer.name,
+        "ref": layer.uid or str(layer.id),
+        "kind": "vector",
+        "geometry_type": layer.geometry_type,
+        "color_mode": mode,
+        "field": style.get("color_field") if mode != "single" else None,
+        "entries": entries,
+        # Size-from-field is a second visual dimension a legend may want to show separately.
+        "size": ({"field": style.get("size_field"), "stops": style.get("size_stops")}
+                 if style.get("size_field") and style.get("size_stops") else None),
+    }
+
+
 @router.get("/{layer_ref}/tilejson")
 async def vector_tilejson(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
     """PUBLIC TileJSON (3.0.0) for a PostGIS vector layer — the ONE URL other tools add directly as a

--- a/api/tests/test_cors_public_surface.py
+++ b/api/tests/test_cors_public_surface.py
@@ -28,6 +28,9 @@ UID = "488c2c7f55d7"          # a real-shaped uid: hex, letters AND digits
     f"/api/data/vector/{UID}/identify",
     f"/api/data/vector/{UID}/parquet/manifest.json",
     f"/api/data/vector/{UID}/parquet/__cell=137/data_0.parquet",
+    # The legend (2026-08-13): a browser-side renderer draws swatches from it cross-origin.
+    f"/api/data/vector/{UID}/legend",
+    f"/api/data/raster/{UID}/legend",
     # Legacy integer ids must keep working — links shared before uids exist in the wild.
     "/api/data/vector/12/pmtiles",
     "/api/data/raster/12/cog",

--- a/api/tests/test_legend_endpoint.py
+++ b/api/tests/test_legend_endpoint.py
@@ -1,0 +1,126 @@
+"""`GET /api/data/{vector,raster}/{ref}/legend` — the legend, served rather than re-derived.
+
+`services.symbology.legend_entries` already decides what a legend shows, and the published portal
+and the About page both read it. Nothing exposed it, so every OTHER renderer — the QGIS plugin
+first — had to reconstruct class labels from `default_style`, and would eventually disagree with
+the map about where a break falls or how a number is rounded. The same argument as `/field-stats`:
+the client asks, it does not recompute.
+
+What is pinned here is therefore mostly PARITY: the route's answer must equal what the portal draws
+from, for the same style.
+"""
+import json
+
+import pytest
+
+from geodeploy.models import RasterLayer, User, VectorLayer
+from geodeploy.services import symbology
+
+GRADUATED = {
+    "color_mode": "graduated",
+    "color_field": "pop",
+    "classes": [{"min": None, "max": 10, "color": "#eff3ff"},
+                {"min": 10, "max": 90.5, "color": "#6baed6"},
+                {"min": 90.5, "max": None, "color": "#08519c"}],
+}
+
+
+def _stored(style: dict) -> str:
+    """A layer's `default_style` column: the style nested under the wrapper the API writes."""
+    return json.dumps({"opacity": 1.0, "style": style, "popup_fields": []})
+
+
+@pytest.fixture
+async def layers(db):
+    db.add(User(id=1, email="k@e.org", name="K", role="owner", hashed_password="x", is_admin=True))
+    db.add_all([
+        VectorLayer(id=1, user_id=1, uid="aaaaaaaaaaaa", name="Roads", table_name="t1",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    geometry_type="linestring", is_public=True, visibility="public",
+                    default_style=_stored(GRADUATED)),
+        VectorLayer(id=2, user_id=1, uid="bbbbbbbbbbbb", name="Plots", table_name="t2",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    geometry_type="polygon", is_public=True, visibility="public",
+                    default_style=_stored({"color": "#e11d48", "marker": "star"})),
+        VectorLayer(id=3, user_id=1, uid="cccccccccccc", name="Bare", table_name="t3",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    is_public=True, visibility="public"),          # never styled
+        VectorLayer(id=4, user_id=1, uid="dddddddddddd", name="Private", table_name="t4",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    is_public=False, visibility="organization",
+                    default_style=_stored(GRADUATED)),
+        VectorLayer(id=5, user_id=1, uid="eeeeeeeeeeee", name="Cities", table_name="t5",
+                    schema_name="gd", storage_backend="postgis", status="ready",
+                    geometry_type="point", is_public=True, visibility="public",
+                    default_style=_stored({"color": "#111", "size_mode": "proportional",
+                                           "size_field": "pop",
+                                           "size_stops": [[0, 4], [1000000, 24]]})),
+    ])
+    db.add_all([
+        RasterLayer(id=1, user_id=1, uid="1111aaaa2222", name="DEM", s3_key="r/1/d.tif",
+                    status="ready", is_public=True, visibility="public", band_count=1,
+                    default_style=_stored({"colormap": "viridis", "rescale": "0,255"})),
+        RasterLayer(id=2, user_id=1, uid="3333bbbb4444", name="Secret", s3_key="r/1/s.tif",
+                    status="ready", is_public=False, visibility="organization"),
+    ])
+    await db.commit()
+    yield db
+
+
+class TestVectorLegend:
+    async def test_a_graduated_layer_lists_its_classes(self, client, layers):
+        r = await client.get("/api/data/vector/aaaaaaaaaaaa/legend")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["color_mode"] == "graduated" and body["field"] == "pop"
+        assert [e["label"] for e in body["entries"]] == ["< 10", "10 – 90.5", "≥ 90.5"]
+        assert [e["color"] for e in body["entries"]] == ["#eff3ff", "#6baed6", "#08519c"]
+
+    async def test_it_is_exactly_what_the_portal_draws_from(self, client, layers):
+        """The whole point. If these ever differ, one of the two renderers is lying."""
+        r = await client.get("/api/data/vector/aaaaaaaaaaaa/legend")
+        assert r.json()["entries"] == symbology.legend_entries(GRADUATED)
+
+    async def test_a_single_symbol_still_gets_one_swatch(self, client, layers):
+        """`legend_entries` returns [] for a single symbol, but a caller drawing a legend needs
+        something to draw — and inventing it per renderer is how they drift."""
+        r = await client.get("/api/data/vector/bbbbbbbbbbbb/legend")
+        body = r.json()
+        assert body["color_mode"] == "single" and body["field"] is None
+        assert body["entries"] == [{"color": "#e11d48", "label": "Plots"}]
+
+    async def test_an_unstyled_layer_falls_back_to_the_default_colour(self, client, layers):
+        r = await client.get("/api/data/vector/cccccccccccc/legend")
+        assert r.json()["entries"] == [{"color": symbology.DEFAULT_COLOR, "label": "Bare"}]
+
+    async def test_size_from_a_field_is_reported_separately(self, client, layers):
+        """A second visual dimension: a legend explaining only colour is half a legend."""
+        body = (await client.get("/api/data/vector/eeeeeeeeeeee/legend")).json()
+        assert body["size"] == {"field": "pop", "stops": [[0, 4], [1000000, 24]]}
+
+    async def test_a_layer_without_data_driven_size_reports_none(self, client, layers):
+        assert (await client.get("/api/data/vector/aaaaaaaaaaaa/legend")).json()["size"] is None
+
+    async def test_a_private_layer_is_not_readable(self, client, layers):
+        """Same terms as every other per-layer artifact — a legend names the classes, which is
+        information about the data."""
+        assert (await client.get("/api/data/vector/dddddddddddd/legend")).status_code == 404
+
+    async def test_it_answers_by_integer_id_too(self, client, layers):
+        assert (await client.get("/api/data/vector/1/legend")).status_code == 200
+
+
+class TestRasterLegend:
+    async def test_a_raster_reports_a_ramp_not_swatches(self, client, layers):
+        body = (await client.get("/api/data/raster/1111aaaa2222/legend")).json()
+        assert body["ramp"] is True
+        assert body["colormap"] == "viridis"
+        assert body["band_count"] == 1
+
+    async def test_the_stretch_comes_back_as_numbers(self, client, layers):
+        """Stored as TiTiler wants it ("0,255"); a client wants to compute with it."""
+        assert (await client.get("/api/data/raster/1111aaaa2222/legend")).json()["rescale"] == [
+            0.0, 255.0]
+
+    async def test_a_private_raster_is_not_readable(self, client, layers):
+        assert (await client.get("/api/data/raster/3333bbbb4444/legend")).status_code == 404

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,10 +36,16 @@ User documentation is `docs/cli.md`; this file is the technical note.
   `layers download` prefers it over queueing an export for those layers.
 - `portals.py` — portal CRUD and `layer_configs` surgery. `layer_configs[0]` = top of the list =
   drawn on top. `editable_config()` drops server-owned fields before a round-trip PUT.
-- `styles.py` — the style vocabulary of `api/geodeploy/services/symbology.py`, assembled from plain
-  arguments. **Classification maths is NOT reimplemented**: `classify()` reads
+- `styles.py` — the style vocabulary of `api/geodeploy/services/symbology.py`, in both directions.
+  `build_style()` **assembles** it from plain arguments; `parse()`/`Style` **reads** one back
+  (mode, field, classes, categories, size, extrusion, rescale) so a consumer — the QGIS plugin —
+  does not re-decide what `color_mode: "graduated"` implies. `Style` is a reader, not a schema: it
+  never rejects and keeps `.raw`, and `to_dict()` makes build → parse → build lossless.
+  **Classification maths is NOT reimplemented**: `classify()` reads
   `GET /data/vector/{ref}/field-stats`, so the CLI cannot disagree with the editor about which class
-  a feature is in.
+  a feature is in. Same rule for legends — `vector.legend()` asks the instance, and
+  `Style.legend()` is the local twin for a style that has no URL yet (an unsaved edit), pinned
+  against the server's exact labels in `test_styles_jobs`.
 - `catalog.py` — the public surfaces, including `public()` (the instance index behind
   `geodeploy browse`) and `portal_style()`, which reads a published portal's own `style.json`.
 - `jobs.py`, `sources.py`, `imports.py`, `admin.py`, `errors.py`.
@@ -58,7 +64,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 298 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 314 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/geodeploy/__init__.py
+++ b/cli/geodeploy/__init__.py
@@ -31,9 +31,12 @@ from .errors import (  # noqa: E402
     ValidationError,
 )
 from .jobs import JobFailed, JobTimeout  # noqa: E402
+from .styles import Style, parse_style  # noqa: E402
 
 __all__ = [
     "Client",
+    "Style",
+    "parse_style",
     "GeoDeployError",
     "APIError",
     "AuthError",

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -76,6 +76,15 @@ examples:
     stats.add_argument("--method", choices=["quantile", "equal", "jenks"], default="quantile")
     stats.add_argument("--ramp", default="viridis")
 
+    legend = add_command(group, "legend", cmd_legend,
+                         "the swatches and labels this layer's style produces",
+                         epilog="""\
+The legend is computed by the INSTANCE, from the same function the portal and the About page use,
+so what you see here is what a published map shows. A raster answers with its colour ramp and the
+value range it is stretched over, since a continuous ramp has no swatches.
+""")
+    layer_ref_arg(legend)
+
     links = add_command(group, "links", cmd_links,
                         "share URLs for this layer, labelled by the tool each one suits")
     layer_ref_arg(links)
@@ -163,6 +172,37 @@ def cmd_show(ctx, args) -> int:
         if layer.get("file_size"):
             layer["file_size"] = human_size(layer["file_size"])
     ctx.out.render(layer)
+    return EXIT_OK
+
+
+def cmd_legend(ctx, args) -> int:
+    """What a legend for this layer shows — asked of the server, not derived here.
+
+    A legend that disagrees with the map is worse than no legend, and the only way to guarantee
+    agreement is for one implementation to produce both.
+    """
+    layer = resolve_layer(ctx, args, public_ok=True)
+    client = ctx.client(auth_required=False)
+    ref = layer.get("uid") or layer["id"]
+    legend = client.layers.api(layer["layer_type"]).legend(ref)
+
+    if ctx.out.json_mode:
+        ctx.out.json(legend)
+        return EXIT_OK
+    if legend.get("ramp"):
+        ctx.out.record(legend, ["layer", "colormap", "rescale", "algorithm", "bidx", "band_count"])
+        ctx.out.info("A raster legend is a continuous ramp, so there are no swatches to list.")
+        return EXIT_OK
+    ctx.out.out(ctx.out.bold(legend.get("layer") or ""))
+    mode = legend.get("color_mode") or "single"
+    ctx.out.out(ctx.out.dim("{0}{1}".format(
+        mode, " on " + legend["field"] if legend.get("field") else "")))
+    ctx.out.out("")
+    ctx.out.table(legend.get("entries") or [], ["color", "label"])
+    size = legend.get("size")
+    if size:
+        ctx.out.info("Size varies with {0}: {1}".format(
+            size.get("field"), ", ".join("{0}→{1}px".format(v, s) for v, s in size["stops"])))
     return EXIT_OK
 
 

--- a/cli/geodeploy/cli/output.py
+++ b/cli/geodeploy/cli/output.py
@@ -52,7 +52,10 @@ def _supports_color(stream) -> bool:
 #: Typographic characters, and what to write instead on a console that cannot encode them.
 #: A Windows console still running code page 437 raises UnicodeEncodeError on "✓" — which would
 #: turn a SUCCESSFUL command into a traceback. Degrading the glyph is the only acceptable failure.
-_FALLBACKS = {"✓": "OK", "→": "->", "—": "-", "…": "...", "·": "-", "≥": ">=", "≤": "<="}
+#: `–` (EN dash) is not the same character as `—` (EM dash) and both reach a console: the em dash
+#: from our own output, the en dash from the SERVER, inside graduated legend labels ("10 – 90").
+_FALLBACKS = {"✓": "OK", "→": "->", "—": "-", "–": "-", "…": "...", "·": "-",
+              "≥": ">=", "≤": "<="}
 
 
 def _encodable(stream) -> bool:

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -187,6 +187,15 @@ class VectorLayers(_LayerBase):
     def tilejson(self, ref: Any) -> Dict[str, Any]:
         return self._c.get("/data/vector/{0}/tilejson".format(ref), auth=False)
 
+    def legend(self, ref: Any) -> Dict[str, Any]:
+        """The swatches and labels for this layer's default style, as the SERVER computes them.
+
+        `styles.Style.legend()` produces the same thing locally; this is the authoritative copy —
+        the portal draws from the same function — so anything that has to match a published map
+        should ask rather than derive.
+        """
+        return self._c.get("/data/vector/{0}/legend".format(ref), auth=False)
+
     # -- the whole GeoParquet dataset, straight from storage ---------------------------------------
 
     def parquet_manifest(self, ref: Any) -> Dict[str, Any]:
@@ -299,6 +308,11 @@ class RasterLayers(_LayerBase):
 
     def tilejson(self, ref: Any) -> Dict[str, Any]:
         return self._c.get("/data/raster/{0}/tilejson".format(ref), auth=False)
+
+    def legend(self, ref: Any) -> Dict[str, Any]:
+        """A raster legend is a continuous RAMP, so this returns the ingredients to draw one —
+        `colormap`, `rescale`, `algorithm`, `bidx` — not a list of swatches."""
+        return self._c.get("/data/raster/{0}/legend".format(ref), auth=False)
 
     def wmts(self, ref: Any) -> str:
         """The WMTS capabilities document — the URL to paste into QGIS, because it is the only one

--- a/cli/geodeploy/styles.py
+++ b/cli/geodeploy/styles.py
@@ -247,6 +247,170 @@ def _validate(style: Dict[str, Any]) -> None:
             raise ValidationError(400, "{0} is a fraction between 0 and 1.".format(key))
 
 
+class Style(object):
+    """A stored style, READ. The reverse direction of `build_style`.
+
+    `build_style` exists so a caller can assemble the vocabulary; nothing existed to take it apart
+    again, so anything rendering a GeoDeploy layer somewhere else — the QGIS plugin first — had to
+    reach into the dict and re-decide what `color_mode: "graduated"` implies, which keys are
+    authoritative, and what a missing one defaults to. That is a second definition of the
+    vocabulary, in a project that already keeps three surfaces in step by hand.
+
+    So this is a READER, not a schema: it never rejects, never fills in a server default it cannot
+    know, and keeps `.raw` so a caller can reach anything not modelled here. `to_dict()` returns the
+    original dict, which is what makes build → parse → build lossless.
+    """
+
+    __slots__ = ("raw",)
+
+    def __init__(self, style: Optional[Dict[str, Any]] = None):
+        self.raw = dict(style or {})
+
+    # -- what kind of symbology is this ------------------------------------------------------------
+
+    @property
+    def mode(self) -> str:
+        """`single` | `graduated` | `categorized` — never None, so a caller can switch on it."""
+        return self.raw.get("color_mode") or "single"
+
+    @property
+    def field(self) -> Optional[str]:
+        """The attribute the colours are driven by, or None for a single symbol."""
+        return self.raw.get("color_field") if self.mode != "single" else None
+
+    @property
+    def is_data_driven(self) -> bool:
+        return bool(self.field) and self.mode in ("graduated", "categorized")
+
+    # -- the pieces a renderer needs ---------------------------------------------------------------
+
+    @property
+    def color(self) -> Optional[str]:
+        return self.raw.get("color")
+
+    @property
+    def classes(self) -> List[Dict[str, Any]]:
+        """`[{min, max, color}]` for a graduated style. `min`/`max` may be None at the ends — that
+        is an OPEN bucket ("< 10", "≥ 90"), not missing data."""
+        return [c for c in (self.raw.get("classes") or []) if isinstance(c, dict)]
+
+    @property
+    def categories(self) -> List[Dict[str, Any]]:
+        """`[{value, color}]` for a categorized style. Anything not listed takes `other_color`."""
+        return [c for c in (self.raw.get("categories") or []) if isinstance(c, dict)]
+
+    @property
+    def other_color(self) -> Optional[str]:
+        return self.raw.get("other_color")
+
+    @property
+    def size(self) -> Optional[Dict[str, Any]]:
+        """`{"field": …, "stops": [[value, size], …]}` when size is data-driven, else None.
+
+        Both halves are required: a field with no stops cannot be interpolated, and stops with no
+        field have nothing to read.
+        """
+        field, stops = self.raw.get("size_field"), self.raw.get("size_stops")
+        if not field or not stops:
+            return None
+        return {"field": field, "stops": [list(s) for s in stops if len(s) == 2]}
+
+    @property
+    def extrusion(self) -> Optional[Dict[str, Any]]:
+        """The 3D block when it is switched ON. `{"enabled": False}` reads as None: a renderer that
+        checks truthiness on the dict alone would extrude a layer the author turned off."""
+        ext = self.raw.get("extrusion")
+        if isinstance(ext, dict) and ext.get("enabled"):
+            return dict(ext)
+        return None
+
+    # -- raster ------------------------------------------------------------------------------------
+
+    @property
+    def colormap(self) -> Optional[str]:
+        return self.raw.get("colormap")
+
+    @property
+    def rescale(self) -> Optional[List[float]]:
+        """The stretch as numbers. Stored as TiTiler wants it — the string "min,max" — so a caller
+        that wants to compute with it should not have to parse it again."""
+        value = self.raw.get("rescale")
+        if isinstance(value, str):
+            try:
+                return [float(v) for v in value.split(",")]
+            except ValueError:
+                return None
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            try:
+                return [float(v) for v in value]
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    # -- output --------------------------------------------------------------------------------------
+
+    def legend(self) -> List[Dict[str, Any]]:
+        """Swatches and labels, WITHOUT asking the server — mirrors `symbology.legend_entries`.
+
+        Prefer `client.vector.legend(ref)`: the server's answer is the one the portal drew. This is
+        for a caller that already holds a style dict (a portal's layer_config, an unsaved edit in a
+        dialog) and cannot make a request per keystroke. The two agree; `test_styles_jobs` pins the
+        labels against the server's format.
+        """
+        if self.mode == "graduated":
+            out = []
+            for c in self.classes:
+                lo, hi = c.get("min"), c.get("max")
+                if lo is None and hi is None:
+                    label = "all"
+                elif lo is None:
+                    label = "< {0}".format(_legend_num(hi))
+                elif hi is None:
+                    label = "≥ {0}".format(_legend_num(lo))
+                else:
+                    label = "{0} – {1}".format(_legend_num(lo), _legend_num(hi))
+                out.append({"color": c.get("color"), "label": label})
+            return out
+        if self.mode == "categorized":
+            out = [{"color": c.get("color"), "label": str(c.get("value"))} for c in self.categories]
+            if out:
+                out.append({"color": self.other_color or "#9ca3af", "label": "Other"})
+            return out
+        return []
+
+    def to_dict(self) -> Dict[str, Any]:
+        """The style as stored — unchanged, so `build_style(**…)` round-trips through this."""
+        return dict(self.raw)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<Style {0}>".format(describe(self.raw))
+
+
+def parse(style: Optional[Dict[str, Any]]) -> Style:
+    """Read a stored style dict. Accepts a layer's `default_style` wrapper or the inner style."""
+    if isinstance(style, dict) and "style" in style and isinstance(style["style"], dict):
+        # A layer record carries {opacity, style: {...}, popup_fields}; a portal layer_config the
+        # same. Taking either means a caller never has to remember which one they are holding.
+        return Style(style["style"])
+    return Style(style)
+
+
+#: The package-level name. `styles.parse` reads well inside this module; at the top level, next to
+#: `Client`, a bare `parse` says nothing about what it parses.
+parse_style = parse
+
+
+def _legend_num(value: Any) -> str:
+    """Legend numbers, formatted as `symbology._num` does — an integer stays an integer."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if number == int(number) and abs(number) < 1e15:
+        return str(int(number))
+    return "{0:,.2f}".format(number).rstrip("0").rstrip(".")
+
+
 def describe(style: Dict[str, Any]) -> str:
     """A one-line human summary of a style — what a table cell shows."""
     if not style:

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -128,6 +128,8 @@ class FakeInstance(object):
             (r"/data/vector/(\S+)/features", self._features),
             (r"/data/raster/(\S+)/cog", lambda *a: (200, b"II-pretend-GeoTIFF-bytes")),
             (r"/data/vector/(\S+)/pmtiles", lambda *a: (200, b"PMTiles pretend")),
+            (r"/data/vector/([\w.-]+)/legend", self._vector_legend),
+            (r"/data/raster/([\w.-]+)/legend", self._raster_legend),
             (r"/data/vector/([\w.-]+)/parquet/manifest\.json", self._parquet_manifest),
             (r"/data/vector/([\w.-]+)/parquet/(.+)", self._parquet_object),
             (r"/public", self._public),
@@ -303,6 +305,22 @@ class FakeInstance(object):
                  "layer_count": 1, "url": base + "/portals/field-sites-2026/",
                  "style_url": base + "/portals/field-sites-2026/style.json",
                  "thumbnail_url": None, "published_at": "2026-08-01T00:00:00"}]
+
+    def _vector_legend(self, method, match, query, headers, body):
+        """The server's legend, en dash and all — the exact characters `symbology._num` emits."""
+        return 200, {
+            "layer": "roads", "ref": "aaaaaaaaaaaa", "kind": "vector",
+            "geometry_type": "linestring", "color_mode": "graduated", "field": "pop",
+            "entries": [{"color": "#eff3ff", "label": "< 10"},
+                        {"color": "#6baed6", "label": "10 – 90"},
+                        {"color": "#08519c", "label": "≥ 90"}],
+            "size": {"field": "pop", "stops": [[0, 2], [1000, 12]]},
+        }
+
+    def _raster_legend(self, method, match, query, headers, body):
+        return 200, {"layer": "dem", "ref": "cccccccccccc", "kind": "raster", "ramp": True,
+                     "colormap": "viridis", "rescale": [0.0, 255.0], "algorithm": None,
+                     "bidx": None, "band_count": 1}
 
     def _portal_style(self, method, match, query, headers, body):
         """A published portal's own style.json — served outside /api, like the real bundle."""

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -179,6 +179,26 @@ class TestLayerCommands:
         assert "UID" in out
         assert "aaaaaaaaaaaa" in out and "cccccccccccc" in out
 
+    def test_legend_comes_from_the_instance(self, run, logged_in, instance):
+        """Not recomputed here: a legend that disagrees with the published map is worse than
+        none, and only one implementation can guarantee agreement."""
+        code, out, err = run("layers", "legend", "roads")
+        assert code == EXIT_OK
+        assert "graduated on pop" in out
+        assert "10 – 90" in out or "10 - 90" in out       # en dash, or its cp437 fallback
+        assert instance.requests_to("/legend"), "it must ASK, not derive"
+
+    def test_a_raster_legend_reports_its_ramp(self, run, logged_in):
+        code, out, err = run("layers", "legend", "raster-1")
+        assert code == EXIT_OK
+        assert "viridis" in out
+        assert "continuous ramp" in err                   # no swatches to list, and it says why
+
+    def test_legend_needs_no_token_for_a_public_layer(self, run, home, server):
+        code, out, err = run("--url", server, "layers", "legend", "roads", "--json")
+        assert code == EXIT_OK
+        assert json.loads(out)["field"] == "pop"
+
     def test_processing_layers_show_their_progress(self, run, logged_in):
         code, out, err = run("layers", "list")
         assert "42%" in out

--- a/cli/tests/test_output.py
+++ b/cli/tests/test_output.py
@@ -151,6 +151,17 @@ class TestLegacyConsoles:
         assert "a - b" in text
         text.encode("cp437")          # the real assertion: this would have raised
 
+    def test_a_server_legend_label_survives_cp437(self):
+        """Graduated labels come from the SERVER and carry an EN dash and ≥ — characters this
+        client never types itself, so they have to be in the fallback map too."""
+        out, err = self.Cp437IO(), self.Cp437IO()
+        fmt = Formatter(stdout=out, stderr=err)
+        fmt.table([{"color": "#6baed6", "label": "10 – 90"},
+                   {"color": "#08519c", "label": "≥ 90"}], ["color", "label"])
+        text = out.getvalue()
+        assert "10 - 90" in text and ">= 90" in text
+        text.encode("cp437")          # the real assertion: this would have raised
+
     def test_utf8_consoles_keep_the_real_glyphs(self):
         class Utf8IO(io.StringIO):
             encoding = "utf-8"

--- a/cli/tests/test_styles_jobs.py
+++ b/cli/tests/test_styles_jobs.py
@@ -136,6 +136,85 @@ class TestDescribe:
         assert "3D" in styles.describe({"extrusion": {"enabled": True, "field": "h"}})
 
 
+class TestStyleModel:
+    """`build_style` writes the vocabulary; `Style` reads it back. The QGIS plugin depends on the
+    reading half, so anything it needs must come off the model rather than out of the raw dict."""
+
+    GRADUATED = {"color_mode": "graduated", "color_field": "pop",
+                 "classes": [{"min": None, "max": 10, "color": "#eff3ff"},
+                             {"min": 10, "max": 90, "color": "#6baed6"},
+                             {"min": 90, "max": None, "color": "#08519c"}]}
+
+    def test_a_single_symbol_reads_as_single(self):
+        style = styles.parse({"color": "#111", "radius": 5})
+        assert style.mode == "single"
+        assert style.field is None and style.is_data_driven is False
+        assert style.color == "#111"
+
+    def test_missing_and_empty_styles_do_not_explode(self):
+        for empty in (None, {}, {"style": {}}):
+            assert styles.parse(empty).mode == "single"
+            assert styles.parse(empty).classes == []
+
+    def test_it_accepts_the_layer_record_wrapper(self):
+        """A layer carries {opacity, style: {...}}; a portal layer_config the same. Taking either
+        means a caller never has to remember which one it is holding."""
+        assert styles.parse({"opacity": 1.0, "style": self.GRADUATED}).field == "pop"
+        assert styles.parse(self.GRADUATED).field == "pop"
+
+    def test_graduated_exposes_its_classes(self):
+        style = styles.parse(self.GRADUATED)
+        assert style.mode == "graduated" and style.is_data_driven
+        assert len(style.classes) == 3
+        assert style.classes[0]["max"] == 10 and style.classes[0]["min"] is None
+
+    def test_categorized_exposes_categories_and_the_other_colour(self):
+        style = styles.parse({"color_mode": "categorized", "color_field": "kind",
+                              "categories": [{"value": "forest", "color": "#0a0"}],
+                              "other_color": "#999"})
+        assert [c["value"] for c in style.categories] == ["forest"]
+        assert style.other_color == "#999"
+
+    def test_size_needs_both_halves(self):
+        assert styles.parse({"size_field": "pop"}).size is None       # nothing to interpolate
+        assert styles.parse({"size_stops": [[0, 2]]}).size is None    # nothing to read
+        size = styles.parse({"size_field": "pop", "size_stops": [[0, 2], [100, 12]]}).size
+        assert size == {"field": "pop", "stops": [[0, 2], [100, 12]]}
+
+    def test_extrusion_switched_off_reads_as_none(self):
+        """A renderer checking truthiness on the dict alone would extrude a layer the author
+        turned off."""
+        assert styles.parse({"extrusion": {"enabled": False, "field": "h"}}).extrusion is None
+        assert styles.parse({"extrusion": {"enabled": True, "field": "h"}}).extrusion["field"] == "h"
+
+    def test_rescale_comes_back_as_numbers(self):
+        assert styles.parse({"rescale": "0,255"}).rescale == [0.0, 255.0]
+        assert styles.parse({"rescale": [1, 2]}).rescale == [1.0, 2.0]
+        assert styles.parse({"rescale": "nonsense"}).rescale is None
+
+    def test_build_then_parse_then_build_is_lossless(self):
+        built = styles.build_style(color="#111", color_field="pop", classes=self.GRADUATED["classes"],
+                                   size_field="pop", size_stops="0:2,100:12", marker="star")
+        assert styles.build_style(styles.parse(built).to_dict()) == built
+
+    def test_the_local_legend_matches_the_server_format(self):
+        """Pinned against `services.symbology.legend_entries`: an EN dash, open-ended buckets, and
+        an integer that stays an integer."""
+        assert styles.parse(self.GRADUATED).legend() == [
+            {"color": "#eff3ff", "label": "< 10"},
+            {"color": "#6baed6", "label": "10 – 90"},
+            {"color": "#08519c", "label": "≥ 90"},
+        ]
+
+    def test_a_categorized_legend_ends_with_other(self):
+        legend = styles.parse({"color_mode": "categorized", "color_field": "k",
+                               "categories": [{"value": "a", "color": "#111"}]}).legend()
+        assert [e["label"] for e in legend] == ["a", "Other"]
+
+    def test_a_single_symbol_has_no_legend_entries(self):
+        assert styles.parse({"color": "#111"}).legend() == []
+
+
 class TestJobs:
     def test_wait_returns_the_final_status(self, client):
         created = client.vector.tile(1)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -275,8 +275,13 @@ geodeploy layers list --query roads        # match name, abstract or keywords
 geodeploy layers show roads                # one layer, in full
 geodeploy layers fields roads              # its attribute columns
 geodeploy layers stats roads --field pop   # the distribution of one attribute
+geodeploy layers legend roads              # the swatches and labels its style produces
 geodeploy layers usage roads               # which portals use it
 ```
+
+`legend` is computed by the **instance**, using the same function the published portal and the
+About page use, so what you see is what a map shows. A raster answers with its colour ramp and the
+value range it is stretched over, because a continuous ramp has no swatches to list.
 
 **You can name a layer any way you have it**: its id (`7`), its stable public id
 (`a7f3c91b04e2`), a `vector-7` reference, or its name — a unique part of the name is enough.
@@ -619,6 +624,40 @@ and certificate settings:
 ```python
 gd = Client(url, token=token, transport=MyQgisTransport())   # any .send(Request) -> Response
 ```
+
+### Reading a style
+
+A plugin that renders a GeoDeploy layer in another tool has to understand the style, not just carry
+it. `parse_style()` reads one without you reaching into the dict:
+
+```python
+from geodeploy import parse_style
+
+layer = gd.layers.resolve("cities")
+style = parse_style(layer["default_style"])     # accepts the layer record or the inner style
+
+style.mode              # 'single' | 'graduated' | 'categorized'
+style.field             # the attribute the colours are driven by, or None
+style.classes           # [{min, max, color}] — min/max None at the ends means an OPEN bucket
+style.categories        # [{value, color}], with style.other_color for everything else
+style.size              # {'field': 'pop', 'stops': [[0, 4], [1000000, 24]]} or None
+style.extrusion         # the 3D block, or None when the author switched it off
+style.rescale           # a raster stretch, as numbers
+style.raw               # anything not modelled above
+```
+
+It never rejects and never invents a default it cannot know, and `style.to_dict()` returns the
+original, so `build_style` → `parse_style` → `build_style` round-trips unchanged.
+
+For the legend, prefer asking the instance — that answer is the one the published portal drew:
+
+```python
+gd.vector.legend("cities")      # {'entries': [{'color': …, 'label': '10 – 90'}], …}
+gd.raster.legend("dem")         # a ramp: colormap, rescale, algorithm, bidx
+```
+
+`style.legend()` computes the same labels locally, for a caller holding an unsaved style that has
+no URL to ask about yet.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,9 +187,10 @@ TileJSON was valid, and only the tile server's log knew otherwise.</p>
 <p class="gd-goal">v1.2 made the data readable by other tools. This one is about reaching an instance
 without a browser, and about being able to take a copy with you.</p>
 
-- [ ] **A real CLI**, not an example script — every argument the API takes, the v1.1 symbology
+- [x] **A real CLI**, not an example script — every argument the API takes, the v1.1 symbology
       included, with its own section in the docs and tests so it is verified without anyone
-      checking by hand
+      checking by hand. Also the Python client the QGIS plugin is built on: zero dependencies,
+      Python 3.9+, so a plugin can vendor it
 - [ ] **Styling that travels** — portal and layer style interchange with GeoLibre and QGIS, for
       every layer type. The CLI is the natural surface for it, so the two are designed together
 - [ ] **Download a backup**, and **restore from disk** — state-only (small, covers a bad restore or
@@ -201,7 +202,11 @@ without a browser, and about being able to take a copy with you.</p>
 - [ ] **A raster's zoom range read from the file, not guessed from its extent** — today a small
       high-resolution layer stops drawing below a computed floor, with nothing saying why
       ([#17](https://github.com/bravemaster3/GeoDeploy/issues/17))
-- [ ] **Size from a field**, and **labels** — the half of data-driven symbology v1.1 did not ship
+- [ ] **Size from a field** — bigger markers for bigger values, thicker lines for busier roads.
+      The instance already draws it and the CLI already sets it; what is missing is a control in
+      the dashboard ([#21](https://github.com/bravemaster3/GeoDeploy/issues/21))
+- [ ] **Labels** — the other half of data-driven symbology v1.1 did not ship, and unlike size this
+      one does not exist anywhere yet
 
 </div>
 
@@ -221,7 +226,6 @@ trip — edit in the tool you prefer, publish back.</p>
 - [ ] Style import from QGIS and GeoLibre, so nobody restyles from scratch
 - [ ] Style interchange — adopt an external MapLibre style, and emit one
 - [ ] Write-back: expose a layer as editable GeoJSON and re-ingest the edit
-- [ ] A packaged `geodeploy` CLI, for scripted uploads and publishing
 - [ ] Catalog **search**, so a client can discover a dataset rather than fetch a known URL
 
 </div>


### PR DESCRIPTION
Groundwork for the QGIS plugin: the two things a renderer outside GeoDeploy needs before it can
draw a layer the way the portal draws it.

## 1. The legend is now served, not re-derived

`services/symbology.legend_entries()` already decides what a legend shows, and the published portal
and the About page both call it — **but nothing exposed it**. Any other renderer had to rebuild
class labels from `default_style`, and would eventually disagree with the map about where a break
falls or how a number rounds. That is the same failure `/field-stats` exists to prevent: the client
asks, it does not recompute.

```
GET /api/data/vector/{ref}/legend   → {color_mode, field, entries[{color,label}], size}
GET /api/data/raster/{ref}/legend   → {ramp: true, colormap, rescale, algorithm, bidx}
```

Public on the same terms as the layer's other artifacts (`_publicly_readable` / `is_public`), and
CORS-open like them. Two deliberate details:

- a **single-symbol** layer gets a one-entry legend, though `legend_entries` returns `[]` — a caller
  drawing a legend still needs a swatch, and inventing one per renderer is exactly the drift being
  avoided;
- a **raster** answers with its ramp rather than swatches. A continuous ramp has no buckets, and
  fabricating some would invent classes nobody chose. `rescale` comes back as numbers even though it
  is stored as TiTiler's `"min,max"`.

`geodeploy layers legend <layer>` exposes it, and `gd.vector.legend(ref)` / `gd.raster.legend(ref)`
in the library.

## 2. The client can now READ a style, not only build one

`styles.py` could assemble the vocabulary and nothing else, so a consumer had to reach into the dict
and re-decide what `color_mode: "graduated"` implies — a second definition of the vocabulary, in a
project that already keeps three surfaces in step by hand.

```python
from geodeploy import parse_style

style = parse_style(layer["default_style"])   # accepts the record or the inner style
style.mode, style.field, style.classes, style.categories
style.size          # {'field': 'pop', 'stops': [[0, 4], [1000000, 24]]} or None
style.extrusion     # None when the author switched 3D off, not a falsy dict
style.rescale       # numbers, whichever way it was stored
style.raw           # anything not modelled
```

A reader, not a schema: it never rejects and never invents a server default it cannot know, and
`to_dict()` makes `build_style` → `parse_style` → `build_style` lossless (pinned by a test).
`Style.legend()` computes the same labels locally for a style that has no URL to ask about yet — an
unsaved edit in a dialog — and is pinned against the server's exact format.

## Caught on the way

The server's graduated labels contain an **EN dash** (`10 – 90`, U+2013). The CLI's legacy-console
fallback map had the EM dash but not the EN dash, so `layers legend` would have died with
`UnicodeEncodeError` on a cp437/cp1252 console. Characters that arrive **from the server** need to be
in that map too, not just the ones we type. Pinned with a cp437 test.

## Roadmap

**"Size from a field, and labels" split in two.** Size is fully implemented server-side
(`_size_expression` for circle-radius/line-width, `icon_size_expression` so marker icons scale too),
mirrored in `ui/src/lib/symbology.js`, and settable from the CLI — it is missing only a dashboard
control, filed as #21. Labels exist nowhere: `label_field` appears in no Python, Vue or template
file. They were one checkbox and are not one task.

Also ticked the CLI item (merged in #20) and removed the duplicate "A packaged `geodeploy` CLI" from
"Next up", which promised the same thing twice.

## Tests

**314** CLI (new: the style model, the legend command, the cp437 label), **94** API
(`test_legend_endpoint.py` — including a parity assertion that the route's entries equal
`symbology.legend_entries` for the same style — plus CORS and symbology).

No deploy caveat: nothing under `tasks/` changed, so this needs the API recreated but not celery.