### PR TITLE
ci: publish the CLI to PyPI by tag, with no stored token

### DIFF
--- a/.github/CI-NOTES.md
+++ b/.github/CI-NOTES.md
@@ -19,6 +19,22 @@ GitHub Actions CI and the community-template validation pipeline.
     is what catches syntax or stdlib use that would break there. The install line is `.[dev]` and
     nothing else — the package must stay dependency-free, and this job failing on a missing wheel
     would mean one had crept in.
+- `workflows/publish-cli.yml` — publishes `cli/` to PyPI on a **`cli-v*`** tag, via **Trusted
+  Publishing**: PyPI verifies a short-lived OIDC token minted by GitHub for this repo, workflow
+  filename and environment, so no API token is stored anywhere. `workflow_dispatch` runs the same
+  pipeline against TestPyPI.
+  - The **tag prefix is deliberate**: `cli-v1.3.0b1`, not the platform's `v1.3` release tags. The
+    two do not always move together — the CLI's first upload is a pre-release that exists before
+    v1.3 does — and a CLI-only fix must be releasable without re-tagging the whole platform.
+  - The `build` job is the gate, because **a version on PyPI can never be re-uploaded**: it runs the
+    suite on 3.9 (the floor), asserts the **tag matches the packaged version** (the failure it
+    prevents is tagging `cli-v1.3.0` while `__init__.py` still says `1.3.0b1`), runs `twine check`,
+    and installs the wheel with `--no-deps` to prove the zero-dependency promise.
+  - **One-time setup on PyPI** (Account → Publishing → pending publisher, before the first upload):
+    owner `bravemaster3`, repository `GeoDeploy`, workflow **`publish-cli.yml`**, environment
+    **`pypi`** (and `testpypi` for the rehearsal). All four must match exactly or the upload is
+    rejected as `invalid-publisher`. Adding a required reviewer to the `pypi` environment makes
+    every upload wait for approval.
 - `workflows/validate-template.yml` — runs on PRs touching `templates/community/**`; installs `jsonschema`/`Pillow`/`maplibre-style-spec` and runs the validator script.
 - `scripts/validate_template.py` — checks each changed community template: required files present, `template.json` schema, `style.json` MapLibre validity, `preview.png` is 800×500, no external CDN URLs in `layout.html`.
 
@@ -31,4 +47,4 @@ GitHub Actions CI and the community-template validation pipeline.
 - The API test suite is minimal (`/health`, initial setup status).
 
 ## Last updated
-2026-08-12 (added the **cli** job for the packaged `geodeploy` client)
+2026-08-13 (added `publish-cli.yml` — Trusted Publishing to PyPI on a `cli-v*` tag)

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,176 @@
+name: Publish CLI
+
+# Publishes the `geodeploy` package (cli/) to PyPI using TRUSTED PUBLISHING: PyPI verifies a
+# short-lived OIDC token minted by GitHub for this exact repository, workflow and environment, so
+# there is no API token stored anywhere — nothing to leak, nothing to rotate, and a stolen repo
+# secret cannot be used to publish because there is no secret.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# ONE-TIME SETUP on PyPI (Your projects → geodeploy → Publishing, or, before the first upload,
+# Account → Publishing → "Add a pending publisher"). The four values must match EXACTLY, or the
+# upload is rejected with "invalid-publisher":
+#
+#     Owner:            bravemaster3
+#     Repository:       GeoDeploy
+#     Workflow name:    publish-cli.yml          ← this file's NAME, not the `name:` above
+#     Environment:      pypi                     ← and `testpypi` for the rehearsal publisher
+#
+# Do the same at test.pypi.org (a separate account, separate 2FA) if you want the rehearsal path.
+# The first upload of a NEW project uses a "pending publisher"; PyPI converts it into a normal one
+# once the project exists.
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+#
+# Trigger: a tag of the form `cli-v1.3.0b1`. A DEDICATED prefix, not the repository's `v1.3` release
+# tags, because the two do not always move together — the CLI's first upload is a pre-release that
+# exists before v1.3 does, and a CLI-only fix must be releasable without re-tagging the whole
+# platform. `workflow_dispatch` runs the same pipeline against TestPyPI on demand.
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        required: true
+        default: testpypi
+        type: choice
+        options: [testpypi, pypi]
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Gate ───────────────────────────────────────────────────────────────────────────────────────
+  # Build and verify BEFORE any publisher job runs. A version on PyPI can never be re-uploaded —
+  # deleting it does not free the number — so everything that can be checked must be checked while
+  # the mistake is still free to fix.
+  build:
+    name: Build and verify
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # 3.9 is the package's floor (the QGIS plugin vendors it, QGIS 3.28 LTR ships 3.9). Test
+          # on the floor: a 3.10+ syntax slip would otherwise reach PyPI and break exactly the
+          # consumer the constraint exists for.
+          python-version: "3.9"
+          cache: pip
+
+      - name: Install
+        working-directory: cli
+        run: pip install -e ".[dev]"
+
+      - name: Run the test suite
+        working-directory: cli
+        # CI already runs this on every push to main, but a TAG is not a push to main: it can point
+        # at any commit, including one that never went through a pull request.
+        run: python -m pytest tests -q
+
+      - name: The console script runs
+        run: |
+          geodeploy --version
+          geodeploy --help > /dev/null
+
+      - name: Read the packaged version
+        id: version
+        working-directory: cli
+        # Single-sourced in geodeploy/__init__.py; read it from the INSTALLED metadata rather than
+        # by parsing the file, so this reports what a user would actually get.
+        run: |
+          set -euo pipefail
+          version=$(python -c "import importlib.metadata as m; print(m.version('geodeploy'))")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "packaged version: $version"
+
+      - name: The tag must match the packaged version
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        # The failure this prevents: tagging `cli-v1.3.0` while __init__.py still says 1.3.0b1, and
+        # publishing a beta under the release number. Unfixable afterwards.
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#cli-v}"
+          if [ "$tag" != "$VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} says $tag, but the package is $VERSION."
+            echo "::error::Fix cli/geodeploy/__init__.py or the tag, then try again."
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches $VERSION"
+
+      - name: Build sdist and wheel
+        working-directory: cli
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+
+      - name: Check the metadata
+        working-directory: cli
+        # twine's own validation: a README that does not render becomes an unreadable project page,
+        # and PyPI rejects it at upload — after the version number has been spent.
+        run: python -m twine check dist/*
+
+      - name: The wheel installs clean, with no dependencies
+        # `--no-deps` is the assertion, not an optimisation: this package promises zero runtime
+        # dependencies, and an accidental one would install silently without it.
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/verify
+          /tmp/verify/bin/pip install --quiet --no-deps cli/dist/*.whl
+          /tmp/verify/bin/geodeploy --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: cli/dist/
+
+  # ── Rehearsal ──────────────────────────────────────────────────────────────────────────────────
+  testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/geodeploy
+    permissions:
+      id-token: write        # the OIDC token IS the credential — nothing else is needed
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI accumulates rehearsals; a re-run of the same version should not fail the job.
+          skip-existing: true
+
+  # ── The real thing ─────────────────────────────────────────────────────────────────────────────
+  pypi:
+    name: Publish to PyPI
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment:
+      # Add a required reviewer to this environment in Settings → Environments if you want a human
+      # to approve every upload. The job then waits rather than publishing.
+      name: pypi
+      url: https://pypi.org/p/geodeploy
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # No `skip-existing` here, deliberately: on the real index, "this version already exists"
+        # means something is wrong and the run should say so rather than pass quietly.

--- a/cli/README.md
+++ b/cli/README.md
@@ -102,14 +102,26 @@ repo convention in CLAUDE.md), which is not what someone landing on PyPI wants t
 the user-facing front page. Keep both current.
 
 The name `geodeploy` was unregistered on PyPI as of 2026-08-13 (re-check immediately before the
-first upload — anyone can claim it). To cut a release:
+first upload — anyone can claim it).
+
+**Releases go through `.github/workflows/publish-cli.yml`, not from a laptop.** It uses PyPI's
+Trusted Publishing: no API token exists to leak or rotate, and the workflow gates the upload on the
+test suite, on `twine check`, on a clean `--no-deps` install, and on the **tag matching the packaged
+version**. Cutting a release is therefore:
+
+```bash
+# 1. bump the one line in geodeploy/__init__.py, commit, merge
+# 2. tag it — the prefix is `cli-v`, not the platform's `v1.3`
+git tag cli-v1.3.0b1 && git push origin cli-v1.3.0b1
+```
+
+Use the workflow's manual run (`Actions → Publish CLI → Run workflow → testpypi`) to rehearse
+against TestPyPI first. Building by hand is still the way to CHECK a change without releasing it:
 
 ```bash
 cd cli
 python -m build                     # sdist + wheel into dist/
 python -m twine check dist/*        # must pass before anything is uploaded
-python -m twine upload --repository testpypi dist/*    # rehearse
-python -m twine upload dist/*
 ```
 
 `dist/` and `build/` are git-ignored. The sdist carries the tests, so the release can be verified

--- a/cli/README.md
+++ b/cli/README.md
@@ -181,6 +181,15 @@ the CLI yet; see below).
   Caveat: reading PMTiles needs a GDAL with the support (3.8+), which rules out the oldest QGIS the
   Python floor above deliberately still supports — so the display path must degrade to OAPIF rather
   than assume it.
+  **Measured on the maintainer's two installs (2026-08-13)**, which is why this is a rule and not a
+  worry: one reports Python **3.9.5** / GDAL **3.7.2** (no PMTiles — and the exact Python the floor
+  above exists for), the other Python **3.12.12** / GDAL **3.12.1** (PMTiles fine). Both are in
+  daily use. So `metadata.txt` should say `qgisMinimumVersion=3.28` (the oldest QGIS whose Python
+  is ≥ 3.9) and the plugin should branch on `gdal.VersionInfo()` at RUNTIME rather than refusing to
+  install — blocking the old one would lock out precisely the pinned installs this package's
+  constraints were chosen to serve.
+  Develop and demo on the NEWEST QGIS; that is a different decision from what the plugin refuses to
+  run on, and only the second one is visible to a user with an old install.
 
 ## Last updated
 2026-08-12 (created — packaged CLI + Python client, replacing `examples/geodeploy_cli.py`; then

--- a/cli/README.md
+++ b/cli/README.md
@@ -69,8 +69,11 @@ on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships
 - **Zero runtime dependencies, Python 3.9+.** Both constraints exist for the QGIS plugin, which
-  vendors this package and cannot pip-install anything (QGIS 3.28 LTR ships Python 3.9). Do not add
-  a dependency here without moving it into an extra.
+  vendors this package and cannot pip-install anything on a user's machine. The floor is set by the
+  **oldest QGIS anyone still runs**, not the current one — institutions pin a release for years —
+  so it reaches back through several LTR lines rather than tracking today's. Current QGIS ships a
+  much newer Python; that is not the constraint. Do not add a dependency here without moving it
+  into an extra.
 - Consumes `api/geodeploy/routers/` — see that folder's README for the permission model. Nothing in
   the API imports this.
 - **GeoLibre does not use this package**: its plugin is browser TypeScript
@@ -166,7 +169,18 @@ the CLI yet; see below).
   `portals export/import` round trip is the seam it would build on. Deliberately deferred.
 - No shell completion.
 - The QGIS plugin does not exist yet; the seams it needs (pluggable transport, progress callbacks,
-  `cancel`, typed errors, no printing) are in place and tested.
+  `cancel`, typed errors, no printing, and `styles.Style` for reading a style back) are in place and
+  tested.
+  **Which URL it should hand QGIS is two questions, not one.** For DISPLAY of a heavy layer,
+  **PMTiles** is the fastest thing we serve — pre-tiled, range-requested, no per-pan query — and it
+  is what `layers links` should offer first for a big GeoParquet layer. But PMTiles is a *rendering*
+  format: generalised geometry, tile-clipped features, attributes trimmed to what the tiles carry.
+  For DATA — full attributes, exact geometry, analysis, editing — the answer is OGC API - Features,
+  the GeoParquet partitions, or a built export. A plugin that offers only one of the two will be
+  wrong half the time, so the layer-add dialog needs both, labelled for what they are.
+  Caveat: reading PMTiles needs a GDAL with the support (3.8+), which rules out the oldest QGIS the
+  Python floor above deliberately still supports — so the display path must degrade to OAPIF rather
+  than assume it.
 
 ## Last updated
 2026-08-12 (created — packaged CLI + Python client, replacing `examples/geodeploy_cli.py`; then

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -15,11 +15,15 @@ authors = [{ name = "Koffi Dodji Noumonvi" }]
 keywords = ["gis", "geospatial", "postgis", "geoparquet", "cog", "maplibre", "qgis", "stac",
             "ogc-api-features", "geodeploy"]
 
-# 3.9 is the floor because the QGIS plugin VENDORS this package: QGIS 3.28 LTR ships Python 3.9,
-# and a plugin cannot pip-install anything on a user's machine. Everything here therefore runs on
-# 3.9 — `from __future__ import annotations` in every module, no match statements, no PEP 604
-# unions evaluated at runtime. No upper bound, deliberately: capping it would break installs on
-# every Python released after this one.
+# 3.9 is the floor because the QGIS plugin VENDORS this package — it drops `geodeploy/` into its own
+# folder and imports it, and a plugin cannot pip-install anything on a user's machine. So the floor
+# is set by the OLDEST QGIS anyone still runs, not by the current one: institutional installs sit on
+# a pinned release for years, and 3.9 reaches back through several LTR lines. (Do not read this as
+# "QGIS ships 3.9" — current releases ship far newer; the point is that WE cannot choose which one
+# the user has.) Everything here therefore runs on 3.9: `from __future__ import annotations` in every
+# module, no match statements, no PEP 604 unions evaluated at runtime. The cost is small and the CI
+# matrix pins it. No upper bound, deliberately: capping it would break installs on every Python
+# released after this one.
 requires-python = ">=3.9"
 
 # NO RUNTIME DEPENDENCIES, deliberately. Same reason: the QGIS plugin drops `geodeploy/` into its


### PR DESCRIPTION
Releasing `geodeploy` becomes `git tag cli-v1.3.0b1 && git push --tags`.

## Trusted Publishing, not an API token

PyPI verifies a short-lived OIDC token that GitHub mints for this repository, this workflow
filename and this environment. Nothing is stored in repository secrets: there is no token to leak,
none to rotate, and a compromised secret cannot be used to publish because none exists.

## The build job is a gate

A version on PyPI **can never be re-uploaded** — deleting it does not free the number — so
everything checkable is checked while a mistake is still free:

- the test suite runs on **3.9**, the package's floor and the version QGIS 3.28 LTR ships;
- **the tag must match the packaged version.** The failure this prevents is tagging `cli-v1.3.0`
  while `__init__.py` still says `1.3.0b1`, and publishing a beta under the release number;
- `twine check` on both artifacts (a README that will not render is rejected at upload, *after* the
  number is spent);
- the wheel installs into a clean venv with `--no-deps`, which is the assertion that the
  zero-dependency promise still holds — an accidental dependency would otherwise install silently.

Only if all of that passes does a publish job run.

## Why `cli-v*` and not the platform's `v1.3`

They do not always move together. The CLI's first upload is a pre-release that exists **before**
v1.3 does, and a CLI-only fix should be releasable without re-tagging the whole platform.

## Before the first run — one-time setup on PyPI

Account → Publishing → *Add a pending publisher* (a "pending" publisher is how a project that does
not exist yet gets one). All four values must match exactly or the upload is rejected as
`invalid-publisher`:

| Field | Value |
| --- | --- |
| Owner | `bravemaster3` |
| Repository | `GeoDeploy` |
| Workflow name | `publish-cli.yml` |
| Environment | `pypi` |

Repeat at test.pypi.org with environment `testpypi` for the rehearsal path (a separate account and
its own 2FA). Adding a required reviewer to the `pypi` environment in Settings → Environments makes
every upload wait for a human.

## Rehearsing

**Actions → Publish CLI → Run workflow → testpypi.** `skip-existing` is set there so a repeated
rehearsal does not fail the job; the real index deliberately has no such flag, because on PyPI
"this version already exists" means something is wrong and should say so.