### PR TITLE
fix: two bugs found by running the CLI against a live instance

### DIFF
--- a/api/geodeploy/deps.py
+++ b/api/geodeploy/deps.py
@@ -171,3 +171,35 @@ async def resolve_cookie_user(request: Request, db: AsyncSession) -> User | None
     """Best-effort user resolution from the session COOKIE (see SESSION_COOKIE). Powers the portal
     access gate's nginx auth_request, where the credential arrives as a cookie, not a header."""
     return await _user_from_token(request.cookies.get(SESSION_COOKIE), db)
+
+
+async def resolve_optional_user(request: Request, db: AsyncSession) -> User | None:
+    """The caller's identity when they have one, None when they do not — for a route that answers
+    EVERYONE, but answers an authenticated caller with more.
+
+    The public per-layer artifacts (tiles, COG, legend) gate on `_publicly_readable`, which is
+    right for an anonymous visitor and wrong for a signed-in one: it 404s a layer the caller can
+    see perfectly well in the dashboard. This closes that gap without turning a public route into
+    an authenticated one.
+
+    Two deliberate choices. An INVALID or expired credential reads as anonymous rather than 401 —
+    the route is public, and failing a request that would have succeeded with no header at all is
+    the worse answer. And an API token without `data:read` also reads as anonymous, so a token can
+    never see more than the scopes it was granted, which is the same deny-by-default posture
+    `require_scope` enforces.
+
+    Delegates to `get_current_user` rather than re-implementing it: API-token vs JWT, revocation,
+    expiry and the `token_version` check are all rules that must not exist twice.
+    """
+    auth = request.headers.get("Authorization", "")
+    raw = auth[7:].strip() if auth[:7].lower() == "bearer " else None
+    if raw:
+        try:
+            user = await get_current_user(request, raw, db)
+        except HTTPException:
+            return None
+        tok = getattr(request.state, "api_token", None)
+        if tok is not None and "data:read" not in (tok.scopes or "").split():
+            return None
+        return user
+    return await resolve_cookie_user(request, db)

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...config import get_settings
 from ...database import get_db
-from ...deps import require_scope
+from ...deps import require_scope, resolve_optional_user
 from ...models import RasterLayer, UploadJob, User
 from ...schemas import JobStatus, LayerRename, PortalRefOut, RasterDefaultStyle, RasterLayerOut, SharingUpdate
 from ...services import share_links
@@ -376,7 +376,7 @@ async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depend
 
 
 @router.get("/{layer_ref}/legend")
-async def raster_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
+async def raster_legend(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
     """PUBLIC legend for a shared raster: the colormap and the value range it is stretched over.
 
     A raster legend is a continuous ramp, not a list of swatches, so this reports the ingredients a
@@ -389,8 +389,17 @@ async def raster_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
     layer = result.scalar_one_or_none()
-    if not layer or layer.status != "ready" or not layer.is_public:
+    if not layer or layer.status != "ready":
         raise HTTPException(404, "No shared raster for this layer.")
+    if not layer.is_public:
+        # Same correction as the vector route: a signed-in caller reads the legend of a raster they
+        # can see. `is_public` alone 404s the owner of their own organization layer.
+        user = await resolve_optional_user(request, db)
+        allowed = user is not None and (await db.execute(
+            select(RasterLayer.id).where(RasterLayer.id == layer.id,
+                                         visible_to(user, RasterLayer)))).scalar_one_or_none()
+        if not allowed:
+            raise HTTPException(404, "No shared raster for this layer.")
 
     style = {}
     if layer.default_style:

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -11,7 +11,7 @@ from slugify import slugify
 
 from ...config import get_settings
 from ...database import get_db
-from ...deps import require_scope
+from ...deps import require_scope, resolve_optional_user
 from ...models import Portal, UploadJob, User, VectorLayer
 from ...schemas import DefaultStyle, JobStatus, LayerRename, PortalRefOut, SharingUpdate, VectorLayerOut
 from ...services import martin as martin_svc
@@ -574,8 +574,31 @@ async def vector_features_public(
     return await _viewport_geojson(layer, bbox, limit)
 
 
+async def _legend_readable(layer, request: Request, db: AsyncSession) -> bool:
+    """Public, or visible to whoever is asking.
+
+    `_publicly_readable` alone was wrong here in a way live testing found immediately: the OWNER of
+    an organization layer, holding a valid token, got a 404 for the legend of their own data. Every
+    other per-layer artifact is a rendering the public can already see, so public-only is right for
+    them; a legend is metadata a signed-in user reads in the dashboard, and the plugin asks for it
+    with exactly the credential the dashboard uses.
+    """
+    if layer is None:
+        return False
+    if await _publicly_readable(layer, db):
+        return True
+    user = await resolve_optional_user(request, db)
+    if user is None:
+        return False
+    # Re-query THROUGH the visibility filter rather than re-deciding what it means here — A-02 lives
+    # in `visible_to`, and a second copy would drift from it.
+    allowed = await db.execute(
+        select(VectorLayer.id).where(VectorLayer.id == layer.id, visible_to(user, VectorLayer)))
+    return allowed.scalar_one_or_none() is not None
+
+
 @router.get("/{layer_ref}/legend")
-async def vector_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
+async def vector_legend(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
     """PUBLIC legend for a vector layer's default style — the swatches and labels, computed once.
 
     `services.symbology.legend_entries` already decides what a legend shows, and the portal and the
@@ -592,7 +615,7 @@ async def vector_legend(layer_ref: str, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
     layer = result.scalar_one_or_none()
-    if not await _publicly_readable(layer, db):
+    if not await _legend_readable(layer, request, db):
         raise HTTPException(404, "Layer not found.")
 
     style = {}

--- a/api/geodeploy/tasks/csv_import.py
+++ b/api/geodeploy/tasks/csv_import.py
@@ -39,6 +39,36 @@ def safe_name(s: str, fallback: str = "col") -> str:
     return s[:60]
 
 
+#: Column names the FINAL table injects itself — `id serial primary key` and the geometry column.
+#: A CSV header matching either one must be renamed, or `CREATE TABLE` gets the name twice.
+RESERVED_COLUMNS = ("id", "geom")
+
+
+def safe_columns(fields: list[str]) -> dict[str, str]:
+    """CSV header → Postgres column names: sanitised, de-duplicated, and clear of the two names the
+    table adds for itself.
+
+    The bug this exists for: a CSV carrying a column called `id` — which is most CSVs anyone
+    exports — produced `CREATE TABLE (id serial primary key, id bigint, …)`, and Postgres refused
+    it with *column "id" specified more than once*. The import failed at 45%, well after the upload
+    had been accepted, naming a column the user never duplicated.
+
+    Such a column now becomes `id_1`, exactly as a duplicated HEADER already did — renaming an
+    attribute is a visible, explainable outcome; losing the import is not.
+    """
+    safe: dict[str, str] = {}
+    used = set(RESERVED_COLUMNS)
+    for f in fields:
+        s = safe_name(f)
+        base, n = s, 1
+        while s in used:
+            s = f"{base}_{n}"
+            n += 1
+        used.add(s)
+        safe[f] = s
+    return safe
+
+
 # Delimiter is chosen by the user (comma default); auto-sniffing is unreliable.
 _DELIM_CHAR = {"comma": ",", "semicolon": ";", "tab": "\t", "pipe": "|", "space": " "}
 
@@ -112,13 +142,7 @@ def _load_copy(path: str, schema: str, table: str, x_col: str | None, y_col: str
     elif x_col not in fields or y_col not in fields:
         raise ValueError("Selected X/Y columns are not in the CSV header.")
 
-    safe, used = {}, set()
-    for f in fields:
-        s = safe_name(f)
-        base, n = s, 1
-        while s in used:
-            s = f"{base}_{n}"; n += 1
-        used.add(s); safe[f] = s
+    safe = safe_columns(fields)
 
     srid = int(srid) or 4326
     # NATIVE-CRS STORAGE: store in the user-picked SRID. Only for 4326 do we apply the Web-Mercator

--- a/api/tests/test_csv_columns.py
+++ b/api/tests/test_csv_columns.py
@@ -1,0 +1,61 @@
+"""CSV header → Postgres column names (`tasks.csv_import.safe_columns`).
+
+Found by uploading a 500-row CSV to a live instance with the CLI: the import ran to 45% and then
+failed with *column "id" specified more than once*. The header was ordinary — `id,name,lon,lat,pop`
+— and nothing in the message suggested that `id` is a name the destination table adds for itself.
+
+The failure mode is what makes this worth pinning: the upload is ACCEPTED, the job is queued, and
+the error arrives from Postgres minutes later naming a duplicate the user never wrote. A rename is
+the right trade — a column called `id_1` is visible and explainable, a lost import is not.
+"""
+from geodeploy.tasks.csv_import import RESERVED_COLUMNS, safe_columns
+
+
+class TestReservedNames:
+    def test_an_id_column_is_renamed_rather_than_colliding(self):
+        """`CREATE TABLE (id serial primary key, …)` — the table already has an `id`."""
+        assert safe_columns(["id", "name"]) == {"id": "id_1", "name": "name"}
+
+    def test_a_geom_column_too(self):
+        """Same reason: the geometry column is injected, not read from the CSV."""
+        assert safe_columns(["geom", "value"]) == {"geom": "geom_1", "value": "value"}
+
+    def test_both_at_once(self):
+        mapping = safe_columns(["id", "geom"])
+        assert mapping == {"id": "id_1", "geom": "geom_1"}
+        assert not set(mapping.values()) & set(RESERVED_COLUMNS)
+
+    def test_case_and_punctuation_still_collide_after_sanitising(self):
+        """`ID` and `Geom.` sanitise to the reserved names, so they must be caught too — the check
+        has to happen AFTER `safe_name`, not on the raw header."""
+        assert safe_columns(["ID"])["ID"] == "id_1"
+        assert safe_columns(["Geom."])["Geom."] == "geom_1"
+
+    def test_a_column_actually_called_id_1_does_not_then_collide(self):
+        """Renaming must not create the very collision it is avoiding."""
+        mapping = safe_columns(["id", "id_1"])
+        assert len(set(mapping.values())) == 2
+        assert "id" not in mapping.values()
+
+
+class TestOrdinaryHeaders:
+    def test_unremarkable_names_are_left_alone(self):
+        assert safe_columns(["name", "lon", "lat", "pop"]) == {
+            "name": "name", "lon": "lon", "lat": "lat", "pop": "pop"}
+
+    def test_headers_that_sanitise_to_the_same_name_are_de_duplicated(self):
+        """`Name` and `name!` both reduce to `name`; the second must not shadow the first."""
+        mapping = safe_columns(["Name", "name!"])
+        assert len(set(mapping.values())) == 2
+
+    def test_sanitising_survives_punctuation_digits_and_blanks(self):
+        mapping = safe_columns(["Population (2024)", "2024", "  "])
+        assert mapping["Population (2024)"] == "population__2024"   # space and '(' each map to _
+        assert mapping["2024"].startswith("_")          # a name may not start with a digit
+        assert mapping["  "]                            # blank falls back rather than empty
+
+    def test_every_name_is_unique(self):
+        """The whole point of the mapping: these become one CREATE TABLE column list."""
+        fields = ["id", "ID", "id_1", "geom", "geometry", "name", "name"]
+        values = list(safe_columns(fields).values())
+        assert len(values) == len(set(values))

--- a/api/tests/test_legend_endpoint.py
+++ b/api/tests/test_legend_endpoint.py
@@ -9,12 +9,17 @@ the client asks, it does not recompute.
 What is pinned here is therefore mostly PARITY: the route's answer must equal what the portal draws
 from, for the same style.
 """
+import hashlib
 import json
+from datetime import timedelta
 
 import pytest
+from jose import jwt
 
-from geodeploy.models import RasterLayer, User, VectorLayer
+from geodeploy.config import get_settings
+from geodeploy.models import ApiToken, RasterLayer, User, VectorLayer
 from geodeploy.services import symbology
+from geodeploy.timeutil import naive_utcnow
 
 GRADUATED = {
     "color_mode": "graduated",
@@ -28,6 +33,21 @@ GRADUATED = {
 def _stored(style: dict) -> str:
     """A layer's `default_style` column: the style nested under the wrapper the API writes."""
     return json.dumps({"opacity": 1.0, "style": style, "popup_fields": []})
+
+
+def _session(uid: int = 1) -> dict:
+    """A browser session for `uid` — the credential the dashboard sends."""
+    return {"Authorization": "Bearer " + jwt.encode({"sub": str(uid)},
+                                                    get_settings().secret_key, algorithm="HS256")}
+
+
+async def _token(db, scopes: str, uid: int = 1, raw: str = "gdp_testtoken") -> dict:
+    """A live API token carrying `scopes` — the credential a plugin or the CLI sends."""
+    db.add(ApiToken(user_id=uid, name="test", scopes=scopes, prefix=raw[:12],
+                    token_hash=hashlib.sha256(raw.encode()).hexdigest(),
+                    expires_at=naive_utcnow() + timedelta(days=1)))
+    await db.commit()
+    return {"Authorization": "Bearer " + raw}
 
 
 @pytest.fixture
@@ -101,13 +121,52 @@ class TestVectorLegend:
     async def test_a_layer_without_data_driven_size_reports_none(self, client, layers):
         assert (await client.get("/api/data/vector/aaaaaaaaaaaa/legend")).json()["size"] is None
 
-    async def test_a_private_layer_is_not_readable(self, client, layers):
-        """Same terms as every other per-layer artifact — a legend names the classes, which is
-        information about the data."""
+    async def test_a_private_layer_is_not_readable_anonymously(self, client, layers):
+        """A legend names the classes, which is information about the data."""
         assert (await client.get("/api/data/vector/dddddddddddd/legend")).status_code == 404
 
     async def test_it_answers_by_integer_id_too(self, client, layers):
         assert (await client.get("/api/data/vector/1/legend")).status_code == 200
+
+
+class TestASignedInCallerSeesTheirOwnLayers:
+    """Found by running the CLI against a live instance: the OWNER of an organization layer, holding
+    a valid token, got 404 for the legend of their own data. `_publicly_readable` is right for a
+    rendering an anonymous visitor can already see; a legend is metadata the dashboard shows, and
+    the plugin asks for it with the same credential the dashboard uses."""
+
+    async def test_a_session_reads_its_own_organization_layer(self, client, layers):
+        r = await client.get("/api/data/vector/dddddddddddd/legend", headers=_session())
+        assert r.status_code == 200
+        assert r.json()["entries"][0]["label"] == "< 10"
+
+    async def test_a_token_with_data_read_does_too(self, client, layers, db):
+        headers = await _token(db, "data:read portal:read")
+        assert (await client.get("/api/data/vector/dddddddddddd/legend",
+                                 headers=headers)).status_code == 200
+
+    async def test_a_token_WITHOUT_data_read_sees_only_the_public_answer(self, client, layers, db):
+        """Deny-by-default: a token never exceeds the scopes it was granted, so an unscoped one is
+        treated as anonymous rather than as its owner."""
+        headers = await _token(db, "portal:write", raw="gdp_noread")
+        assert (await client.get("/api/data/vector/dddddddddddd/legend",
+                                 headers=headers)).status_code == 404
+        assert (await client.get("/api/data/vector/aaaaaaaaaaaa/legend",
+                                 headers=headers)).status_code == 200      # public, still fine
+
+    async def test_a_garbage_credential_reads_as_anonymous_not_as_an_error(self, client, layers):
+        """The route is public. Failing a request that would have succeeded with no header at all
+        is the worse answer."""
+        bad = {"Authorization": "Bearer gdp_not_a_real_token"}
+        assert (await client.get("/api/data/vector/aaaaaaaaaaaa/legend",
+                                 headers=bad)).status_code == 200
+        assert (await client.get("/api/data/vector/dddddddddddd/legend",
+                                 headers=bad)).status_code == 404
+
+    async def test_a_raster_behaves_the_same_way(self, client, layers):
+        assert (await client.get("/api/data/raster/3333bbbb4444/legend")).status_code == 404
+        assert (await client.get("/api/data/raster/3333bbbb4444/legend",
+                                 headers=_session())).status_code == 200
 
 
 class TestRasterLegend:


### PR DESCRIPTION
Both found within ten minutes of pointing the published CLI at a real instance, and neither was
reachable by the test suite as it stood.

## 1. A CSV with an `id` column could not be imported

Uploading an ordinary `id,name,lon,lat,pop` CSV:

```
cli_smoke_points.csv:  45%  Loading into PostGIS
error: cli_smoke_points.csv: column "id" specified more than once
```

The sanitiser de-duplicated the CSV's headers **against each other**, but the destination table
injects two names of its own — `id serial primary key` and `geom` — so the statement became
`CREATE TABLE (id serial primary key, id bigint, …)`.

What makes it worth more than a one-line patch is the shape of the failure: the upload is
**accepted**, the job is **queued**, and the error surfaces from Postgres minutes later naming a
duplicate the user never wrote. Nothing points at the real cause.

`id` and `geom` are now reserved, so such a column becomes `id_1` — exactly what a duplicated
header already did. Renaming an attribute is visible and explainable; losing the import is not. The
logic moved out of `_load_copy` into `safe_columns()`, which is testable without a database.

## 2. The legend 404'd for the owner of their own layer

Live, with a valid owner token:

```
$ geodeploy layers legend "zz cli smoke test"     # organization visibility, not on a portal
error: Layer not found.
$ geodeploy layers share "zz cli smoke test" --visibility public
$ geodeploy layers legend "zz cli smoke test"
#000004  < 17181
#8c2981  17181 – 34498
…
```

`/legend` gated on `_publicly_readable`. That is right for the other per-layer artifacts — they are
renderings an anonymous visitor can already see — and wrong for a legend, which is metadata the
dashboard shows and which the QGIS plugin will request with the same credential the dashboard uses.

**`deps.resolve_optional_user`** is the missing piece: a route that answers *everyone*, and answers
an authenticated caller with *more*. Three deliberate rules:

- it delegates to `get_current_user`, so API-token vs JWT, revocation, expiry and `token_version`
  are not re-implemented where they could drift;
- an **invalid** credential reads as anonymous rather than 401 — the route is public, and failing a
  request that would have succeeded with no header at all is the worse answer;
- a token **without `data:read`** also reads as anonymous, so a token never exceeds its granted
  scopes.

## Tests

Full API suite: **621 passed**. New: the reserved-column cases (including `ID`/`Geom.`, which only
collide *after* sanitising, and a header literally called `id_1`), and the legend's auth matrix —
session, scoped token, unscoped token, garbage token, anonymous.

## Also verified live, and working

Upload → ingest → `--wait`; `layers stats`; server-side classification (`--classify quantile
--classes 5`, breaks matching the stats preview); `--size-field`/`--size-stops` (which sets
`size_mode` for you); portal create → add-layer → publish → anonymous read of the published bundle
by URL; the built export (`complete: yes`, `500 rows` in `MANIFEST.txt`); and the uncapped
GeoParquet download (`manifest.json` + partition, no worker). Every test object was deleted
afterwards.