### PR TITLE
feat: close the open symbology issues, plus HEAD/#17 fixes found by using it

### DIFF
--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -408,6 +408,44 @@ class _DemoUploadCap:
         await self.app(scope, receive, send)
 
 
+class _HeadAsGet:
+    """Answer HEAD on every GET route, by running the GET and dropping the body.
+
+    FastAPI's `APIRoute` does NOT add HEAD to a GET route (plain Starlette's `Route` does), so every
+    endpoint here answered **405** to HEAD. That is not a formality: **`/vsicurl/` opens a URL with a
+    HEAD request**, so GDAL — and therefore QGIS, ogr2ogr and anything else built on it — could not
+    open a single GeoDeploy artifact. `ogrinfo /vsicurl/…/pmtiles` failed with "not recognized as
+    being in a supported file format", which reads like a broken file and is really a 405 on a probe.
+    The COG path our own documentation recommends for QGIS was affected too.
+
+    PURE ASGI for the reason `_DemoUploadCap` documents above: a second `BaseHTTPMiddleware` broke
+    dependency teardown once and silently rolled back commits.
+
+    Headers — Content-Length and Content-Range included — are passed through untouched, which is
+    what a HEAD is FOR; only the body bytes are dropped. A streamed response is still produced
+    server-side, but the probes that matter here are small metadata reads.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or scope.get("method") != "HEAD":
+            await self.app(scope, receive, send)
+            return
+
+        scope = dict(scope, method="GET")
+
+        async def send_without_body(message):
+            if message.get("type") == "http.response.body":
+                # Keep the message (the protocol needs it) but empty, and never ask for more.
+                message = {"type": "http.response.body", "body": b"", "more_body": False}
+            await send(message)
+
+        await self.app(scope, receive, send_without_body)
+
+
+app.add_middleware(_HeadAsGet)
 app.add_middleware(_DemoUploadCap)
 
 

--- a/api/geodeploy/models.py
+++ b/api/geodeploy/models.py
@@ -319,6 +319,12 @@ class RasterLayer(Base):
     bbox: Mapped[str | None] = mapped_column(Text)
     band_count: Mapped[int | None] = mapped_column(Integer)
     nodata_value: Mapped[float | None] = mapped_column(Float)
+    # Can this raster be drawn zoomed OUT without an expensive read? Decided at ingest from the
+    # file's overview pyramid (cog_converter.low_zoom_is_cheap), because the alternative — guessing
+    # from the layer's EXTENT — hides a small high-resolution layer at zooms where someone might
+    # legitimately be looking, with no message. NULL on layers ingested before this existed, which
+    # keeps the old extent heuristic for them. Issue #17.
+    low_zoom_ok: Mapped[bool | None] = mapped_column(Boolean)
     file_size: Mapped[int | None] = mapped_column(BigInteger)   # BIGINT: a single raster or GeoParquet can exceed int4's 2.1 GB
     status: Mapped[str] = mapped_column(String(16), default="processing")
     error_message: Mapped[str | None] = mapped_column(Text)

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -254,11 +254,15 @@ deliberately NOT visibility-filtered (published portals depend on them).
   carries **`bounds`** (from the stored EPSG:4326 bbox; TiTiler `/cog/info` only as a fallback for
   legacy rows) — bounds are the whole point: a bare XYZ URL has none, so "zoom to layer" fails.
 - **HEAD works on every GET route** (2026-08-14, `main._HeadAsGet`). FastAPI's `APIRoute` does not
-  add HEAD to a GET route, so every endpoint here answered **405** — and **`/vsicurl/` probes a URL
-  with HEAD**, so GDAL (and therefore QGIS, ogr2ogr, anything on GDAL) could not open `/cog`,
-  `/pmtiles` or a parquet partition. It failed as "not recognized as being in a supported file
-  format", which reads like a broken file. The middleware runs the GET and drops the body; headers,
-  including Content-Length and Content-Range, pass through. Tests: `test_head_requests.py`.
+  add HEAD to a GET route (plain Starlette's `Route` does), so every endpoint answered **405** — non
+  conformant, and some clients probe with HEAD before fetching. The middleware runs the GET and
+  drops the body; headers, including Content-Length and Content-Range, pass through. Tests:
+  `test_head_requests.py`.
+  **What it does NOT explain:** GDAL was never blocked by it. Verified against a live instance
+  BEFORE the fix — `ogr.Open("/vsicurl/…/pmtiles")` opened fine, because `/vsicurl/` tolerates a 405
+  probe and falls back to a ranged GET. (A container test that said otherwise was getting 403 from
+  Cloudflare, which GDAL reports with the same "not recognized as being in a supported file format"
+  message.)
 - **`GET /data/{vector,raster}/{ref}/legend`** — **PUBLIC** legend for the layer's default style
   (2026-08-13), on the same terms as the other artifacts. Vector returns
   `{color_mode, field, entries[{color,label}], size}` straight from

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -253,6 +253,12 @@ deliberately NOT visibility-filtered (published portals depend on them).
   missing nginx's `/raster` prefix). Bakes the layer's saved styling into the tile template and
   carries **`bounds`** (from the stored EPSG:4326 bbox; TiTiler `/cog/info` only as a fallback for
   legacy rows) — bounds are the whole point: a bare XYZ URL has none, so "zoom to layer" fails.
+- **HEAD works on every GET route** (2026-08-14, `main._HeadAsGet`). FastAPI's `APIRoute` does not
+  add HEAD to a GET route, so every endpoint here answered **405** — and **`/vsicurl/` probes a URL
+  with HEAD**, so GDAL (and therefore QGIS, ogr2ogr, anything on GDAL) could not open `/cog`,
+  `/pmtiles` or a parquet partition. It failed as "not recognized as being in a supported file
+  format", which reads like a broken file. The middleware runs the GET and drops the body; headers,
+  including Content-Length and Content-Range, pass through. Tests: `test_head_requests.py`.
 - **`GET /data/{vector,raster}/{ref}/legend`** — **PUBLIC** legend for the layer's default style
   (2026-08-13), on the same terms as the other artifacts. Vector returns
   `{color_mode, field, entries[{color,label}], size}` straight from

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -778,6 +778,7 @@ async def field_stats(
     classes: int = 5,
     method: str = "quantile",
     ramp: str = "viridis",
+    reverse: bool = False,
     user: User = Depends(require_scope("data:read")),
     db: AsyncSession = Depends(get_db),
 ):
@@ -834,7 +835,9 @@ async def field_stats(
     if stats.get("kind") == "numeric":
         stats["suggestion"] = {
             "color_mode": "graduated",
-            "classes": symbology.build_classes(stats.get("values") or [], method, classes, ramp),
+            "color_ramp_reverse": reverse,   # echoed so a client stores the direction it asked for
+            "classes": symbology.build_classes(stats.get("values") or [], method, classes, ramp,
+                                               reverse),
         }
         # The raw sample is for the classifier, not for the browser: tens of thousands of numbers
         # would be the bulk of this response and the UI never reads them.
@@ -842,8 +845,9 @@ async def field_stats(
     else:
         stats["suggestion"] = {
             "color_mode": "categorized",
+            "color_ramp_reverse": reverse,
             "categories": symbology.build_categories(
-                [c["value"] for c in stats.get("categories") or []]),
+                [c["value"] for c in stats.get("categories") or []], reverse=reverse),
         }
     return stats
 

--- a/api/geodeploy/schema_migrations.py
+++ b/api/geodeploy/schema_migrations.py
@@ -58,4 +58,8 @@ PG_MIGRATIONS = [
     # 'public' already says it may be seen, and a geoportal that cannot be browsed is a filing
     # cabinet. An operator who wants their public portal reachable-but-unlisted turns this off.
     "ALTER TABLE setup_config ADD COLUMN public_index_enabled BOOLEAN DEFAULT TRUE",
+    # Raster low-zoom cost, read from the COG's overview pyramid at ingest (issue #17). Nullable with
+    # NO default on purpose: NULL means "not measured", which is different from False and is what
+    # keeps every existing layer on the extent heuristic until it is re-ingested.
+    "ALTER TABLE raster_layers ADD COLUMN IF NOT EXISTS low_zoom_ok BOOLEAN",
 ]

--- a/api/geodeploy/schemas.py
+++ b/api/geodeploy/schemas.py
@@ -447,6 +447,10 @@ class RasterLayerOut(BaseModel):
     bbox: list[float] | None
     band_count: int | None
     nodata_value: float | None
+    # Whether a zoomed-out tile is cheap for this file (issue #17). Exposed so the CLI and a
+    # plugin can explain why a layer does or does not draw at low zoom, rather than the
+    # answer living only inside the published style.
+    low_zoom_ok: bool | None = None
     file_size: int | None
     status: str
     error_message: str | None

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -222,6 +222,13 @@ Deliberately NOT deck.gl's ColumnLayer for these: PostGIS layers render through 
 and switching renderer when 3D is ticked would need a second implementation of identify, visibility
 and z-order. GeoParquet points are deck-rendered and their half is NOT built — the editor hides the
 control for them rather than showing one that does nothing.)
+2026-08-13b (`cog_converter.low_zoom_is_cheap` + `portal_generator.raster_minzoom` — issue #17. The
+raster minzoom floor was computed from the layer's EXTENT, a proxy; what decides whether a
+zoomed-out tile is expensive is the file's OVERVIEW PYRAMID. Measured at ingest on the CONVERTED
+COG (the pyramid is what conversion adds, so reading `meta` from the original would answer the
+wrong question) and stored as `raster_layers.low_zoom_ok`. True → no floor; NULL/False → the
+heuristic. NULL is deliberately not False: existing layers keep today's behaviour until they are
+re-ingested, which is the conservative direction for a guard against a page-wide hang.)
 2026-08-13 (`ramp_colors(name, count, reverse=False)` — reversing a ramp is a FLAG
 (`color_ramp_reverse` in the style, `?reverse=` on `field-stats`), never a second table of reversed
 ramps: which end means "high" is a cartographic choice, and nine ramps would become eighteen. The

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -222,6 +222,15 @@ Deliberately NOT deck.gl's ColumnLayer for these: PostGIS layers render through 
 and switching renderer when 3D is ticked would need a second implementation of identify, visibility
 and z-order. GeoParquet points are deck-rendered and their half is NOT built — the editor hides the
 control for them rather than showing one that does nothing.)
+2026-08-13 (`ramp_colors(name, count, reverse=False)` — reversing a ramp is a FLAG
+(`color_ramp_reverse` in the style, `?reverse=` on `field-stats`), never a second table of reversed
+ramps: which end means "high" is a cartographic choice, and nine ramps would become eighteen. The
+sampled OUTPUT is reversed, not the stop list, so a reversed ramp is the same colours backwards.
+**While adding it, the twins were found to already disagree**: sampling used `round()`, which is
+half-to-EVEN in Python and half-UP in JavaScript, so every 5- and 9-class ramp picked a different
+stop in `ui/src/lib/symbology.js` than here. Latent only because nothing in the UI called
+`rampColors` yet. Both now use `x + 0.5` truncated — one formula, expressible identically in either
+language — and `test_symbology` pins three literal colour lists as the contract between them.)
 2026-08-06 (**new `symbology.py` — data-driven styling**. THE source of truth for turning a layer's
 friendly style keys into MapLibre expressions: `classify` (quantile/equal/jenks-by-k-means),
 `build_classes`/`build_categories`, `color_expression` (`step`/`match`), `size_expression`

--- a/api/geodeploy/services/cog_converter.py
+++ b/api/geodeploy/services/cog_converter.py
@@ -114,10 +114,46 @@ def _read_meta(ds) -> dict:
         "nodata_value": float(nodata) if nodata is not None else None,
         "width": ds.width,
         "height": ds.height,
+        # Overview decimation factors ([2, 4, 8, …]) of band 1. What they answer is "how cheaply can
+        # this be drawn zoomed OUT" — see `low_zoom_is_cheap`.
+        "overviews": list(ds.overviews(1) or []),
         # dtype of band 1 — drives whether a default display rescale is needed (non-8-bit data renders
         # black on tile servers that assume 0–255, so ingest computes a stretch for those).
         "dtype": str(ds.dtypes[0]) if ds.dtypes else None,
     }
+
+
+#: A zoomed-out request is cheap when the pyramid has an overview at or below this many pixels on
+#: its longest side — one small read, whatever area the tile covers.
+_CHEAP_OVERVIEW_PX = 1024
+
+
+def low_zoom_is_cheap(width: int | None, height: int | None, overviews: list | None) -> bool:
+    """Can this raster be drawn at a low zoom without a big read? (issue #17)
+
+    The minzoom floor exists because a z3 tile of a drone orthomosaic once took long enough that
+    nginx returned 504, and a hanging tile costs the whole portal. But the floor is computed from
+    the layer's EXTENT, which is only a proxy: what actually decides the cost is whether the file
+    has an overview small enough to answer from directly.
+
+    A COG we built always has one — the converter writes a full pyramid — so for those the floor is
+    guesswork that hides a small high-resolution layer at zooms where someone might legitimately be
+    looking, with no message and nothing in the console. An imported file with no overviews keeps
+    the floor, because for that one the original reasoning still holds.
+    """
+    if not width or not height:
+        return False
+    longest = max(int(width), int(height))
+    if longest <= _CHEAP_OVERVIEW_PX:
+        return True                      # small enough that the full read IS the cheap read
+    for factor in (overviews or []):
+        try:
+            if factor and longest / float(factor) <= _CHEAP_OVERVIEW_PX:
+                return True
+        except (TypeError, ValueError, ZeroDivisionError):
+            # A driver can report anything; a display hint must not raise inside ingest.
+            continue
+    return False
 
 
 def inspect(path: str) -> dict:

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -271,7 +271,7 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
                 # MapLibre then sits waiting on that tile, the portal's load handler never settles,
                 # and the whole page hangs on the loading screen until the 15s backstop. A 504 is
                 # far worse than a 404: the 404 is instant, this one costs the entire page.
-                _mz = _min_zoom_for(_rb)
+                _mz = raster_minzoom(layer, _rb)
                 if _mz:
                     sources[source_id]["minzoom"] = _mz
             # Base opacity + an optional raster-paint passthrough (GeoLibre import carries
@@ -1513,6 +1513,24 @@ def _min_zoom_for(bounds: list[float]) -> int:
         return 0
     fits_at = math.log2(360.0 / width) if width < 360 else 0
     return max(0, min(int(fits_at) - _MINZOOM_SLACK, 18))
+
+
+def raster_minzoom(layer, bounds) -> int:
+    """The `minzoom` to write for this raster source — 0 meaning "write none" (issue #17).
+
+    The floor above is computed from the layer's EXTENT, which is a proxy for cost. `low_zoom_ok` is
+    the measurement: taken at ingest from the file's own overview pyramid
+    (`cog_converter.low_zoom_is_cheap`). When the file can answer a zoomed-out tile from a small
+    overview, the 504 the floor exists to prevent cannot happen, and keeping the floor only makes a
+    small high-resolution layer disappear below a computed zoom with no message.
+
+    `None` — every layer ingested before the measurement existed — keeps the heuristic. So this
+    changes nothing for an existing instance until its rasters are re-ingested, which is the
+    conservative direction for a guard that was protecting against a page-wide hang.
+    """
+    if getattr(layer, "low_zoom_ok", None) is True:
+        return 0
+    return _min_zoom_for(bounds)
 
 
 def _geom_kind(geometry_type: str | None) -> str:

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -98,10 +98,11 @@ def vector_links(layer, base: str) -> list[dict]:
                 "pmtiles", "PMTiles archive (fast rendering)", f"{api}/pmtiles",
                 fmt="PMTiles (vector)", tools=["GeoLibre", "MapLibre", "download", "GDAL"],
                 hint="Paste as-is — no pmtiles:// prefix (that is a MapLibre-internal protocol "
-                     "handler, not part of any address). QGIS cannot add this through Add Vector "
-                     "Tile Layer: that dialog builds an XYZ template ({z}/{x}/{y}) and a PMTiles "
-                     "archive is one file, so prefer the OGC API - Features link above for QGIS. "
-                     "GDAL 3.8+ has a PMTiles driver and reads it as /vsicurl/<this URL>."))
+                     "handler, not part of any address). In QGIS this does NOT go in Add Vector "
+                     "Tile Layer (that dialog builds an XYZ template and an archive is one file); "
+                     "open it with GDAL 3.8+ as /vsicurl/<this URL>. For attributes and queries "
+                     "prefer the OGC API - Features service above — PMTiles is generalized per "
+                     "zoom."))
         links.append(_link(
             "features-geojson", "Viewport features (GeoDeploy native)",
             f"{api}/features.geojson?bbox=minx,miny,maxx,maxy&limit=50000",

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -45,13 +45,16 @@ def vector_links(layer, base: str) -> list[dict]:
     # FME, anything on GDAL's OAPIF driver), it carries real attributes, and it works the same for
     # both storage backends. Tiles/PMTiles below are for RENDERING speed, not interchange.
     links: list[dict] = [
-        _link("ogc-features", "OGC API - Features — this layer",
+        # NOT primary, and NOT labelled for QGIS. A desktop client connects to the SERVICE and picks
+        # a layer; pasting a COLLECTION url into QGIS's "Add OGC API - Features Layer" dialog
+        # produces an empty list and no error, which is exactly what happened to the first person
+        # who tried it — because this link was the promoted one and named QGIS first.
+        _link("ogc-features", "OGC API - Features — this layer (for GDAL)",
               f"{base}/api/ogc/collections/vector-{public_ref(layer)}",
               fmt="OGC API - Features (GeoJSON)",
-              tools=["QGIS", "ArcGIS Pro", "FME", "GDAL/ogr2ogr"],
-              hint="GDAL/ogr2ogr: use OAPIF:<this URL>. In QGIS you connect to the SERVICE url "
-                   "below and pick the layer from the list.",
-              primary=True),
+              tools=["GDAL/ogr2ogr", "Python", "R"],
+              hint="For GDAL: ogr2ogr out.gpkg \"OAPIF:<this URL>\". QGIS and ArcGIS cannot connect "
+                   "to a single collection — use the service URL below and pick this layer."),
         # Named for its SCOPE, not its role. "service endpoint" sat next to "this layer" and read as
         # a synonym, so it was copied expecting one dataset and opened the whole list. The scope is
         # not a leak — /api/ogc lists only layers explicitly shared as public (ogcapi._public_layers)
@@ -59,6 +62,7 @@ def vector_links(layer, base: str) -> list[dict]:
         _link("ogc-service", "OGC API - Features — ALL your public layers", f"{base}/api/ogc",
               fmt="OGC API - Features landing page",
               tools=["QGIS", "ArcGIS Pro", "FME"],
+              primary=True,
               hint="Not just this layer: this is the service, and it lists every layer you have "
                    "shared publicly. It is what QGIS needs — Layer ▸ Add Layer ▸ Add OGC API - "
                    "Features Layer ▸ New ▸ paste this, then pick this layer from the list."),
@@ -93,10 +97,11 @@ def vector_links(layer, base: str) -> list[dict]:
             links.append(_link(
                 "pmtiles", "PMTiles archive (fast rendering)", f"{api}/pmtiles",
                 fmt="PMTiles (vector)", tools=["GeoLibre", "MapLibre", "download", "GDAL"],
-                hint="Paste as-is. A MapLibre style source needs the pmtiles:// protocol prefix "
-                     "added in code, but no UI field wants it. GDAL builds with PMTiles support "
-                     "read it via /vsicurl/. To load this layer INTO QGIS, prefer the OGC API - "
-                     "Features link above \u2014 PMTiles is a rendering format."))
+                hint="Paste as-is — no pmtiles:// prefix (that is a MapLibre-internal protocol "
+                     "handler, not part of any address). QGIS cannot add this through Add Vector "
+                     "Tile Layer: that dialog builds an XYZ template ({z}/{x}/{y}) and a PMTiles "
+                     "archive is one file, so prefer the OGC API - Features link above for QGIS. "
+                     "GDAL 3.8+ has a PMTiles driver and reads it as /vsicurl/<this URL>."))
         links.append(_link(
             "features-geojson", "Viewport features (GeoDeploy native)",
             f"{api}/features.geojson?bbox=minx,miny,maxx,maxy&limit=50000",

--- a/api/geodeploy/services/symbology.py
+++ b/api/geodeploy/services/symbology.py
@@ -79,13 +79,19 @@ DEFAULT_COLOR = "#3b82f6"
 DEFAULT_OTHER_COLOR = "#9ca3af"
 
 
-def ramp_colors(name: str, count: int) -> list[str]:
-    """`count` colours sampled evenly from a named ramp.
+def ramp_colors(name: str, count: int, reverse: bool = False) -> list[str]:
+    """`count` colours sampled evenly from a named ramp, optionally end-to-end reversed.
 
     Nearest-stop sampling, not channel interpolation: the ramps above are already perceptually
     tuned, and a hand-rolled RGB blend between two of their stops can leave the uniform path — the
     property that makes them worth using. For the class counts a legend can actually be read at
     (3–9) the sampled stops are visually distinct anyway.
+
+    `reverse` is a FLAG rather than a second table of reversed ramps: which end means "high" is a
+    cartographic choice (a dark basemap often wants the light end for low values), and doubling nine
+    ramps into eighteen would turn the picker into a wall. Reversing the sampled OUTPUT rather than
+    the stop list keeps the sampling positions identical, so a reversed ramp is exactly the same
+    colours in the opposite order — not a differently-sampled one.
     """
     stops = RAMPS.get(name) or RAMPS["viridis"]
     if count <= 0:
@@ -95,8 +101,12 @@ def ramp_colors(name: str, count: int) -> list[str]:
     out = []
     for i in range(count):
         pos = i * (len(stops) - 1) / (count - 1)
-        out.append(stops[int(round(pos))])
-    return out
+        # `int(pos + 0.5)`, NOT `round()`. Python's round() is round-half-to-EVEN and JavaScript's
+        # Math.round() is round-half-UP, so the twin in ui/src/lib/symbology.js picked a different
+        # stop wherever `pos` landed on .5 — which is every 5- and 9-class ramp, in all nine ramps.
+        # Half-up is expressible identically in both languages, so the two cannot drift again.
+        out.append(stops[int(pos + 0.5)])
+    return out[::-1] if reverse else out
 
 
 # ── Classification ───────────────────────────────────────────────────────────────────────────────
@@ -195,7 +205,8 @@ def _usable(breaks: list[float], lo: float, hi: float) -> list[float]:
     return [b for b in breaks if lo < b <= hi]
 
 
-def build_classes(values: list[float], method: str, count: int, ramp: str) -> list[dict]:
+def build_classes(values: list[float], method: str, count: int, ramp: str,
+                  reverse: bool = False) -> list[dict]:
     """Breaks + ramp → the `classes` list the style stores and the legend reads.
 
     `min` of the first class and `max` of the last are `None`, matching the open outer edges
@@ -206,20 +217,21 @@ def build_classes(values: list[float], method: str, count: int, ramp: str) -> li
         vals = [v for v in values if v is not None]
         if not vals:
             return []
-        return [{"min": None, "max": None, "color": ramp_colors(ramp, 1)[0]}]
-    colors = ramp_colors(ramp, len(breaks) + 1)
+        return [{"min": None, "max": None, "color": ramp_colors(ramp, 1, reverse)[0]}]
+    colors = ramp_colors(ramp, len(breaks) + 1, reverse)
     edges = [None, *breaks, None]
     return [{"min": edges[i], "max": edges[i + 1], "color": colors[i]}
             for i in range(len(breaks) + 1)]
 
 
-def build_categories(values: list, ramp: str | None = None) -> list[dict]:
+def build_categories(values: list, ramp: str | None = None,
+                     reverse: bool = False) -> list[dict]:
     """Distinct values → categories, in the order given (the stats endpoint returns them by
     frequency, so the commonest gets the first, most distinguishable colour)."""
     out = []
     for i, v in enumerate(values):
         if ramp and ramp in RAMPS:
-            colors = ramp_colors(ramp, max(len(values), 1))
+            colors = ramp_colors(ramp, max(len(values), 1), reverse)
             color = colors[i] if i < len(colors) else DEFAULT_OTHER_COLOR
         else:
             color = CATEGORY_COLORS[i % len(CATEGORY_COLORS)]

--- a/api/geodeploy/tasks/raster_ingest.py
+++ b/api/geodeploy/tasks/raster_ingest.py
@@ -12,7 +12,8 @@ from botocore.client import Config
 from .. import state_db
 from ..celery_app import celery_app
 from ..config import get_settings
-from ..services.cog_converter import convert_to_cog, inspect as inspect_raster, is_cog
+from ..services.cog_converter import (convert_to_cog, inspect as inspect_raster, is_cog,
+                                      low_zoom_is_cheap)
 
 
 def _get_storage_creds() -> dict:
@@ -191,6 +192,18 @@ def ingest_raster(self, job_id: str, layer_id: int, file_path: str, s3_key: str)
             rescale = _default_rescale(s3_key, settings)
             if rescale:
                 extra["default_style"] = json.dumps({"rescale": rescale})
+        # Whether a zoomed-out tile is cheap is a property of the FILE — its overview pyramid — not
+        # of its extent, so it is decided once here rather than guessed from the bounding box at
+        # every publish (issue #17). Read from the COG we are about to serve, NOT from `meta`: that
+        # describes the ORIGINAL, and the pyramid is what conversion just added.
+        try:
+            cog_meta = inspect_raster(cog_path)
+            extra["low_zoom_ok"] = bool(low_zoom_is_cheap(
+                cog_meta.get("width"), cog_meta.get("height"), cog_meta.get("overviews")))
+        except Exception:
+            # Never fail an otherwise-good ingest over a display hint; absent means "use the
+            # extent heuristic", which is what every existing layer already does.
+            extra["low_zoom_ok"] = None
         _update_layer(layer_id,
                       status="ready",
                       crs=meta["crs"],

--- a/api/tests/test_head_requests.py
+++ b/api/tests/test_head_requests.py
@@ -1,0 +1,51 @@
+"""HEAD works on every GET route (`main._HeadAsGet`).
+
+Found by trying to open a GeoDeploy layer in QGIS. `ogrinfo /vsicurl/…/pmtiles` answered "not
+recognized as being in a supported file format", which reads like a corrupt archive — the file was
+perfect (`PMTiles` v3 magic, byte ranges served, 206 on a ranged GET). **`/vsicurl/` probes a URL
+with a HEAD request first**, FastAPI's `APIRoute` does not add HEAD to a GET route, and every
+endpoint answered 405. So GDAL gave up before reading a byte, and with it QGIS, ogr2ogr and
+everything else built on GDAL — including the `/cog` path this project's own documentation
+recommends for QGIS.
+
+The bar these tests set: a HEAD answers with the GET's STATUS and HEADERS and an empty body.
+"""
+import pytest
+
+
+class TestHeadIsAnswered:
+    @pytest.mark.parametrize("path", [
+        "/health",
+        "/api/setup/status",
+        "/api/public",
+        "/api/ogc",
+        "/api/stac",
+    ])
+    async def test_head_is_not_405(self, client, path):
+        r = await client.head(path)
+        assert r.status_code != 405, f"HEAD {path} answered 405 — /vsicurl/ cannot open this"
+        assert r.status_code < 500
+
+    async def test_head_matches_the_get_status(self, client):
+        assert (await client.head("/health")).status_code == (
+            await client.get("/health")).status_code
+
+    async def test_head_returns_no_body(self, client):
+        """The whole point of HEAD. The headers still describe what a GET would return."""
+        r = await client.head("/health")
+        assert r.content == b""
+
+    async def test_the_headers_survive(self, client):
+        """A probe reads Content-Type (and, on a real artifact, Content-Length and Accept-Ranges)
+        from the HEAD — dropping them would leave GDAL as stuck as the 405 did."""
+        head = await client.head("/health")
+        get = await client.get("/health")
+        assert head.headers.get("content-type") == get.headers.get("content-type")
+
+    async def test_a_missing_route_still_404s(self, client):
+        """Answering HEAD everywhere must not turn unknown paths into successes."""
+        assert (await client.head("/api/no-such-endpoint")).status_code == 404
+
+    async def test_get_is_unaffected(self, client):
+        r = await client.get("/health")
+        assert r.status_code == 200 and r.content

--- a/api/tests/test_ogcapi.py
+++ b/api/tests/test_ogcapi.py
@@ -256,10 +256,20 @@ async def test_share_links_lead_with_ogc_features(client, db):
     assert r.status_code == 200
     body = r.json()
     assert body["public"] is True
-    assert body["links"][0]["id"] == "ogc-features"       # the recommended one, first
-    assert body["links"][0]["primary"] is True
     ids = [l["id"] for l in body["links"]]
-    assert {"ogc-service", "ogc-items", "tilejson", "stac"} <= set(ids)
+    assert {"ogc-features", "ogc-service", "ogc-items", "tilejson", "stac"} <= set(ids)
+
+    # The PRIMARY link is the SERVICE, not the collection. It used to be the other way round, and a
+    # desktop user followed it into a dead end: QGIS's "Add OGC API - Features Layer" connects to a
+    # service and lists its collections, so a collection URL produces an empty list and no error.
+    # The collection link stays (GDAL takes `OAPIF:<collection>` happily) but is not the one led with.
+    primary = [l for l in body["links"] if l.get("primary")]
+    assert [l["id"] for l in primary] == ["ogc-service"]
+    service = next(l for l in body["links"] if l["id"] == "ogc-service")
+    assert service["url"].endswith("/api/ogc")
+    assert "QGIS" in service["tools"]
+    collection = next(l for l in body["links"] if l["id"] == "ogc-features")
+    assert "QGIS" not in collection["tools"], "labelling a collection for QGIS is what misled"
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_raster_low_zoom.py
+++ b/api/tests/test_raster_low_zoom.py
@@ -1,0 +1,98 @@
+"""Whether a raster may be drawn zoomed OUT (issue #17).
+
+The minzoom floor exists for a real reason: a z3 tile of a drone orthomosaic once took TiTiler long
+enough that nginx answered 504, and MapLibre waits on a hanging tile, so the portal's load handler
+never settles and the whole page sits on its loading screen. A 404 costs nothing; that 504 cost
+everything.
+
+But the floor was computed from the layer's EXTENT, which is only a proxy for cost. The actual
+question is whether the file has an overview small enough to answer a zoomed-out tile from directly
+— and a COG this instance built always does, because the converter writes a full pyramid. For those
+layers the floor is guesswork that makes a small high-resolution layer VANISH below a computed zoom,
+with no message and nothing in the console.
+
+So: measure it at ingest, from the file. `None` (never measured) keeps the heuristic, which is what
+every layer ingested before this does.
+"""
+import pytest
+
+from geodeploy.services.cog_converter import low_zoom_is_cheap
+
+
+class TestCheapWhenThePyramidSaysSo:
+    def test_a_small_image_needs_no_overviews(self):
+        """The whole file IS the cheap read."""
+        assert low_zoom_is_cheap(800, 600, []) is True
+
+    def test_a_big_image_with_a_deep_pyramid_is_cheap(self):
+        """20000px ÷ 32 = 625px — one small read, whatever area the tile covers."""
+        assert low_zoom_is_cheap(20000, 18000, [2, 4, 8, 16, 32]) is True
+
+    def test_a_big_image_with_a_shallow_pyramid_is_not(self):
+        """20000 ÷ 4 = 5000px still has to be read and warped for a single tile."""
+        assert low_zoom_is_cheap(20000, 18000, [2, 4]) is False
+
+    def test_a_big_image_with_no_overviews_is_not(self):
+        """An imported GeoTIFF that was already a COG but without a pyramid: the original
+        reasoning still applies to it, so it keeps the floor."""
+        assert low_zoom_is_cheap(20000, 18000, []) is False
+
+    def test_the_longest_side_decides(self):
+        """A tall thin raster is as expensive as a wide one — the read is 2D."""
+        assert low_zoom_is_cheap(500, 40000, []) is False
+        assert low_zoom_is_cheap(40000, 500, [64]) is True
+
+
+class TestItNeverThrows:
+    """This runs inside ingest. A display hint must never fail an otherwise-good upload."""
+
+    @pytest.mark.parametrize("args", [
+        (None, None, None),
+        (0, 0, []),
+        (1000, None, [2]),
+        (20000, 20000, [0]),          # a zero factor would divide by zero
+        (20000, 20000, [None, "x"]),  # nonsense from an odd driver
+    ])
+    def test_bad_input_answers_false_rather_than_raising(self, args):
+        assert low_zoom_is_cheap(*args) in (True, False)
+
+
+class _Layer:
+    """Just the attribute `raster_minzoom` reads."""
+
+    def __init__(self, low_zoom_ok):
+        self.low_zoom_ok = low_zoom_ok
+
+
+class TestThePublishedStyle:
+    """What `portal_generator` writes as the source's `minzoom` — 0 meaning "write none"."""
+
+    #: Drone-sized: small enough that the extent heuristic produces a floor well above 0.
+    SMALL = [11.0000, 55.0000, 11.0020, 55.0015]
+    #: Continent-sized: the heuristic already writes nothing.
+    HUGE = [-20.0, 30.0, 40.0, 70.0]
+
+    def test_the_heuristic_still_applies_by_default(self):
+        from geodeploy.services.portal_generator import raster_minzoom
+        floor = raster_minzoom(_Layer(None), self.SMALL)
+        assert floor > 0, "a small extent must still get a floor when nothing was measured"
+
+    def test_a_file_measured_as_cheap_gets_no_floor(self):
+        """The point of the issue: the layer stops vanishing at low zoom."""
+        from geodeploy.services.portal_generator import raster_minzoom
+        assert raster_minzoom(_Layer(True), self.SMALL) == 0
+
+    def test_measured_as_EXPENSIVE_keeps_the_floor(self):
+        from geodeploy.services.portal_generator import raster_minzoom
+        assert raster_minzoom(_Layer(False), self.SMALL) > 0
+
+    def test_an_existing_layer_is_unchanged(self):
+        """NULL is not False. Every raster ingested before the measurement existed keeps exactly
+        the behaviour it has today, until it is re-ingested — the conservative direction for a
+        guard that was protecting against a page-wide hang."""
+        from geodeploy.services.portal_generator import raster_minzoom
+        assert raster_minzoom(_Layer(None), self.SMALL) == raster_minzoom(object(), self.SMALL)
+
+    def test_a_continent_sized_raster_never_had_a_floor_anyway(self):
+        from geodeploy.services.portal_generator import raster_minzoom
+        assert raster_minzoom(_Layer(None), self.HUGE) == 0

--- a/api/tests/test_symbology.py
+++ b/api/tests/test_symbology.py
@@ -405,6 +405,66 @@ def test_an_unknown_ramp_falls_back_rather_than_failing():
     assert sym.ramp_colors("no-such-ramp", 3) == sym.ramp_colors("viridis", 3)
 
 
+def test_the_sampled_colours_are_pinned_against_the_javascript_twin():
+    """Literal, because the twin is `ui/src/lib/symbology.js::rampColors` and it cannot be imported
+    here — this list IS the contract between them.
+
+    It caught a real divergence: the sampling used `round()`, which in Python rounds half to EVEN
+    and in JavaScript rounds half UP, so at every `.5` position the two picked different stops —
+    every 5- and 9-class ramp, in all nine ramps. Both now use `x + 0.5` truncated, which is
+    expressible identically in either language. If this test fails, the JS file has drifted and the
+    editor preview no longer matches what the portal publishes.
+    """
+    assert sym.ramp_colors("viridis", 5) == [
+        "#440154", "#365c8d", "#277f8e", "#4ac16d", "#fde725"]
+    assert sym.ramp_colors("magma", 5) == [
+        "#000004", "#8c2981", "#de4968", "#fecf92", "#fcfdbf"]
+    assert sym.ramp_colors("blues", 9) == [
+        "#f7fbff", "#deebf7", "#c6dbef", "#c6dbef", "#9ecae1",
+        "#6baed6", "#3182bd", "#3182bd", "#08519c"]
+
+
+# ── Reversing a ramp (issue #11) ─────────────────────────────────────────────────────────────────
+# Which end means "high" is a cartographic choice, not a property of the ramp. Stored as a FLAG
+# rather than as reversed copies in the table: nine ramps would become eighteen and the picker a
+# wall. `ui/src/lib/symbology.js::rampColors` is the twin and must reverse identically.
+
+def test_reversing_returns_the_same_colours_in_the_opposite_order():
+    """The SAMPLED output is reversed, not the stop list — so a reversed ramp is the same colours
+    backwards, not a differently-sampled ramp."""
+    for n in (2, 3, 5, 9, 12):
+        forward = sym.ramp_colors("viridis", n)
+        assert sym.ramp_colors("viridis", n, reverse=True) == forward[::-1]
+
+
+def test_reversing_twice_is_the_identity():
+    assert sym.ramp_colors("magma", 6, reverse=True)[::-1] == sym.ramp_colors("magma", 6)
+
+
+def test_a_single_class_is_unaffected_by_direction():
+    """One colour has no ends to swap; reversing must not pick a different stop."""
+    assert sym.ramp_colors("blues", 1, reverse=True) == sym.ramp_colors("blues", 1)
+
+
+def test_classes_carry_the_reversed_colours_with_the_same_breaks():
+    """Reversing changes which class is which COLOUR and nothing else — the breaks are the
+    classifier's business and must not move."""
+    values = [float(v) for v in range(1, 101)]
+    forward = sym.build_classes(values, "quantile", 5, "viridis")
+    reversed_ = sym.build_classes(values, "quantile", 5, "viridis", reverse=True)
+    assert [c["min"] for c in forward] == [c["min"] for c in reversed_]
+    assert [c["max"] for c in forward] == [c["max"] for c in reversed_]
+    assert [c["color"] for c in reversed_] == [c["color"] for c in forward][::-1]
+
+
+def test_categories_can_be_reversed_too():
+    values = ["a", "b", "c", "d"]
+    forward = sym.build_categories(values, "viridis")
+    flipped = sym.build_categories(values, "viridis", reverse=True)
+    assert [c["value"] for c in flipped] == values          # order of VALUES is unchanged
+    assert [c["color"] for c in flipped] == [c["color"] for c in forward][::-1]
+
+
 # ── 3D bar defaults come from the DATA ───────────────────────────────────────────────────────────
 # A point has no size, so BOTH the width and the height of a bar come from defaults — and a fixed
 # default is right at exactly one scale. 240 country centroids with the old fixed 30 m radius drew

--- a/cli/README.md
+++ b/cli/README.md
@@ -64,7 +64,7 @@ no account. `_LayerBase.export_to_file()` drives the queue-poll-download of a bu
   styling flags, shared by the three commands that take them, and `resolve_layer(..., public_ok=)`
   which decides between the authenticated list and the public index.
 
-`tests/` — 314 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
+`tests/` — 317 tests against a real HTTP server (`conftest.FakeInstance`) that records what arrived
 on the wire. `pyproject.toml` — packaging; console script `geodeploy`.
 
 ## Dependencies / relationships

--- a/cli/geodeploy/cli/commands/_common.py
+++ b/cli/geodeploy/cli/commands/_common.py
@@ -47,6 +47,8 @@ def add_style_args(parser, raster: bool = True) -> None:
     driven.add_argument("--classes", type=int, default=None,
                         help="how many classes to compute (2-12, default 5)")
     driven.add_argument("--ramp", choices=RAMPS, help="colour ramp for computed classes")
+    driven.add_argument("--reverse-ramp", action="store_true",
+                        help="run the ramp the other way (light end for the low values)")
     driven.add_argument("--class-breaks",
                         help="explicit classes instead of computing them: '0-10:#fee,10-50:#f00' "
                              "(* is an open edge)")
@@ -99,7 +101,8 @@ def style_from_args(args, client=None, layer_ref: Optional[Any] = None,
         style, stats = styles_mod.classify(
             client, layer_ref, args.color_field, mode=getattr(args, "color_mode", None),
             classes=getattr(args, "classes", None) or 5, method=args.classify,
-            ramp=getattr(args, "ramp", None) or "viridis", base=style)
+            ramp=getattr(args, "ramp", None) or "viridis",
+            reverse=bool(getattr(args, "reverse_ramp", False)), base=style)
         if out is not None:
             count = len(style.get("classes") or style.get("categories") or [])
             out.info("Classified {0} on {1}: {2} {3} from {4} values.".format(

--- a/cli/geodeploy/layers.py
+++ b/cli/geodeploy/layers.py
@@ -266,7 +266,7 @@ class VectorLayers(_LayerBase):
                 "crs": manifest.get("crs")}
 
     def field_stats(self, ref: Any, field: str, classes: int = 5, method: str = "quantile",
-                    ramp: str = "viridis") -> Dict[str, Any]:
+                    ramp: str = "viridis", reverse: bool = False) -> Dict[str, Any]:
         """Distribution of ONE attribute plus a ready-made classification `suggestion`.
 
         The classification maths lives on the server (`services/symbology.py`) and is shared with
@@ -275,8 +275,12 @@ class VectorLayers(_LayerBase):
         two implementations of quantile breaks would eventually disagree, and the disagreement
         would only be visible on a published map.
         """
-        return self._c.get("/data/vector/{0}/field-stats".format(ref),
-                           {"field": field, "classes": classes, "method": method, "ramp": ramp})
+        params = {"field": field, "classes": classes, "method": method, "ramp": ramp}
+        if reverse:
+            # Only when asked: an older instance has no `reverse` parameter, and sending
+            # `reverse=false` to it would be a pointless difference in every request.
+            params["reverse"] = "true"
+        return self._c.get("/data/vector/{0}/field-stats".format(ref), params)
 
     def tile(self, layer_id: Any) -> Dict[str, Any]:
         """(Re)generate the layer's PMTiles archive — the fallback display path for heavy layers."""

--- a/cli/geodeploy/styles.py
+++ b/cli/geodeploy/styles.py
@@ -52,6 +52,7 @@ _SIMPLE_KEYS = (
     ("color_mode", "color_mode"),
     ("color_ramp", "color_ramp"),
     ("color_ramp_reverse", "color_ramp_reverse"),
+    ("classes_n", "classes_n"),
     ("size_field", "size_field"),
     ("size_mode", "size_mode"),
 )
@@ -222,6 +223,11 @@ def classify(client: Any, layer_ref: Any, field: str, mode: Optional[str] = None
     # Recorded so the direction survives a re-classify: the class COLOURS are stored per class, so
     # without this a later change of method or class count would silently un-reverse the ramp.
     style["color_ramp_reverse"] = bool(reverse)
+    # What was ASKED for, which is not always what came back — repeated values collapse a break, and
+    # some columns yield one class however many you request. The editor shows this number in its
+    # Classes box; storing it here means a CLI-classified layer opens in the browser showing the
+    # count you asked for rather than the count you got.
+    style["classes_n"] = int(classes)
     if resolved == "graduated":
         found = suggestion.get("classes") or []
         if not found:
@@ -310,6 +316,14 @@ class Style(object):
     @property
     def other_color(self) -> Optional[str]:
         return self.raw.get("other_color")
+
+    @property
+    def requested_classes(self) -> Optional[int]:
+        """How many classes were ASKED for. `len(style.classes)` is how many came back, and the two
+        differ whenever repeated values collapse a break — so a UI that shows the second number as
+        the input fights the user (issue #10)."""
+        value = self.raw.get("classes_n")
+        return int(value) if isinstance(value, (int, float)) else None
 
     @property
     def ramp(self) -> Optional[str]:

--- a/cli/geodeploy/styles.py
+++ b/cli/geodeploy/styles.py
@@ -50,6 +50,8 @@ _SIMPLE_KEYS = (
     ("other_color", "other_color"),
     ("color_field", "color_field"),
     ("color_mode", "color_mode"),
+    ("color_ramp", "color_ramp"),
+    ("color_ramp_reverse", "color_ramp_reverse"),
     ("size_field", "size_field"),
     ("size_mode", "size_mode"),
 )
@@ -191,6 +193,7 @@ def _edge(text: str) -> Optional[float]:
 
 def classify(client: Any, layer_ref: Any, field: str, mode: Optional[str] = None,
              classes: int = 5, method: str = "quantile", ramp: str = "viridis",
+             reverse: bool = False,
              base: Optional[Dict[str, Any]] = None) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Ask the server to classify `field`, and fold the answer into a style dict.
 
@@ -205,7 +208,8 @@ def classify(client: Any, layer_ref: Any, field: str, mode: Optional[str] = None
     if ramp not in RAMPS:
         raise ValidationError(400, "Unknown colour ramp {0!r}. Known: {1}".format(
             ramp, ", ".join(RAMPS)))
-    stats = client.vector.field_stats(layer_ref, field, classes=classes, method=method, ramp=ramp)
+    stats = client.vector.field_stats(layer_ref, field, classes=classes, method=method, ramp=ramp,
+                                      reverse=reverse)
     suggestion = (stats or {}).get("suggestion") or {}
     kind = (stats or {}).get("kind")
     resolved = mode or suggestion.get("color_mode") or (
@@ -214,6 +218,10 @@ def classify(client: Any, layer_ref: Any, field: str, mode: Optional[str] = None
     style = dict(base or {})
     style["color_field"] = field
     style["color_mode"] = resolved
+    style["color_ramp"] = ramp
+    # Recorded so the direction survives a re-classify: the class COLOURS are stored per class, so
+    # without this a later change of method or class count would silently un-reverse the ramp.
+    style["color_ramp_reverse"] = bool(reverse)
     if resolved == "graduated":
         found = suggestion.get("classes") or []
         if not found:
@@ -302,6 +310,16 @@ class Style(object):
     @property
     def other_color(self) -> Optional[str]:
         return self.raw.get("other_color")
+
+    @property
+    def ramp(self) -> Optional[str]:
+        """The ramp the classes were generated from, when one was recorded. The class colours are
+        stored per class, so this is provenance — not what a renderer should read to draw."""
+        return self.raw.get("color_ramp")
+
+    @property
+    def ramp_reversed(self) -> bool:
+        return bool(self.raw.get("color_ramp_reverse"))
 
     @property
     def size(self) -> Optional[Dict[str, Any]]:

--- a/cli/tests/test_styles_jobs.py
+++ b/cli/tests/test_styles_jobs.py
@@ -108,6 +108,19 @@ class TestClassify:
         assert query["classes"] == ["7"] and query["method"] == ["jenks"]
         assert query["ramp"] == ["magma"]
 
+    def test_the_ramp_direction_is_asked_for_and_recorded(self, client, instance):
+        """Recorded in the style because the class COLOURS are stored per class: without it, a
+        later change of method or class count would silently un-reverse the ramp."""
+        style, _ = styles.classify(client, 1, "pop", ramp="magma", reverse=True)
+        assert style["color_ramp"] == "magma" and style["color_ramp_reverse"] is True
+        assert instance.requests_to("field-stats")[0]["query"]["reverse"] == ["true"]
+
+    def test_the_default_direction_is_not_sent_at_all(self, client, instance):
+        """An older instance has no `reverse` parameter; sending the default would be a pointless
+        difference in every request."""
+        styles.classify(client, 1, "pop")
+        assert "reverse" not in instance.requests_to("field-stats")[0]["query"]
+
     def test_unknown_method_and_ramp_fail_locally(self, client):
         with pytest.raises(ValidationError):
             styles.classify(client, 1, "pop", method="kmeans")
@@ -180,6 +193,13 @@ class TestStyleModel:
         assert styles.parse({"size_stops": [[0, 2]]}).size is None    # nothing to read
         size = styles.parse({"size_field": "pop", "size_stops": [[0, 2], [100, 12]]}).size
         assert size == {"field": "pop", "stops": [[0, 2], [100, 12]]}
+
+    def test_the_ramp_and_its_direction_are_readable(self):
+        """Provenance for a plugin offering "reverse" as a control — the drawn colours still come
+        from `classes`, which is what a renderer reads."""
+        style = styles.parse({"color_ramp": "magma", "color_ramp_reverse": True})
+        assert style.ramp == "magma" and style.ramp_reversed is True
+        assert styles.parse({}).ramp is None and styles.parse({}).ramp_reversed is False
 
     def test_extrusion_switched_off_reads_as_none(self):
         """A renderer checking truthiness on the dict alone would extrude a layer the author

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -403,6 +403,17 @@ breaks) with the same code the portal editor and the published map use, so a CLI
 in exactly the classes the editor would show. Ramps: `viridis` `magma` `blues` `reds` `greens`
 `oranges` `rdbu` `brbg` `spectral`.
 
+**`--reverse-ramp`** runs the ramp the other way — the light end for the low values, which is what
+a dark basemap usually wants, and how a diverging ramp is flipped to match a convention your
+readers already have:
+
+```bash
+geodeploy portals style 3 parcels --color-field pop --classify quantile --ramp blues --reverse-ramp
+```
+
+The direction is stored with the style, so re-classifying later (a different method, more classes)
+keeps it.
+
 Size and 3D work the same way:
 
 ```bash

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -215,11 +215,20 @@ filtering, no transactions, no OGC API - Tiles or Records — and `/api/ogc/conf
 > field or an address bar. To load a layer *into QGIS*, use OGC API - Features — PMTiles is a
 > rendering format.
 >
-> Specifically, **QGIS's *Add Vector Tile Layer* cannot open a PMTiles URL**: that dialog builds an
-> XYZ template (`type=xyz&url=…{z}/{x}/{y}`) and an archive is a single file, so it answers
-> *"Invalid Data Source"*. GDAL 3.8+ ships a PMTiles driver and reads it as
-> `/vsicurl/<the plain URL>`; older GDAL — including what QGIS 3.28-era installs bundle — cannot
-> read PMTiles at all.
+> **In QGIS, use the right dialog.** *Add Vector Tile Layer ▸ New Generic Connection* builds an XYZ
+> template (`type=xyz&url=…{z}/{x}/{y}`) and cannot describe a single-file archive — it answers
+> *"Invalid Data Source"*. What works, on GDAL 3.8+ (QGIS 3.34 and later), is opening the archive
+> directly:
+>
+> ```python
+> # QGIS ▸ Plugins ▸ Python Console
+> from osgeo import ogr
+> ds = ogr.Open("/vsicurl/https://YOUR-HOST/api/data/vector/{uid}/pmtiles")
+> ```
+>
+> — verified against a live instance, returning the `geodeploy` layer. Older GDAL cannot read
+> PMTiles at all. For most QGIS work OGC API - Features is still the better route: it carries
+> attributes and is not generalized per zoom.
 
 ## Consuming the assets
 

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -214,6 +214,12 @@ filtering, no transactions, no OGC API - Tiles or Records — and `/api/ogc/conf
 > in *code*; it belongs inside a style source (GeoDeploy's own portals emit it), never in a UI
 > field or an address bar. To load a layer *into QGIS*, use OGC API - Features — PMTiles is a
 > rendering format.
+>
+> Specifically, **QGIS's *Add Vector Tile Layer* cannot open a PMTiles URL**: that dialog builds an
+> XYZ template (`type=xyz&url=…{z}/{x}/{y}`) and an archive is a single file, so it answers
+> *"Invalid Data Source"*. GDAL 3.8+ ships a PMTiles driver and reads it as
+> `/vsicurl/<the plain URL>`; older GDAL — including what QGIS 3.28-era installs bundle — cannot
+> read PMTiles at all.
 
 ## Consuming the assets
 

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -387,9 +387,23 @@
        than the card edge, so it reads as belonging to that layer and not to the list. */
     .legend-classes { display: flex; flex-direction: column; gap: 2px; padding-left: 46px; }
     .legend-class { display: flex; align-items: center; gap: 6px; min-width: 0; }
+    .legend-body { display: flex; flex-direction: column; gap: 2px; }
+    /* The collapse control. Deliberately quiet — it is a way to get the class list out of the way,
+       not a thing to look at, so it reads as a caption until hovered. */
+    .legend-toggle {
+      display: flex; align-items: center; gap: 4px; margin: 0 0 2px; padding: 0;
+      background: none; border: 0; cursor: pointer; font: inherit; font-size: 10px;
+      color: var(--muted, #6b7280); opacity: .8;
+    }
+    .legend-toggle:hover { opacity: 1; text-decoration: underline; }
+    .legend-caret { font-size: 9px; line-height: 1; }
+    /* The hairline is an INSET shadow, not a border: a border on an 11px box is drawn inside it
+       (border-box), so a fifth of the swatch was frame rather than colour and two nearby classes
+       were hard to tell apart. The shadow keeps the full square coloured and still separates a pale
+       class from the panel behind it. */
     .legend-chip {
-      width: 11px; height: 11px; border-radius: 2px; flex-shrink: 0;
-      border: 1px solid rgba(0,0,0,.25);
+      width: 12px; height: 12px; border-radius: 2px; flex-shrink: 0;
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,.28);
     }
     .legend-label {
       font-size: 10.5px; color: var(--text-muted); white-space: nowrap;
@@ -448,6 +462,18 @@
       width: 24px; height: 22px; padding: 0; border: 1px solid var(--border);
       border-radius: 4px; cursor: pointer; background: none;
     }
+    /* A native colour input draws its OWN chrome inside the box — a padded wrapper and an inner
+       border — which at swatch size leaves more frame than colour. Strip both here and in the
+       dashboard (ui/src/style.css) so the square is the colour it stands for. */
+    .layer-style-color, .layer-marker-color {
+      -webkit-appearance: none; appearance: none;
+    }
+    .layer-style-color::-webkit-color-swatch-wrapper,
+    .layer-marker-color::-webkit-color-swatch-wrapper { padding: 0; }
+    .layer-style-color::-webkit-color-swatch,
+    .layer-marker-color::-webkit-color-swatch { border: none; border-radius: 3px; }
+    .layer-style-color::-moz-color-swatch,
+    .layer-marker-color::-moz-color-swatch { border: none; border-radius: 3px; }
     .layer-style-size, .rstyle-min, .rstyle-max, .rstyle-zfactor {
       width: 54px; font-size: 11px; padding: 2px 5px; font-family: inherit;
       border: 1px solid var(--border); border-radius: 4px;

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -1339,6 +1339,62 @@
           0 0, 0 0, 0 0, 0 0;
       }
     }
+    /* ── Story maps on a phone (issue #27) ──────────────────────────────────────────────────────
+       PORTRAIT: the narrative is a bottom STRIP that scrolls sideways, with the map above it. The
+       desktop layout is a tall column overlaying the left 46vw, which on a narrow screen leaves the
+       map no room and sits under the control cluster. Stacking is the standard answer, and swiping
+       sideways is what a phone reader expects for "next section".
+       The JS half (portal.js::setupStory) switches the wheel axis, the IntersectionObserver's root
+       margin and the chevrons to match — it reads the same media query, so the two cannot disagree. */
+    @media (max-width: 640px) and (orientation: portrait) {
+      body[data-archetype="storymap"] #story-panel {
+        top: auto; left: 0; right: 0; bottom: 0;
+        width: 100%; height: 44vh; max-height: 44vh;
+        padding: 10px 12px 14px;
+        display: flex; flex-direction: row; align-items: stretch; gap: 12px;
+        overflow-x: auto; overflow-y: hidden;
+        scroll-snap-type: x mandatory;          /* one section per swipe */
+        overscroll-behavior-x: contain;         /* don't chain to the page/browser back-gesture */
+        background: linear-gradient(0deg, var(--story-bg, var(--bg)) 84%, transparent);
+      }
+      /* The gradient's direction is horizontal on desktop; both side-anchored variants would fight
+         the bottom strip, so they are overridden together. */
+      body[data-layerlist-side="right"][data-archetype="storymap"] #story-panel {
+        left: 0; right: 0;
+        background: linear-gradient(0deg, var(--story-bg, var(--bg)) 84%, transparent);
+      }
+      body[data-archetype="storymap"] .story-section {
+        flex: 0 0 86vw; max-width: 86vw; margin: 0;
+        scroll-snap-align: center;
+        overflow-y: auto;                        /* a long section still scrolls, downward */
+        -webkit-overflow-scrolling: touch;
+      }
+      body[data-layerlist-side="right"][data-archetype="storymap"] .story-section { margin-left: 0; }
+      /* Chevrons become left/right and sit beside the strip, clear of the map controls. */
+      body[data-archetype="storymap"] .gd-story-more { left: auto; right: auto; }
+      body[data-archetype="storymap"] .gd-story-up { top: auto; bottom: calc(44vh / 2 - 21px); left: 8px; }
+      body[data-archetype="storymap"] .gd-story-down { bottom: calc(44vh / 2 - 21px); right: 8px; }
+      /* Keep the map's own controls above the strip rather than behind it. */
+      body[data-archetype="storymap"] .maplibregl-ctrl-bottom-right,
+      body[data-archetype="storymap"] .maplibregl-ctrl-bottom-left { bottom: calc(44vh + 6px); }
+    }
+
+    /* LANDSCAPE on a phone (~360px tall): the control cluster is a single vertical stack and simply
+       does not fit, so the controls at the bottom are unreachable. Let it WRAP into a second column
+       instead — nothing is hidden, nothing shrinks below a comfortable touch target, and no control
+       moves somewhere the user has to learn about. */
+    @media (max-height: 480px) {
+      .maplibregl-ctrl-top-right, .maplibregl-ctrl-top-left {
+        display: flex; flex-direction: column; flex-wrap: wrap;
+        max-height: calc(100vh - 12px);
+        align-content: flex-start;
+      }
+      body[data-controls-side="left"] .maplibregl-ctrl-top-left { align-content: flex-start; }
+      .maplibregl-ctrl-group { margin-bottom: 4px !important; }
+      /* A flyout must not run off a short screen either. */
+      .gd-basemap-menu, .gd-tools-menu { max-height: calc(100vh - 24px); overflow-y: auto; }
+    }
+
     @media (prefers-reduced-motion: reduce) {
       #map-wrap.gd-space, .gd-space { animation: none; }
     }

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -1681,6 +1681,17 @@
       container.appendChild(card);
     });
 
+    container.querySelectorAll('.legend-toggle').forEach(btn => {
+      btn.addEventListener('click', e => setLegendCollapsed(
+        e.currentTarget.closest('.layer-legend'),
+        e.currentTarget.getAttribute('aria-expanded') === 'true'));
+    });
+    // Expanded for ONE classified layer, collapsed beyond that: with a single legend the
+    // classification is usually the point of the map, and with several the layer NAMES — the thing
+    // you click — get pushed off screen. Only the initial state; the buttons win afterwards.
+    const legends = container.querySelectorAll('.legend-classes');
+    if (legends.length > 1) legends.forEach(el => setLegendCollapsed(el, true));
+
     container.querySelectorAll('.layer-eye').forEach(btn => {
       btn.addEventListener('click', e => {
         const id = e.currentTarget.dataset.layerId;
@@ -1965,12 +1976,36 @@
         '<button type="button" class="lg-expand-all la-icon" title="Expand all" aria-label="Expand all folders"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg></button>' +
         '<button type="button" class="lg-collapse-all la-icon" title="Collapse all" aria-label="Collapse all folders"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg></button>';
     }
+    // "Show me less" belongs in ONE place, so the legend control sits in the same row as the folder
+    // one. Offered only when there is a legend to hide.
+    const hasLegends = !!container.querySelector('.legend-classes');
+    if (hasLegends) {
+      left.insertAdjacentHTML('beforeend',
+        '<button type="button" class="lg-legends la-icon" title="Show / hide all legends" ' +
+        'aria-label="Show or hide all legends" aria-pressed="false">' +
+        '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" ' +
+        'stroke-width="2" stroke-linecap="round"><line x1="8" y1="6" x2="21" y2="6"/>' +
+        '<line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/>' +
+        '<circle cx="3.5" cy="6" r="1.5"/><circle cx="3.5" cy="12" r="1.5"/>' +
+        '<circle cx="3.5" cy="18" r="1.5"/></svg></button>');
+    }
     acts.appendChild(left);
     acts.appendChild(right);
     parent.insertBefore(acts, container);
     if (hasGroups) {
       acts.querySelector('.lg-expand-all').addEventListener('click', function () { setAllGroups(false); });
       acts.querySelector('.lg-collapse-all').addEventListener('click', function () { setAllGroups(true); });
+    }
+    if (hasLegends) {
+      const btn = acts.querySelector('.lg-legends');
+      // One button that flips, rather than a pair: the state is knowable (are any expanded?), so a
+      // second button would spend width on something the first can answer.
+      btn.addEventListener('click', function () {
+        const anyOpen = !!document.querySelector(
+          '#layer-list .legend-toggle[aria-expanded="true"]');
+        setAllLegends(anyOpen);
+        btn.setAttribute('aria-pressed', anyOpen ? 'true' : 'false');
+      });
     }
     // Relocate the Reset-styling button (from layout.html) into the row — moves the node + its handler.
     const reset = document.getElementById('reset-styling');
@@ -1981,6 +2016,23 @@
       right.appendChild(reset);
     }
     // The About link is appended into `.la-right` by buildAboutPanel (runs after this).
+  }
+  function setLegendCollapsed(legend, collapsed) {
+    if (!legend) return;
+    const body = legend.querySelector(':scope > .legend-body');
+    const btn = legend.querySelector(':scope > .legend-toggle');
+    if (body) body.style.display = collapsed ? 'none' : '';
+    if (btn) {
+      btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      btn.title = collapsed ? 'Show these classes' : 'Hide these classes';
+      const caret = btn.querySelector('.legend-caret');
+      if (caret) caret.textContent = collapsed ? '▸' : '▾';
+    }
+  }
+  function setAllLegends(collapsed) {
+    const container = document.getElementById('layer-list');
+    if (!container) return;
+    container.querySelectorAll('.legend-classes').forEach(el => setLegendCollapsed(el, collapsed));
   }
   function setAllGroups(collapsed) {
     const container = document.getElementById('layer-list');
@@ -2372,7 +2424,15 @@
         '<span class="legend-label">' + escHtml(e.label == null ? '' : String(e.label)) + '</span>' +
         '</div>';
     }).join('');
-    return '<div class="layer-legend legend-classes">' + rows + '</div>';
+    // A count button, then the classes. Collapsing is a DISPLAY state and nothing else: the entries
+    // come from `geodeploy:legend`, baked at publish from the same class list the map draws, and are
+    // never rebuilt here — that is what stops a published legend drifting from its map.
+    const head = '<button type="button" class="legend-toggle" aria-expanded="true" ' +
+      'title="Hide these classes">' +
+      '<span class="legend-caret" aria-hidden="true">▾</span>' +
+      '<span class="legend-count">' + entries.length + ' classes</span></button>';
+    return '<div class="layer-legend legend-classes">' + head +
+      '<div class="legend-body">' + rows + '</div></div>';
   }
 
   function rasterLegendHtml(layer) {

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -1439,13 +1439,29 @@
       }
       if (s && s.layers) applyStoryLayers(s.layers);
     }
-    const io = new IntersectionObserver(function (entries) {
-      // Pick the most-centered intersecting section (rootMargin narrows the trigger band to mid-screen).
-      let best = null;
-      entries.forEach(function (en) { if (en.isIntersecting && (!best || en.intersectionRatio > best.intersectionRatio)) best = en; });
-      if (best) activate(parseInt(best.target.dataset.idx, 10), true);
-    }, { rootMargin: '-45% 0px -45% 0px', threshold: [0, 0.5, 1] });
-    sections.forEach(function (el) { io.observe(el); });
+    // Issue #27: on a phone in PORTRAIT the narrative is a bottom strip that scrolls SIDEWAYS (see
+    // portal.css). Same media query on both sides, so the layout and the behaviour cannot disagree.
+    const horizontal = window.matchMedia('(max-width: 640px) and (orientation: portrait)');
+    function isSideways() { return document.body.dataset.archetype === 'storymap' && horizontal.matches; }
+
+    let io = null;
+    function observeSections() {
+      if (io) io.disconnect();
+      // Narrow the trigger band to the middle of whichever axis is scrolling.
+      const margin = isSideways() ? '0px -45% 0px -45%' : '-45% 0px -45% 0px';
+      io = new IntersectionObserver(function (entries) {
+        // Pick the most-centered intersecting section.
+        let best = null;
+        entries.forEach(function (en) { if (en.isIntersecting && (!best || en.intersectionRatio > best.intersectionRatio)) best = en; });
+        if (best) activate(parseInt(best.target.dataset.idx, 10), true);
+      }, { rootMargin: margin, threshold: [0, 0.5, 1] });
+      sections.forEach(function (el) { io.observe(el); });
+    }
+    observeSections();
+    // Rotating the phone swaps the axis; without this the trigger band stays on the old one and
+    // sections stop activating.
+    try { horizontal.addEventListener('change', observeSections); }
+    catch (e) { try { horizontal.addListener(observeSections); } catch (e2) {} }
     // E4: in the editor preview each edit reloads the iframe — DON'T fly to section 0 (it yanks the
     // author's map away). Just mark it active; the baked initial_view keeps the author's camera.
     // Sections default to opacity .35 and the ACTIVE one goes to 1 through a transition. On load that
@@ -1471,7 +1487,8 @@
         // wheel zoom. The panel is pointer-events:none, so we hit-test the pointer against its box.
         const inX = e.clientX >= r.left && e.clientX <= r.right;
         if (!inX || e.clientY < r.top || e.clientY > r.bottom) return;  // over the map → MapLibre zooms
-        panel.scrollTop += e.deltaY;
+        if (isSideways()) panel.scrollLeft += (e.deltaY || e.deltaX);
+        else panel.scrollTop += e.deltaY;
         e.preventDefault();
         e.stopPropagation();                    // don't let the map zoom too
       }, { passive: false, capture: true });
@@ -1483,12 +1500,26 @@
       const down = document.createElement('div'); down.className = 'gd-story-more gd-story-down'; down.innerHTML = chevron('down');
       mw.appendChild(up); mw.appendChild(down);
       function updateArrows() {
-        up.classList.toggle('show', panel.scrollTop > 6);
-        down.classList.toggle('show', panel.scrollTop + panel.clientHeight < panel.scrollHeight - 6);
+        if (isSideways()) {
+          up.classList.toggle('show', panel.scrollLeft > 6);
+          down.classList.toggle('show', panel.scrollLeft + panel.clientWidth < panel.scrollWidth - 6);
+        } else {
+          up.classList.toggle('show', panel.scrollTop > 6);
+          down.classList.toggle('show', panel.scrollTop + panel.clientHeight < panel.scrollHeight - 6);
+        }
       }
       panel.addEventListener('scroll', updateArrows);
-      up.addEventListener('click', function () { panel.scrollBy({ top: -panel.clientHeight * 0.8, behavior: 'smooth' }); });
-      down.addEventListener('click', function () { panel.scrollBy({ top: panel.clientHeight * 0.8, behavior: 'smooth' }); });
+      // One page = one section when snapping sideways, so a tap lands on a section rather than
+      // between two.
+      up.addEventListener('click', function () {
+        if (isSideways()) panel.scrollBy({ left: -panel.clientWidth * 0.86, behavior: 'smooth' });
+        else panel.scrollBy({ top: -panel.clientHeight * 0.8, behavior: 'smooth' });
+      });
+      down.addEventListener('click', function () {
+        if (isSideways()) panel.scrollBy({ left: panel.clientWidth * 0.86, behavior: 'smooth' });
+        else panel.scrollBy({ top: panel.clientHeight * 0.8, behavior: 'smooth' });
+      });
+      try { horizontal.addEventListener('change', updateArrows); } catch (e) {}
       setTimeout(updateArrows, 120);
     }
   }

--- a/ui/README.md
+++ b/ui/README.md
@@ -27,7 +27,14 @@ Vue 3 single-page dashboard — the browser-only control panel for setup, data u
 ## Current status & known issues
 - Phases 0–1 features are present (setup, data manager, portal builder/editor, templates gallery, settings). **GeoParquet display via deck.gl is now wired** (editor preview + published portal); DuckDB filter/analysis UI is still Phase 2 (not built). deck.gl deps (`deck.gl`, `@deck.gl/mapbox`, `@deck.gl/layers`) are in `package.json`.
 - The preview-vs-published parity is a recurring footgun: a fix in `PortalEditor.vue` often needs a mirror fix in `portal_generator.py` (and `templates/.../layout.html`). See `notes_temp/notes_for_future.md`.
+- `src/lib/symbology.js` is the **line-by-line twin** of `api/.../services/symbology.py`, and the two
+  drifted once already without anyone noticing: sampling a ramp used `Math.round()` here and
+  `round()` there, which disagree on `.5` (half-up vs half-to-even), so every 5- and 9-class ramp
+  produced a different fourth colour. It was invisible only because nothing imported `rampColors`
+  yet. Both now use `x + 0.5` truncated, and `api/tests/test_symbology.py` pins literal colour lists
+  as the contract. **When you touch either file, run the parity check, not just the tests.**
 - `vite.config.js` dev proxy must stay aligned with `nginx/nginx.conf` (prefix stripping + titiler port 80).
 
 ## Last updated
-2026-06-11
+2026-08-13 (ramp reverse toggle + swatch strip in `components/portal/LayerPanel.vue`; class-count
+ceiling raised 9 → 12 to match the server; the symbology-twin rounding fix above)

--- a/ui/src/components/README.md
+++ b/ui/src/components/README.md
@@ -44,6 +44,15 @@ Reusable presentational/interactive widgets used by the views, grouped by featur
   operator's question (user call, 2026-08-06).
 - `portal/CreatePortalModal.vue` — new-portal dialog (title, description, access); creates via the portals store then routes to the editor.
 - `portal/LayerPanel.vue` (resolves vector/raster/**external** layers from the data store; external sources get an opacity-only popover, plus a colour picker for WFS vector) — **thin row** mirroring the published portal: drag handle (reorder is wired in `PortalEditor.vue`) · eye/eye-off (`update {visible}`) · **symbol swatch** that opens a **teleported symbology popover** · name · zoom · remove. The popover holds: opacity; vector colour/fill/outline/width; **line type** (solid/dashed/dotted); **point marker shape** (circle/square/triangle/diamond/star/cross) + size; popup-field picker; **raster band selection** (multiband → RGB composite with R/G/B band pickers, or single band) + palette/hillshade/Z (single-band output) and stretch/rescale (all); save/use default. Band selection stores `style.bidx` (`[n]` single, `[r,g,b]` RGB). The list swatch (`geomSvg`/`markerSvg`) draws the actual symbol (colour, dash, marker shape). Emits `update`/`remove`/`zoom`.
+  **Two hosts, one control** (issue #23): `standalone` renders the symbology body ALONE — no row, no
+  popover chrome, no default-style actions — via `<Teleport :disabled>`, which is what lets
+  `data/StyleModal.vue` reuse it in My Data instead of a second styling UI growing there. The panel
+  stays host-agnostic: it takes a `config` and emits patches; the HOST decides where they are saved
+  (portal `layer_configs`, or `PUT /data/{kind}/{id}/default-style`).
+  Also holds **size-by-a-field** for points and lines (`size_mode`/`size_field`/`size_stops`, issue
+  #21 — the instance had drawn it since v1.1 with no way to set it) and the ramp **Reverse**
+  checkbox, which flips the stored class colours locally: a reversed ramp is the same colours
+  backwards, so no request is needed and hand-edited colours survive.
 - `portal/PortalCard.vue` — portal tile in the builder grid (edit/publish/view/unpublish/delete).
 - `shared/StatusBadge.vue` — colored processing/ready/error pill.
 - `shared/StorageBar.vue` — used/total storage bar (Settings).

--- a/ui/src/components/data/RasterRow.vue
+++ b/ui/src/components/data/RasterRow.vue
@@ -34,6 +34,14 @@
     >
       <LinkIcon class="w-4 h-4" />
     </button>
+    <!-- Style: colormap, stretch, hillshade — the layer's DEFAULT, editable here rather than only
+         inside a portal (issue #23). -->
+    <button v-if="auth.canEdit && layer.status === 'ready'" @click="showStyle = true"
+      class="p-1.5 rounded transition-all opacity-0 group-hover:opacity-100 text-muted-foreground/70 hover:text-primary"
+      title="Default style — colormap and stretch"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="18" cy="13" r="2.5"/><circle cx="6.5" cy="10.5" r="2.5"/><circle cx="10" cy="18" r="2.5"/><path d="M12 2a10 10 0 1 0 0 20c1.1 0 2-.9 2-2 0-1.4-1-1.9-1-3 0-.6.4-1 1-1h2a5 5 0 0 0 5-5c0-5-4.5-9-9-9z"/></svg>
+    </button>
     <!-- Sharing: workspace visibility (private / organization / public catalog + raw COG) -->
     <button v-if="auth.canEdit && layer.status === 'ready'" @click="showSharing = true"
       class="p-1.5 rounded transition-all"
@@ -49,6 +57,7 @@
     </button>
     <SharingModal v-if="showSharing" :layer="layer" layer-type="raster" @close="showSharing = false" />
     <ShareLinksModal v-if="showLinks" :layer="layer" layer-type="raster" @close="showLinks = false" />
+    <StyleModal v-if="showStyle" :layer="layer" layer-type="raster" @close="showStyle = false" />
   </div>
 </template>
 
@@ -60,6 +69,7 @@ import { useDataStore } from '@/stores/data'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import SharingModal from '@/components/data/SharingModal.vue'
 import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
+import StyleModal from '@/components/data/StyleModal.vue'
 
 const props = defineProps({ layer: Object })
 defineEmits(['delete'])
@@ -67,6 +77,7 @@ defineEmits(['delete'])
 const auth = useAuthStore()
 const dataStore = useDataStore()
 const showSharing = ref(false)
+const showStyle = ref(false)
 const showLinks = ref(false)
 
 // Inline rename

--- a/ui/src/components/data/StyleModal.vue
+++ b/ui/src/components/data/StyleModal.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="$emit('close')">
+    <div class="bg-card border border-border rounded-lg shadow-xl w-full max-w-md max-h-[90vh] flex flex-col">
+      <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-border/60">
+        <div class="min-w-0">
+          <h3 class="text-sm font-semibold truncate">{{ layer.name }}</h3>
+          <p class="text-[11px] text-muted-foreground">
+            Default style — how this layer looks wherever it is added next.
+          </p>
+        </div>
+        <button @click="$emit('close')"
+          class="text-muted-foreground/70 hover:text-foreground text-xl leading-none flex-shrink-0">&times;</button>
+      </div>
+
+      <div class="px-4 py-3 overflow-y-auto">
+        <!-- The SAME control the portal editor uses, rendered without its layer row. A second
+             styling UI would be a second definition of the symbology vocabulary. -->
+        <LayerPanel :config="config" standalone @update="apply" />
+      </div>
+
+      <div class="flex items-center gap-2 px-4 py-3 border-t border-border/60">
+        <p v-if="error" class="text-xs text-red-400 flex-1">{{ error }}</p>
+        <p v-else class="text-[11px] text-muted-foreground flex-1">
+          Portals already using this layer keep their own styling.
+        </p>
+        <button @click="$emit('close')" class="btn-secondary text-xs px-3 py-1.5">Cancel</button>
+        <button @click="save" :disabled="saving" class="btn-primary text-xs px-3 py-1.5">
+          {{ saving ? 'Saving…' : 'Save' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Style a layer from My Data (issue #23).
+ *
+ * Until now the symbology popover existed only inside the portal editor, and its "Save as default"
+ * button was the ONLY writer of a layer's default style in the whole UI — so a layer had no style
+ * of its own until someone added it to a portal, styled it there, and remembered to press that
+ * button. Anything that asks "what does this layer look like" without naming a portal (the legend
+ * endpoint, the QGIS plugin, a catalog view) got the fallback instead.
+ *
+ * This is a HOST, not a second editor: it builds the config LayerPanel expects, collects patches,
+ * and persists them to `PUT /data/{kind}/{id}/default-style`.
+ */
+import { ref } from 'vue'
+import LayerPanel from '@/components/portal/LayerPanel.vue'
+import { saveVectorDefaultStyle, saveRasterDefaultStyle } from '@/api'
+import { useDataStore } from '@/stores/data'
+
+const props = defineProps({ layer: Object, layerType: String })
+const emit = defineEmits(['close'])
+const dataStore = useDataStore()
+
+const saving = ref(false)
+const error = ref('')
+
+// LayerPanel speaks `layer_config` — the shape a portal stores. A layer's default_style is the same
+// vocabulary in a slightly different wrapper, so translate once here rather than teaching the panel
+// about a second one. Rasters keep their keys at the top level, as the API stores them.
+const ds = props.layer.default_style || {}
+const config = ref({
+  layer_id: props.layer.id,
+  layer_type: props.layerType,
+  visible: true,
+  opacity: ds.opacity ?? 1.0,
+  style: props.layerType === 'vector'
+    ? { ...(ds.style || {}) }
+    : {
+        colormap: ds.colormap || null,
+        rescale: ds.rescale || null,
+        algorithm: ds.algorithm || null,
+        zfactor: ds.zfactor ?? null,
+        bidx: ds.bidx || null,
+      },
+  popup_fields: ds.popup_fields || [],
+})
+
+function apply(patch) {
+  config.value = { ...config.value, ...patch }
+}
+
+async function save() {
+  saving.value = true
+  error.value = ''
+  try {
+    const c = config.value
+    const body = props.layerType === 'vector'
+      ? { opacity: c.opacity, style: c.style, popup_fields: c.popup_fields }
+      : {
+          opacity: c.opacity,
+          colormap: c.style?.colormap || null,
+          rescale: c.style?.rescale || null,
+          algorithm: c.style?.algorithm || null,
+          zfactor: c.style?.zfactor ?? null,
+          bidx: c.style?.bidx || null,
+        }
+    const fn = props.layerType === 'vector' ? saveVectorDefaultStyle : saveRasterDefaultStyle
+    const { data: updated } = await fn(props.layer.id, body)
+    // Keep the store in step so the row re-renders without a refetch.
+    const list = props.layerType === 'vector' ? dataStore.vectorLayers : dataStore.rasterLayers
+    const idx = list.findIndex(l => l.id === props.layer.id)
+    if (idx !== -1) list[idx] = updated
+    emit('close')
+  } catch (e) {
+    error.value = e?.response?.data?.detail || 'Could not save the style.'
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/ui/src/components/data/VectorRow.vue
+++ b/ui/src/components/data/VectorRow.vue
@@ -72,6 +72,15 @@
     >
       <LinkIcon class="w-4 h-4" />
     </button>
+    <!-- Style: the layer's DEFAULT symbology, editable where the layer lives rather than only
+         inside a portal (issue #23). What is saved here is what a portal picks up when the layer is
+         added, and what the legend endpoint reports. -->
+    <button v-if="auth.canEdit && layer.status === 'ready'" @click="showStyle = true"
+      class="p-1.5 rounded transition-all opacity-0 group-hover:opacity-100 text-muted-foreground/70 hover:text-primary"
+      title="Default style — colour, size, classification"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="18" cy="13" r="2.5"/><circle cx="6.5" cy="10.5" r="2.5"/><circle cx="10" cy="18" r="2.5"/><path d="M12 2a10 10 0 1 0 0 20c1.1 0 2-.9 2-2 0-1.4-1-1.9-1-3 0-.6.4-1 1-1h2a5 5 0 0 0 5-5c0-5-4.5-9-9-9z"/></svg>
+    </button>
     <!-- Sharing: workspace visibility (private / organization / public catalog) -->
     <button v-if="auth.canEdit && layer.status === 'ready'" @click="showSharing = true"
       class="p-1.5 rounded transition-all"
@@ -88,6 +97,7 @@
     </button>
     <SharingModal v-if="showSharing" :layer="layer" layer-type="vector" @close="showSharing = false" />
     <ShareLinksModal v-if="showLinks" :layer="layer" layer-type="vector" @close="showLinks = false" />
+    <StyleModal v-if="showStyle" :layer="layer" layer-type="vector" @close="showStyle = false" />
   </div>
 </template>
 
@@ -99,6 +109,7 @@ import { useDataStore } from '@/stores/data'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import SharingModal from '@/components/data/SharingModal.vue'
 import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
+import StyleModal from '@/components/data/StyleModal.vue'
 
 const props = defineProps({ layer: Object })
 defineEmits(['delete'])
@@ -115,6 +126,7 @@ const sharingBtn = computed(() => {
 const dataStore = useDataStore()
 const showSharing = ref(false)
 const showLinks = ref(false)
+const showStyle = ref(false)
 const restarting = ref(false)
 const tiling = ref(false)
 

--- a/ui/src/components/portal/LayerPanel.vue
+++ b/ui/src/components/portal/LayerPanel.vue
@@ -68,7 +68,7 @@
                 <div v-if="colorMode === 'graduated' && config.style?.color_field" class="flex gap-1.5">
                   <label class="flex-1">
                     <span class="text-[11px] text-muted-foreground">Classes</span>
-                    <input type="number" min="2" max="9" :value="classCount" @change="setClassCount($event.target.value)"
+                    <input type="number" min="2" max="12" :value="classCount" @change="setClassCount($event.target.value)"
                       class="w-full text-xs border border-border rounded px-1.5 py-1 mt-0.5" />
                   </label>
                   <label class="flex-[1.4]">
@@ -82,18 +82,31 @@
                   </label>
                 </div>
 
-                <label v-if="colorMode === 'graduated' && config.style?.color_field" class="block">
+                <div v-if="colorMode === 'graduated' && config.style?.color_field" class="block">
                   <span class="text-[11px] text-muted-foreground">Colour ramp</span>
-                  <select :value="ramp" @change="setRamp($event.target.value)"
-                    class="w-full text-xs border border-border rounded px-1.5 py-1 mt-0.5">
-                    <optgroup label="Sequential">
-                      <option v-for="r in SEQUENTIAL" :key="r" :value="r">{{ r }}</option>
-                    </optgroup>
-                    <optgroup label="Diverging (has a midpoint)">
-                      <option v-for="r in DIVERGING" :key="r" :value="r">{{ r }}</option>
-                    </optgroup>
-                  </select>
-                </label>
+                  <div class="flex items-center gap-1 mt-0.5">
+                    <select :value="ramp" @change="setRamp($event.target.value)"
+                      class="flex-1 min-w-0 text-xs border border-border rounded px-1.5 py-1">
+                      <optgroup label="Sequential">
+                        <option v-for="r in SEQUENTIAL" :key="r" :value="r">{{ r }}</option>
+                      </optgroup>
+                      <optgroup label="Diverging (has a midpoint)">
+                        <option v-for="r in DIVERGING" :key="r" :value="r">{{ r }}</option>
+                      </optgroup>
+                    </select>
+                    <!-- Which end means "high" is a cartographic choice, not a property of the
+                         ramp: on a dark basemap the light end often belongs to the low values. -->
+                    <button type="button" @click="toggleRampReverse"
+                      :aria-pressed="rampReverse"
+                      :title="rampReverse ? 'Ramp reversed — click to restore' : 'Reverse the ramp'"
+                      class="shrink-0 text-xs border border-border rounded px-1.5 py-1"
+                      :class="rampReverse ? 'bg-primary/15 border-primary/40' : ''">⇄</button>
+                  </div>
+                  <div class="flex h-1.5 mt-1 rounded overflow-hidden" aria-hidden="true">
+                    <span v-for="(c, i) in rampPreview" :key="i" class="flex-1"
+                      :style="{ backgroundColor: c }"></span>
+                  </div>
+                </div>
 
                 <p v-if="statsBusy" class="text-[11px] text-muted-foreground/70">Reading the field…</p>
                 <p v-else-if="statsError" class="text-[11px] text-red-400">{{ statsError }}</p>
@@ -394,8 +407,8 @@ import { saveVectorDefaultStyle, saveRasterDefaultStyle, listColormaps, getRaste
          getFieldStats } from '@/api'
 // The shared symbology vocabulary — twin of api/geodeploy/services/symbology.py. The swatch and
 // the legend here must describe exactly what the published portal will draw.
-import { RAMPS, DIVERGING, NO_OUTLINE, markerOutline, legendEntries, representativeColor,
-         pillarRadius } from '@/lib/symbology'
+import { RAMPS, DIVERGING, NO_OUTLINE, markerOutline, legendEntries, rampColors,
+         representativeColor, pillarRadius } from '@/lib/symbology'
 import { TrashIcon, LocateIcon } from '@/views/icons'
 
 const props = defineProps({ config: Object })
@@ -538,6 +551,9 @@ const colorMode = computed(() => props.config.style?.color_mode || 'single')
 const classCount = computed(() => (props.config.style?.classes || []).length || 5)
 const classMethod = computed(() => props.config.style?.class_method || 'quantile')
 const ramp = computed(() => props.config.style?.color_ramp || 'viridis')
+const rampReverse = computed(() => !!props.config.style?.color_ramp_reverse)
+// The swatch strip under the picker: what the classes WILL look like, in the current direction.
+const rampPreview = computed(() => rampColors(ramp.value, 7, rampReverse.value))
 
 // Fields worth offering. The geometry column is never a symbology field, and a column of unique
 // ids classifies into as many classes as there are rows — offering them invites a useless map.
@@ -576,9 +592,14 @@ function pickColorField(field) {
   emitStyle({ color_field: field, classes: [], categories: [] })
   if (field) refreshClasses({ color_field: field })
 }
-function setClassCount(n) { refreshClasses({ classes_n: Math.max(2, Math.min(9, parseInt(n) || 5)) }) }
+// 12, not 9: the server clamps `classes` to 12 in routers/data/vector.py, and a control that stops
+// at 9 silently refuses counts the classifier would have produced (issue #10).
+function setClassCount(n) { refreshClasses({ classes_n: Math.max(2, Math.min(12, parseInt(n) || 5)) }) }
 function setMethod(m) { refreshClasses({ class_method: m }) }
 function setRamp(r) { refreshClasses({ color_ramp: r }) }
+// Reversing has to REGENERATE the class colours, not just flip the legend swatches: the colours are
+// stored per class and are individually editable, so the stored list is the truth (issue #11).
+function toggleRampReverse() { refreshClasses({ color_ramp_reverse: !rampReverse.value }) }
 
 /**
  * Ask the server to classify the chosen field and apply the result.
@@ -595,17 +616,22 @@ async function refreshClasses(over = {}) {
   statsBusy.value = true
   statsError.value = ''
   try {
+    // `??`, not `||`: turning the reverse OFF passes false, which `||` would discard and the
+    // toggle would only ever work in one direction.
+    const reverse = over.color_ramp_reverse ?? rampReverse.value
     const { data } = await getFieldStats(props.config.layer_id, {
       field,
       classes: over.classes_n || classCount.value,
       method: over.class_method || classMethod.value,
       ramp: over.color_ramp || ramp.value,
+      reverse,
     })
     truncatedCats.value = !!data.truncated
     const patch = {
       color_mode: mode,
       color_field: field,
       color_ramp: over.color_ramp || ramp.value,
+      color_ramp_reverse: reverse,
       class_method: over.class_method || classMethod.value,
     }
     // A text column cannot be graduated and a numeric one is usually not meant to be categorical.

--- a/ui/src/components/portal/LayerPanel.vue
+++ b/ui/src/components/portal/LayerPanel.vue
@@ -1,30 +1,38 @@
 <template>
-  <div class="flex items-center gap-1.5 py-1 px-1 rounded hover:bg-muted/60">
-    <span class="text-muted-foreground/40 cursor-grab flex-shrink-0 flex items-center" draggable="true"
-      @dragstart="$emit('dragstart', $event)" @dragend="$emit('dragend', $event)"
-      title="Drag to reorder / into a folder" v-html="dragSvg"></span>
-    <button @click="toggleVisible" class="text-muted-foreground/70 hover:text-foreground flex-shrink-0 flex items-center"
-      :class="{ 'opacity-50': !visible }" :title="visible ? 'Hide' : 'Show'" v-html="visible ? eyeSvg : eyeOffSvg"></button>
-    <button ref="swatchBtn" @click.stop="toggleStyle"
-      class="flex-shrink-0 flex items-center justify-center w-[22px] h-[22px] rounded hover:bg-muted"
-      :class="config.layer_type === 'raster' ? 'text-amber-400' : ''" :title="geomLabel" v-html="geomSvg"></button>
-    <span class="text-xs font-medium flex-1 truncate" :class="visible ? '' : 'text-muted-foreground/70'" :title="layerName">{{ layerName }}</span>
-    <button @click="$emit('zoom')" class="text-muted-foreground/70 hover:text-primary flex-shrink-0" title="Zoom to layer">
-      <LocateIcon class="w-3.5 h-3.5" />
-    </button>
-    <button @click="$emit('remove')" class="text-muted-foreground/70 hover:text-red-500 flex-shrink-0" title="Remove">
-      <TrashIcon class="w-3.5 h-3.5" />
-    </button>
+  <!-- Two hosts, one control (issue #23). In a PORTAL this is a row in the layer list whose swatch
+       opens a teleported popover. In MY DATA there is no list and no map — the same symbology body
+       is rendered in place inside a modal, editing the layer's DEFAULT style. `standalone` is the
+       only difference, because a second styling UI is a second place for the vocabulary to drift. -->
+  <div :class="standalone ? '' : 'flex items-center gap-1.5 py-1 px-1 rounded hover:bg-muted/60'">
+    <template v-if="!standalone">
+      <span class="text-muted-foreground/40 cursor-grab flex-shrink-0 flex items-center" draggable="true"
+        @dragstart="$emit('dragstart', $event)" @dragend="$emit('dragend', $event)"
+        title="Drag to reorder / into a folder" v-html="dragSvg"></span>
+      <button @click="toggleVisible" class="text-muted-foreground/70 hover:text-foreground flex-shrink-0 flex items-center"
+        :class="{ 'opacity-50': !visible }" :title="visible ? 'Hide' : 'Show'" v-html="visible ? eyeSvg : eyeOffSvg"></button>
+      <button ref="swatchBtn" @click.stop="toggleStyle"
+        class="flex-shrink-0 flex items-center justify-center w-[22px] h-[22px] rounded hover:bg-muted"
+        :class="config.layer_type === 'raster' ? 'text-amber-400' : ''" :title="geomLabel" v-html="geomSvg"></button>
+      <span class="text-xs font-medium flex-1 truncate" :class="visible ? '' : 'text-muted-foreground/70'" :title="layerName">{{ layerName }}</span>
+      <button @click="$emit('zoom')" class="text-muted-foreground/70 hover:text-primary flex-shrink-0" title="Zoom to layer">
+        <LocateIcon class="w-3.5 h-3.5" />
+      </button>
+      <button @click="$emit('remove')" class="text-muted-foreground/70 hover:text-red-500 flex-shrink-0" title="Remove">
+        <TrashIcon class="w-3.5 h-3.5" />
+      </button>
+    </template>
 
-    <!-- Symbology popover (opens from the swatch) -->
-    <Teleport to="body">
-      <div v-if="showStyle" ref="popEl" :style="popStyle"
-        class="fixed z-[60] bg-card border border-border rounded-lg shadow-xl text-foreground/85">
-        <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-border/60 text-xs font-semibold">
+    <!-- Symbology popover (opens from the swatch) — rendered IN PLACE when standalone. -->
+    <Teleport to="body" :disabled="standalone">
+      <div v-if="showStyle || standalone" ref="popEl" :style="standalone ? null : popStyle"
+        :class="standalone
+          ? 'text-foreground/85'
+          : 'fixed z-[60] bg-card border border-border rounded-lg shadow-xl text-foreground/85'">
+        <div v-if="!standalone" class="flex items-center justify-between gap-2 px-3 py-2 border-b border-border/60 text-xs font-semibold">
           <span class="truncate">{{ layerName }}</span>
           <button @click="showStyle = false" class="text-muted-foreground/70 hover:text-foreground text-lg leading-none flex-shrink-0">&times;</button>
         </div>
-        <div class="px-3 py-2.5 space-y-3 max-h-[70vh] overflow-auto">
+        <div class="space-y-3" :class="standalone ? '' : 'px-3 py-2.5 max-h-[70vh] overflow-auto'">
 
           <!-- Opacity (all layers) -->
           <div>
@@ -94,17 +102,20 @@
                         <option v-for="r in DIVERGING" :key="r" :value="r">{{ r }}</option>
                       </optgroup>
                     </select>
+                  </div>
+                  <div class="flex items-center justify-between gap-2 mt-1">
+                    <div class="flex h-2 flex-1 rounded overflow-hidden" aria-hidden="true">
+                      <span v-for="(c, i) in rampPreview" :key="i" class="flex-1"
+                        :style="{ backgroundColor: c }"></span>
+                    </div>
                     <!-- Which end means "high" is a cartographic choice, not a property of the
                          ramp: on a dark basemap the light end often belongs to the low values. -->
-                    <button type="button" @click="toggleRampReverse"
-                      :aria-pressed="rampReverse"
-                      :title="rampReverse ? 'Ramp reversed — click to restore' : 'Reverse the ramp'"
-                      class="shrink-0 text-xs border border-border rounded px-1.5 py-1"
-                      :class="rampReverse ? 'bg-primary/15 border-primary/40' : ''">⇄</button>
-                  </div>
-                  <div class="flex h-1.5 mt-1 rounded overflow-hidden" aria-hidden="true">
-                    <span v-for="(c, i) in rampPreview" :key="i" class="flex-1"
-                      :style="{ backgroundColor: c }"></span>
+                    <label class="flex items-center gap-1 text-[11px] text-muted-foreground
+                                  cursor-pointer shrink-0">
+                      <input type="checkbox" :checked="rampReverse"
+                        @change="toggleRampReverse" class="cursor-pointer" />
+                      Reverse
+                    </label>
                   </div>
                 </div>
 
@@ -117,13 +128,20 @@
                   <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-1.5">
                     <input type="color" :value="e.color" @input="setEntryColor(i, $event.target.value)"
                       :disabled="e.isOther"
-                      class="w-4 h-4 rounded border border-border cursor-pointer p-0 flex-shrink-0 disabled:opacity-60" />
+                      class="w-5 h-5 rounded border border-border/50 cursor-pointer p-0 flex-shrink-0 disabled:opacity-60" />
                     <span class="text-[11px] text-muted-foreground truncate">{{ e.label }}</span>
                   </div>
                 </div>
                 <p v-if="truncatedCats" class="text-[11px] text-amber-300/80">
                   Showing the {{ (config.style?.categories || []).length }} commonest values; the rest
                   draw in the “Other” colour.
+                </p>
+                <!-- Says what happened instead of silently rewriting the box. Repeated values
+                     collapse a break, so a column can legitimately yield fewer classes than asked
+                     — one on a live instance yields exactly one, whatever you request. -->
+                <p v-if="fewerThanAsked" class="text-[11px] text-amber-300/80">
+                  {{ producedClasses }} of {{ classCount }} classes — the rest would be empty,
+                  because this column's values repeat.
                 </p>
               </div>
             </div>
@@ -223,6 +241,41 @@
                   At this thickness the fill is hidden — the marker reads as a ring.
                 </p>
               </div>
+            </div>
+
+            <!-- Size from a field (issue #21). The instance has drawn this since v1.1 — an
+                 `interpolate` over `size_field` for circle-radius and line-width, and `icon-size`
+                 for marker shapes — but nothing in the dashboard could set it, so it was reachable
+                 only from the CLI. Points and lines only: a polygon has no width to vary. -->
+            <div v-if="canSizeByField" class="pt-1 border-t border-border/50 space-y-1.5">
+              <label class="text-xs text-muted-foreground">
+                {{ geomType === 'point' ? 'Size by a field' : 'Width by a field' }}
+              </label>
+              <select :value="sizeField || ''" @change="pickSizeField($event.target.value)"
+                class="w-full text-xs border border-border rounded px-1.5 py-1">
+                <option value="">Fixed {{ geomType === 'point' ? 'size' : 'width' }}</option>
+                <option v-for="f in numericFields" :key="f.name" :value="f.name">{{ f.name }}</option>
+              </select>
+              <div v-if="sizeField" class="flex items-center gap-1.5">
+                <label class="flex-1">
+                  <span class="text-[11px] text-muted-foreground">Smallest</span>
+                  <input type="number" min="0.5" max="60" step="0.5" :value="sizePx[0]"
+                    @change="setSizePx(0, $event.target.value)"
+                    class="w-full text-xs border border-border rounded px-1.5 py-1 mt-0.5" />
+                </label>
+                <label class="flex-1">
+                  <span class="text-[11px] text-muted-foreground">Largest</span>
+                  <input type="number" min="0.5" max="60" step="0.5" :value="sizePx[1]"
+                    @change="setSizePx(1, $event.target.value)"
+                    class="w-full text-xs border border-border rounded px-1.5 py-1 mt-0.5" />
+                </label>
+              </div>
+              <p v-if="sizeField && sizeRange" class="text-[11px] text-muted-foreground/70">
+                {{ sizeRange[0] }} → {{ sizeRange[1] }} maps to {{ sizePx[0] }} → {{ sizePx[1] }} px.
+              </p>
+              <p v-else-if="sizeField && sizeBusy" class="text-[11px] text-muted-foreground/70">
+                Reading the field…
+              </p>
             </div>
 
             <!-- 3D. Polygons extrude directly (MapLibre raises a fill); POINTS become pillars —
@@ -387,8 +440,10 @@
             </p>
           </template>
 
-          <!-- Default style actions (not applicable to external sources) -->
-          <div v-if="config.layer_type !== 'external'" class="flex items-center gap-2 pt-1 border-t border-border/60">
+          <!-- Default style actions (not applicable to external sources). Hidden when standalone:
+               in My Data this IS the default style, so "use default" and "save as default" would be
+               a control acting on itself — the host's own Save button writes it. -->
+          <div v-if="config.layer_type !== 'external' && !standalone" class="flex items-center gap-2 pt-1 border-t border-border/60">
             <button v-if="layer?.default_style" @click="useDefault" class="text-xs text-primary hover:text-primary/80 font-medium"
               title="Apply saved default style to this portal">↩ Use default</button>
             <button @click="saveDefault" :disabled="savingDefault" class="text-xs text-muted-foreground hover:text-foreground ml-auto"
@@ -411,7 +466,12 @@ import { RAMPS, DIVERGING, NO_OUTLINE, markerOutline, legendEntries, rampColors,
          representativeColor, pillarRadius } from '@/lib/symbology'
 import { TrashIcon, LocateIcon } from '@/views/icons'
 
-const props = defineProps({ config: Object })
+const props = defineProps({
+  config: Object,
+  // Render the symbology body ALONE, without the layer row, the popover chrome or the
+  // default-style actions — for a host that is not a portal layer list (My Data).
+  standalone: { type: Boolean, default: false },
+})
 const emit = defineEmits(['remove', 'update', 'zoom', 'dragstart', 'dragend'])
 
 const dataStore = useDataStore()
@@ -548,7 +608,16 @@ const statsError = ref('')
 const truncatedCats = ref(false)
 
 const colorMode = computed(() => props.config.style?.color_mode || 'single')
-const classCount = computed(() => (props.config.style?.classes || []).length || 5)
+// The REQUESTED count, not the produced one. Reading it back from `classes.length` meant the box
+// showed whatever came back: a column whose values tie (a real one on a live instance returns ONE
+// class however many you ask for) snapped the input to 1 and there was no way to ask for more —
+// the control fought the user. `classes_n` is what was asked; the note below says what happened.
+const classCount = computed(() =>
+  props.config.style?.classes_n || (props.config.style?.classes || []).length || 5)
+const producedClasses = computed(() => (props.config.style?.classes || []).length)
+const fewerThanAsked = computed(() =>
+  colorMode.value === 'graduated' && producedClasses.value > 0
+  && producedClasses.value < classCount.value)
 const classMethod = computed(() => props.config.style?.class_method || 'quantile')
 const ramp = computed(() => props.config.style?.color_ramp || 'viridis')
 const rampReverse = computed(() => !!props.config.style?.color_ramp_reverse)
@@ -597,9 +666,30 @@ function pickColorField(field) {
 function setClassCount(n) { refreshClasses({ classes_n: Math.max(2, Math.min(12, parseInt(n) || 5)) }) }
 function setMethod(m) { refreshClasses({ class_method: m }) }
 function setRamp(r) { refreshClasses({ color_ramp: r }) }
-// Reversing has to REGENERATE the class colours, not just flip the legend swatches: the colours are
-// stored per class and are individually editable, so the stored list is the truth (issue #11).
-function toggleRampReverse() { refreshClasses({ color_ramp_reverse: !rampReverse.value }) }
+/**
+ * Flip the ramp — INSTANTLY, and without asking the server (issue #11).
+ *
+ * A reversed ramp is by construction the same colours in the opposite order (`ramp_colors` reverses
+ * its sampled output), so reversing the STORED class colours is exactly equal to re-classifying with
+ * `reverse=true` — and it is equal for hand-edited colours too, which a re-classify would discard.
+ * That makes the round trip pure latency: the map recolours on the next tick instead of after a
+ * request that can also fail.
+ *
+ * The flag is still stored, so a later change of method or class count keeps the direction.
+ */
+function toggleRampReverse() {
+  const style = props.config.style || {}
+  const patch = { color_ramp_reverse: !rampReverse.value }
+  if ((style.classes || []).length) {
+    const colors = style.classes.map(c => c.color).reverse()
+    patch.classes = style.classes.map((c, i) => ({ ...c, color: colors[i] }))
+  }
+  if ((style.categories || []).length) {
+    const colors = style.categories.map(c => c.color).reverse()
+    patch.categories = style.categories.map((c, i) => ({ ...c, color: colors[i] }))
+  }
+  emitStyle(patch)
+}
 
 /**
  * Ask the server to classify the chosen field and apply the result.
@@ -633,6 +723,7 @@ async function refreshClasses(over = {}) {
       color_ramp: over.color_ramp || ramp.value,
       color_ramp_reverse: reverse,
       class_method: over.class_method || classMethod.value,
+      classes_n: over.classes_n || classCount.value,
     }
     // A text column cannot be graduated and a numeric one is usually not meant to be categorical.
     // Follow the DATA rather than refusing: the mode switches, and the legend shows what happened.
@@ -673,6 +764,62 @@ function setEntryColor(i, color) {
 //     same rule as hiding it when a layer has no numeric field.
 // GeoParquet POLYGONS are fine and offered: deck's GeoJsonLayer extrudes them directly
 // (`extruded` + `getElevation`), and a PMTiles-tiled one takes the normal MapLibre path.
+// ── Size from a field (issue #21) ────────────────────────────────────────────────────────────────
+// The style keys are `size_mode: 'proportional'` + `size_field` + `size_stops`, exactly as
+// services/symbology.py reads them; two stops, because the server interpolates LINEARLY between
+// them and a size legend is only honest if it is a straight line.
+const canSizeByField = computed(() =>
+  !!numericFields.value.length && (geomType.value === 'point' || geomType.value === 'line'))
+const sizeField = computed(() =>
+  (props.config.style?.size_mode === 'proportional' && props.config.style?.size_field) || '')
+const sizeStops = computed(() => {
+  const s = props.config.style?.size_stops
+  return Array.isArray(s) && s.length === 2 ? s : null
+})
+// The data values the two stops sit at, and the pixel sizes they map to.
+const sizeRange = computed(() => sizeStops.value ? [sizeStops.value[0][0], sizeStops.value[1][0]] : null)
+const sizePx = computed(() => sizeStops.value
+  ? [sizeStops.value[0][1], sizeStops.value[1][1]]
+  : (geomType.value === 'point' ? [4, 20] : [1, 8]))
+const sizeBusy = ref(false)
+
+async function pickSizeField(field) {
+  if (!field) {
+    // `size_mode` back to fixed AND the field cleared: leaving a stale field behind means the next
+    // person to switch it on inherits a column they never chose.
+    emitStyle({ size_mode: 'fixed', size_field: null, size_stops: null })
+    return
+  }
+  sizeBusy.value = true
+  try {
+    // The server already knows the column's min and max — asking beats guessing a range, and it is
+    // the same endpoint the colour classification uses.
+    const { data } = await getFieldStats(props.config.layer_id, { field, classes: 2 })
+    const lo = data.min ?? 0
+    const hi = data.max ?? (lo + 1)
+    const px = sizePx.value
+    emitStyle({
+      size_mode: 'proportional',
+      size_field: field,
+      // Equal values would make MapLibre's interpolate stops non-ascending, which throws.
+      size_stops: [[lo, px[0]], [hi > lo ? hi : lo + 1, px[1]]],
+    })
+  } catch (e) {
+    statsError.value = e?.response?.data?.detail || 'Could not read that field.'
+  } finally {
+    sizeBusy.value = false
+  }
+}
+
+function setSizePx(index, value) {
+  const stops = sizeStops.value
+  if (!stops) return
+  const px = Math.max(0.5, Math.min(60, parseFloat(value) || 1))
+  const next = stops.map(s => s.slice())
+  next[index][1] = px
+  emitStyle({ size_stops: next })
+}
+
 const canExtrude = computed(() => {
   if (!numericFields.value.length) return false
   if (geomType.value === 'line') return false

--- a/ui/src/lib/symbology.js
+++ b/ui/src/lib/symbology.js
@@ -48,16 +48,22 @@ export const DEFAULT_COLOR = '#3b82f6'
 export const DEFAULT_OTHER_COLOR = '#9ca3af'
 
 /** `count` colours sampled evenly from a named ramp. Nearest-stop, matching ramp_colors(). */
-export function rampColors(name, count) {
+export function rampColors(name, count, reverse = false) {
   const stops = RAMPS[name] || RAMPS.viridis
   if (count <= 0) return []
   if (count === 1) return [stops[Math.floor(stops.length / 2)]]
   const out = []
   for (let i = 0; i < count; i++) {
     const pos = (i * (stops.length - 1)) / (count - 1)
-    out.push(stops[Math.round(pos)])
+    // `Math.floor(pos + 0.5)` — the twin of `int(pos + 0.5)` in symbology.ramp_colors. Math.round()
+    // rounds half UP and Python's round() rounds half to EVEN, so the two disagreed at every .5
+    // position: a 5-class viridis differed in its fourth colour. Same formula, no drift.
+    out.push(stops[Math.floor(pos + 0.5)])
   }
-  return out
+  // Reverse the sampled OUTPUT, not the stop list — the twin of symbology.ramp_colors, which must
+  // produce the identical array or the editor preview and the published portal disagree about which
+  // class is which colour.
+  return reverse ? out.reverse() : out
 }
 
 /**

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -53,6 +53,20 @@
   input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]):not([type="file"]):not([type="submit"]):not([type="button"]) {
     @apply bg-background text-foreground;
   }
+
+  /* Colour swatches (the class colours in the symbology legend). A native colour input draws its
+     own chrome — a padded wrapper AND an inner border — so at swatch size there is more frame than
+     colour, and telling two classes apart gets hard. Strip both: the square IS the colour, and the
+     element's own border supplies the single hairline that keeps a pale class visible. */
+  input[type="color"] {
+    -webkit-appearance: none;
+    appearance: none;
+    padding: 0;
+    background: none;
+  }
+  input[type="color"]::-webkit-color-swatch-wrapper { padding: 0; }
+  input[type="color"]::-webkit-color-swatch { border: none; border-radius: 3px; }
+  input[type="color"]::-moz-color-swatch { border: none; border-radius: 3px; }
 }
 
 @layer components {


### PR DESCRIPTION
Closes #9. Closes #10. Closes #11. Closes #17. Closes #21. Closes #23. Closes #27.

Every open issue, so v1.3 can ship with the list clear — plus three bugs that were not on it,
found by actually using the thing.

## The issues

| Issue | What changed |
| --- | --- |
| **#11** invert a ramp | `color_ramp_reverse` + a **Reverse checkbox** that recolours instantly, `?reverse=` on `field-stats`, `--reverse-ramp` in the CLI |
| **#10** class count | ceiling 9 → **12** (the server's own clamp), and the box shows what you **asked for**, not what came back |
| **#21** size by a field | field picker + two pixel sizes, for points and lines |
| **#23** style in My Data | the **same panel**, reused via a `standalone` prop, hosted on vector and raster rows |
| **#9** legend collapse | per-legend toggle + show/hide-all beside the folder controls |
| **#27** story maps on a phone | portrait: map on top, narrative a **sideways-scrolling strip**; landscape: the control cluster **wraps** |
| **#17** raster minzoom | **measured** from the file's overview pyramid at ingest, instead of guessed from the extent |

## Three things found by using it, not by testing it

**1. HEAD returned 405 on every route.** FastAPI's `APIRoute` does not add HEAD to a GET route
(plain Starlette's does), so every endpoint answered 405 � non-conformant, and some clients probe
with HEAD before fetching. Fixed with a pure-ASGI middleware that runs the GET and drops the body.

> **Correction, and it is the interesting part.** I first reported this as the reason PMTiles would
> not open in QGIS. It is not. Verified on QGIS 3.40 / GDAL 3.12 against the instance BEFORE the
> fix: `ogr.Open("/vsicurl/�/pmtiles")` opens fine � `/vsicurl/` tolerates a 405 probe and falls
> back to a ranged GET. My evidence was a false negative: `ogrinfo` in a GDAL container was getting
> **403 from Cloudflare** (datacenter IP), and GDAL reports a failed fetch with the same
> "not recognized as being in a supported file format" text as a genuine format error. The
> middleware stays on its own merits; it explains nothing about QGIS.

**2. Share links sent QGIS to a dead end.** The *collection* URL was `primary` and listed QGIS
first; QGIS connects to a *service* and lists its collections, so the promoted link produced an
empty dialog and no error. Service is primary now; the collection says plainly that QGIS can't use
it.

**3. The symbology twins had already drifted.** `ramp_colors` sampled with `round()` —
half-to-even in Python, half-up in JavaScript — so every 5- and 9-class ramp differed between
server and editor:

```
viridis, 5 classes
  server:  #440154 #365c8d #277f8e #1fa187 #fde725
  editor:  #440154 #365c8d #277f8e #4ac16d #fde725
```

Latent since v1.1, invisible only because nothing imported `rampColors` — the swatch strip in this
PR would have shipped it. Both use one formula now; all **108** cases verified equal and three
literal colour lists pinned as the contract.

## Measured on the live instance, not assumed

- `field-stats` returns 5→5, 9→9, 12→12 and clamps 15→12 — the UI stopped at 9.
- The column `nb_bat_grp` returns **1 class** whether you ask for 5, 9 or 12 — the snap-back, on
  real data.
- The PMTiles archive serves `PMTiles` v3 with byte ranges; only the HEAD probe was refused.

## Notes on two deliberate choices

- **Reverse recolours locally.** A reversed ramp is by construction the same colours in the
  opposite order, so flipping the stored class colours is identical to re-classifying — no request,
  no failure mode, and hand-edited colours survive, which a re-classify would discard.
- **`low_zoom_ok` NULL is not False.** Existing rasters keep today's behaviour until re-ingested;
  no backfill, because computing one means reading every COG header and the conservative direction
  for a guard against a page-wide hang is "change nothing you have not measured".

## Validation

Full API suite **646 passed** (the one failure was a test pinning the old share-link order, now
updated to encode the new contract with its reason); CLI **317**; the UI image builds; `portal.js`
passes `node --check`.

**Deploy:** `tasks/` changed → recreate **celery** as well as the API, and recreate them together
(the new column is added by `PG_MIGRATIONS` at API startup and the worker writes it). Published
portals need a **re-publish** for the legend collapse. The Vue and portal.js changes are visual —
worth a look before merging.
