### PR TITLE
fix(api): one failed migration must not disable every migration after it

### DIFF
--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -100,11 +100,20 @@ async def lifespan(app: FastAPI):
 def _apply_pg_migrations(conn) -> None:
     """Apply the additive column migrations. Each runs independently so one failure cannot block the
     rest, and a failure is logged rather than fatal — the API must keep serving (and the wizard must
-    stay reachable) even if a migration cannot be applied."""
+    stay reachable) even if a migration cannot be applied.
+
+    "Independently" needs a SAVEPOINT, which is what `begin_nested` opens. The try/except alone did
+    NOT deliver it: Postgres aborts the entire transaction on the first failed statement, so every
+    later migration then fails with "current transaction is aborted" — and the except swallowed
+    that too, silently. It shipped exactly that way: one statement missing `IF NOT EXISTS` failed on
+    every instance that already had the column, and the column added AFTER it was never created, so
+    `/data/raster` answered 500 on a real deploy. One statement, one savepoint, one rollback.
+    """
     from sqlalchemy import text
     for stmt in _PG_MIGRATIONS:
         try:
-            conn.execute(text(stmt))
+            with conn.begin_nested():
+                conn.execute(text(stmt))
         except Exception:
             log.exception("schema migration failed: %s", stmt)
 

--- a/api/geodeploy/schema_migrations.py
+++ b/api/geodeploy/schema_migrations.py
@@ -57,7 +57,7 @@ PG_MIGRATIONS = [
     # The anonymous instance index (`GET /api/public`). Default TRUE: publishing a portal as
     # 'public' already says it may be seen, and a geoportal that cannot be browsed is a filing
     # cabinet. An operator who wants their public portal reachable-but-unlisted turns this off.
-    "ALTER TABLE setup_config ADD COLUMN public_index_enabled BOOLEAN DEFAULT TRUE",
+    "ALTER TABLE setup_config ADD COLUMN IF NOT EXISTS public_index_enabled BOOLEAN DEFAULT TRUE",
     # Raster low-zoom cost, read from the COG's overview pyramid at ingest (issue #17). Nullable with
     # NO default on purpose: NULL means "not measured", which is different from False and is what
     # keeps every existing layer on the extent heuristic until it is re-ingested.

--- a/api/tests/test_pg_migrations.py
+++ b/api/tests/test_pg_migrations.py
@@ -1,0 +1,82 @@
+"""One failing migration must not take the others down with it.
+
+This shipped. `_apply_pg_migrations` wrapped each statement in `try/except` and its docstring said
+each one "runs independently", but they all shared ONE transaction — and Postgres aborts the whole
+transaction on the first failed statement, so every later statement fails with "current transaction
+is aborted" and the except swallowed that too, in silence.
+
+The trigger was a single statement missing `IF NOT EXISTS`: on any instance that already had the
+column it errored, and the column added AFTER it was therefore never created. The symptom was
+`/data/raster` answering **500** on a freshly updated instance — the model selected a column the
+database did not have — with nothing in the UI but an empty page.
+
+So two things are pinned here: every statement is written to be re-runnable, and one that is not
+still cannot poison its neighbours.
+"""
+import pytest
+from sqlalchemy import text
+
+from geodeploy.main import _apply_pg_migrations
+from geodeploy.schema_migrations import PG_MIGRATIONS
+
+
+class TestTheStatementsThemselves:
+    def test_every_add_column_is_idempotent(self):
+        """These run on EVERY start. `ADD COLUMN` without `IF NOT EXISTS` fails the second time —
+        which, before the savepoint fix, also broke everything after it."""
+        offenders = [s for s in PG_MIGRATIONS
+                     if "ADD COLUMN" in s.upper() and "IF NOT EXISTS" not in s.upper()]
+        assert offenders == [], f"not re-runnable: {offenders}"
+
+    def test_nothing_destructive_slipped_in(self):
+        """The file's own rule: additive only. A DROP or a rename running unattended on every boot
+        is how databases get lost."""
+        for stmt in PG_MIGRATIONS:
+            upper = stmt.upper()
+            assert "DROP COLUMN" not in upper, stmt
+            assert "DROP TABLE" not in upper, stmt
+            assert "RENAME" not in upper, stmt
+
+
+class TestOneFailureCannotPoisonTheRest:
+    async def test_a_later_migration_still_applies(self, db):
+        """The exact shape of the bug: a broken statement, then a good one."""
+        conn = await db.connection()
+
+        def run(sync_conn):
+            sync_conn.execute(text("CREATE TABLE IF NOT EXISTS mig_probe (id integer)"))
+            broken = "ALTER TABLE mig_probe ADD COLUMN dup integer"
+            statements = [broken, broken,                       # the second one fails
+                          "ALTER TABLE mig_probe ADD COLUMN IF NOT EXISTS after_the_failure text"]
+            import geodeploy.main as main_mod
+            original = main_mod._PG_MIGRATIONS
+            main_mod._PG_MIGRATIONS = statements
+            try:
+                _apply_pg_migrations(sync_conn)
+            finally:
+                main_mod._PG_MIGRATIONS = original
+            cols = sync_conn.execute(text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'mig_probe'")).scalars().all()
+            sync_conn.execute(text("DROP TABLE mig_probe"))
+            return cols
+
+        cols = await conn.run_sync(run)
+        assert "after_the_failure" in cols, (
+            "a migration after a failing one was skipped — the transaction was poisoned")
+
+    async def test_the_connection_is_still_usable_afterwards(self, db):
+        """A poisoned transaction takes the rest of startup with it, not just the migrations."""
+        conn = await db.connection()
+
+        def run(sync_conn):
+            import geodeploy.main as main_mod
+            original = main_mod._PG_MIGRATIONS
+            main_mod._PG_MIGRATIONS = ["ALTER TABLE no_such_table ADD COLUMN x integer"]
+            try:
+                _apply_pg_migrations(sync_conn)
+            finally:
+                main_mod._PG_MIGRATIONS = original
+            return sync_conn.execute(text("SELECT 1")).scalar()
+
+        assert await conn.run_sync(run) == 1


### PR DESCRIPTION
**This shipped and broke a live instance**, so the interesting part is not the one-line trigger but
why nothing noticed.

## What happened

After updating, `/data/raster` answered **500**, and both **My Data** and the **portal editor**
rendered empty — each loads the vector and raster lists with `Promise.all`, so a single 500 blanks
the whole page. `raster_layers.low_zoom_ok` was in the model and absent from the database.

## Why the migration did not run

`_apply_pg_migrations` wrapped each statement in `try/except`, and its own docstring claimed each
one ran *"independently"*. They shared **one transaction** — and Postgres aborts the entire
transaction on the first failed statement. Every statement after it then fails with *"current
transaction is aborted"*, and the `except` swallowed that too. In silence, on every start.

The trigger was one statement missing `IF NOT EXISTS`:

```sql
ALTER TABLE setup_config ADD COLUMN public_index_enabled BOOLEAN DEFAULT TRUE
```

which fails on any instance that already has the column — i.e. every existing install. `low_zoom_ok`
was the only statement after it, so it was the only casualty. Both were mine, added in the same
session: the non-idempotent statement first, then the column that depended on it running.

## Two fixes, because the missing keyword was only the trigger

1. **`IF NOT EXISTS`** on the offender — it was never re-runnable, against a list that runs on
   *every* start.
2. **`conn.begin_nested()` — a SAVEPOINT per statement** — so the next non-idempotent statement
   someone adds cannot poison its neighbours. Without this the same failure recurs the next time a
   column is added.

## The tests were verified to fail first

A test that passes on the broken code proves nothing, so I ran the new file against the old
implementation before keeping it:

| | old code | with the fix |
| --- | --- | --- |
| `test_a_later_migration_still_applies` | **FAILED** | passed |
| `test_the_connection_is_still_usable_afterwards` | **FAILED** | passed |

Plus a static one — every `ADD COLUMN` in `PG_MIGRATIONS` must contain `IF NOT EXISTS` — which
would have caught the trigger before it left my machine, and one asserting nothing destructive
(`DROP`/`RENAME`) slips into a list that runs unattended on every boot.

## Recovering an instance that already updated

No restart needed — the running API already expects the column:

```bash
docker compose exec -T postgres psql -U geodeploy -d geodeploy \
  -c "ALTER TABLE raster_layers ADD COLUMN IF NOT EXISTS low_zoom_ok BOOLEAN;"
```

After merging, a normal update applies it by itself.