### PR TITLE
fix(portal): sideways chevrons, and controls that stay on the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ Notable changes, newest first. Versions are **major.minor** — `v1.0`, `v1.1`, 
 `v2.0`. The minor number moves for anything shipped, features or fixes; the major changes when an
 upgrade needs manual work.
 
+## v1.3 — 2026-08-14
+
+### Reach your instance without a browser
+
+- **A packaged command-line client — `pip install geodeploy`.** Uploads of any format and any size
+  (multi-gigabyte files go straight to object storage in parallel presigned parts), layers, portals,
+  data-driven symbology, publishing, the public catalog, jobs, users and instance administration.
+  Every command takes `--json`, and exit codes separate an authentication problem from a network one
+  from a server one, so a scheduled job can alert on the right thing.
+- **It is also a Python client**, with no dependencies and a Python 3.9 floor, because the QGIS
+  plugin will vendor it rather than pip-install into someone's QGIS.
+- **Start from a URL alone.** `GET /api/public` is an anonymous index of what an instance
+  publishes — public portals, and public layers grouped by how they are stored — so a desktop client
+  can browse an instance before anyone signs in. An admin can switch the listing off in
+  **Settings → Infrastructure**; it defaults to listed.
+
+### Take a copy with you
+
+- **Download any layer, whole.** A PostGIS table is built into a GeoPackage, CSV or GeoJSON; a
+  GeoParquet layer comes straight from its own partition files — complete, lossless and with no
+  worker involved; a raster is its COG.
+- **A truncated export now says so.** A built export stops at a row cap so the worker cannot run out
+  of memory, and until now a capped download looked exactly like a complete one. The row count of
+  every file is in `MANIFEST.txt`, in the job status, and in the CLI's non-zero exit — with the
+  uncapped alternatives named.
+
+### Symbology
+
+- **Size from a field** — bigger markers for bigger values, thicker lines for busier roads. The
+  instance had drawn this since v1.1 with no way to set it outside the API.
+- **Invert a colour ramp**, as a checkbox that recolours instantly.
+- **Style a layer in My Data**, not only inside a portal — the same panel, reused. What you save
+  there is what a portal picks up when the layer is added.
+- **Legends collapse** in a published portal's layer list, and the class count stops snapping back
+  to whatever the classifier returned.
+- **A legend anyone can read**: `GET /api/data/{kind}/{ref}/legend` serves the swatches and labels
+  the portal draws, so no other renderer has to re-derive them.
+
+### Fixes found by using it
+
+- **A CSV with an `id` column could not be imported.** The destination table adds its own `id`, so
+  the load failed at 45% with "column id specified more than once" — for most CSVs anyone exports.
+- **The legend 404'd for the owner of their own layer** when it was not public.
+- **Share links sent QGIS to a URL it cannot open** — the OGC *collection* was promoted where QGIS
+  needs the *service*. A tiled GeoParquet layer now leads with its PMTiles archive, which QGIS opens
+  through *Add Vector Layer*.
+- **A raster's zoom floor is measured, not guessed** — read from the file's overview pyramid at
+  ingest instead of inferred from its extent, so a small high-resolution layer stops vanishing when
+  you zoom out.
+- **Story maps work on a phone**: portrait puts the map above a sideways-scrolling narrative, and
+  the control cluster stops running off a landscape screen.
+- **One failing schema migration no longer disables every migration after it.** They shared a
+  transaction, and Postgres aborts the whole thing on the first error — silently, because each
+  statement was wrapped in its own `try`.
+- **HEAD works on every route.** FastAPI does not add it to a GET route, so every endpoint answered
+  405 to a probe.
+
 ## v1.2 — 2026-08-07
 
 ### From an upload to a map anyone can open

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ couple of minutes later. No terminal, no Docker knowledge, no database configura
   embeds in another site with one `<iframe>`.
 - **Share data properly.** Layers you mark public are readable by standard clients over open
   standards, so QGIS, Python and R consume them directly with no export step.
+- **Work without the browser.** `pip install geodeploy` gives you a command-line client covering the
+  whole API — upload many files at once, style with data-driven symbology, build and publish a
+  portal, administer the instance. It is also the zero-dependency Python client the QGIS plugin is
+  built on.
 - **Work as a team.** Roles from viewer to owner, per-layer visibility, invitation links, scoped API
   tokens, and an audit log of who changed what.
 - **Operate it from the browser.** Service logs, a terminal, scheduled backups to a separate

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -316,7 +316,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="0.3.0",
+    version="1.3.0",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # nginx proxies ONLY `/api/` to this app; every other path falls through to the SPA. At

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -97,12 +97,12 @@ def vector_links(layer, base: str) -> list[dict]:
             links.append(_link(
                 "pmtiles", "PMTiles archive (fast rendering)", f"{api}/pmtiles",
                 fmt="PMTiles (vector)", tools=["GeoLibre", "MapLibre", "download", "GDAL"],
-                hint="Paste as-is — no pmtiles:// prefix (that is a MapLibre-internal protocol "
-                     "handler, not part of any address). In QGIS this does NOT go in Add Vector "
-                     "Tile Layer (that dialog builds an XYZ template and an archive is one file); "
-                     "open it with GDAL 3.8+ as /vsicurl/<this URL>. For attributes and queries "
-                     "prefer the OGC API - Features service above — PMTiles is generalized per "
-                     "zoom."))
+                hint="QGIS: Layer > Add Layer > ADD VECTOR LAYER and paste this URL as-is — GDAL "
+                     "3.8+ opens it with its PMTiles driver (verified: driver=PMTiles, 1 layer). "
+                     "NOT Add Vector TILE Layer: that dialog builds an XYZ template and an archive "
+                     "is one file. No pmtiles:// prefix and no /vsicurl/ needed. For attributes and "
+                     "queries prefer the OGC API - Features service above — tiles are generalized "
+                     "per zoom."))
         links.append(_link(
             "features-geojson", "Viewport features (GeoDeploy native)",
             f"{api}/features.geojson?bbox=minx,miny,maxx,maxy&limit=50000",

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -40,6 +40,13 @@ def stac_item_url(base: str, kind: str, layer) -> str:
     return f"{base}/api/stac/collections/{kind}/items/{kind[:-1]}-{public_ref(layer)}"
 
 
+def _has_pmtiles(layer) -> bool:
+    """A tiled GeoParquet layer — the case where a rendering link beats a feature service."""
+    return (getattr(layer, "storage_backend", "postgis") != "postgis"
+            and bool(getattr(layer, "pmtiles_key", None))
+            and getattr(layer, "tile_status", None) == "ready")
+
+
 def vector_links(layer, base: str) -> list[dict]:
     # OGC API - Features FIRST: it is the one standard every GIS reads natively (QGIS, ArcGIS Pro,
     # FME, anything on GDAL's OAPIF driver), it carries real attributes, and it works the same for
@@ -62,7 +69,10 @@ def vector_links(layer, base: str) -> list[dict]:
         _link("ogc-service", "OGC API - Features — ALL your public layers", f"{base}/api/ogc",
               fmt="OGC API - Features landing page",
               tools=["QGIS", "ArcGIS Pro", "FME"],
-              primary=True,
+              # Recommended UNLESS this layer has PMTiles — see the reorder at the end of the
+              # function. For a multi-million-feature GeoParquet layer, paging OAPIF into QGIS is
+              # minutes of waiting where the archive draws immediately.
+              primary=not _has_pmtiles(layer),
               hint="Not just this layer: this is the service, and it lists every layer you have "
                    "shared publicly. It is what QGIS needs — Layer ▸ Add Layer ▸ Add OGC API - "
                    "Features Layer ▸ New ▸ paste this, then pick this layer from the list."),
@@ -95,8 +105,9 @@ def vector_links(layer, base: str) -> list[dict]:
             # never understood the prefix. GeoDeploy's OWN portals still emit `pmtiles://…` inside
             # their MapLibre style — see portal_generator — which is correct and unrelated to this.
             links.append(_link(
-                "pmtiles", "PMTiles archive (fast rendering)", f"{api}/pmtiles",
-                fmt="PMTiles (vector)", tools=["GeoLibre", "MapLibre", "download", "GDAL"],
+                "pmtiles", "PMTiles archive — fastest way to draw this layer", f"{api}/pmtiles",
+                fmt="PMTiles (vector)", tools=["QGIS", "GeoLibre", "MapLibre", "GDAL"],
+                primary=True,
                 hint="QGIS: Layer > Add Layer > ADD VECTOR LAYER and paste this URL as-is — GDAL "
                      "3.8+ opens it with its PMTiles driver (verified: driver=PMTiles, 1 layer). "
                      "NOT Add Vector TILE Layer: that dialog builds an XYZ template and an archive "
@@ -120,6 +131,16 @@ def vector_links(layer, base: str) -> list[dict]:
                 fmt="JSON", tools=["DuckDB", "GDAL/ogr2ogr", "pyarrow"],
                 hint=f"Partition grid + file keys; each file is then at {api}/parquet/<key> "
                      "(HTTP Range supported)."))
+    # A tiled GeoParquet layer LEADS with PMTiles. These layers are the big ones — that is why they
+    # are GeoParquet — and for them the honest first answer is the one that draws: QGIS opens the
+    # archive through Add Vector Layer in seconds, where OAPIF pages millions of features one screen
+    # at a time. OGC API - Features stays directly below it for full attributes and queries, which
+    # tiles cannot give: they are generalized per zoom and clipped to tile boundaries.
+    for i, l in enumerate(links):
+        if l.get("id") == "pmtiles":
+            links.insert(0, links.pop(i))
+            break
+
     links.append(_link(
         "stac", "STAC item (metadata + all assets)", stac_item_url(base, "vectors", layer),
         fmt="STAC 1.0 Item", tools=["QGIS 3.40+", "stac-browser", "pystac-client"],

--- a/api/tests/test_ogcapi.py
+++ b/api/tests/test_ogcapi.py
@@ -273,6 +273,49 @@ async def test_share_links_lead_with_ogc_features(client, db):
 
 
 @pytest.mark.asyncio
+async def test_a_tiled_geoparquet_layer_leads_with_pmtiles(client, db):
+    """These are the BIG layers — that is why they are GeoParquet — and for them the honest first
+    answer is the one that draws. QGIS opens the archive through Add Vector Layer in seconds, where
+    OAPIF pages millions of features a screen at a time. Verified against a live instance: GDAL
+    reports driver=PMTiles and reads features straight from the plain URL."""
+    from geodeploy.services.share_links import vector_links
+
+    class _Tiled:
+        id, uid, name = 9, "abc123abc123", "big"
+        storage_backend, pmtiles_key, tile_status = "geoparquet", "k.pmtiles", "ready"
+        schema_name = table_name = columns = s3_key = None
+        is_public, visibility = True, "public"
+
+    links = vector_links(_Tiled(), "https://example.org")
+    assert links[0]["id"] == "pmtiles", "the fastest path should be first, not buried"
+    assert links[0]["primary"] is True
+    assert "QGIS" in links[0]["tools"]
+    # Case-insensitive: the hint capitalises the menu name for emphasis, and pinning the shouting
+    # would make this a test of formatting rather than of content.
+    assert "add vector layer" in links[0]["hint"].lower()   # the dialog that actually works
+    assert "add vector tile layer" in links[0]["hint"].lower()  # …and the one that does not
+    # Only ONE thing may wear the badge, or "recommended" means nothing.
+    assert [l["id"] for l in links if l.get("primary")] == ["pmtiles"]
+    # …and the feature service is still right there for attributes, which tiles cannot carry.
+    assert "ogc-service" in [l["id"] for l in links]
+
+
+@pytest.mark.asyncio
+async def test_an_untiled_geoparquet_layer_still_leads_with_the_service(client, db):
+    """No archive, no shortcut: OAPIF is the answer again."""
+    from geodeploy.services.share_links import vector_links
+
+    class _Untiled:
+        id, uid, name = 10, "def456def456", "small"
+        storage_backend, pmtiles_key, tile_status = "geoparquet", None, None
+        schema_name = table_name = columns = s3_key = None
+        is_public, visibility = True, "public"
+
+    links = vector_links(_Untiled(), "https://example.org")
+    assert [l["id"] for l in links if l.get("primary")] == ["ogc-service"]
+
+
+@pytest.mark.asyncio
 async def test_share_links_flag_a_non_public_layer(client, db):
     await _seed(db)
     body = (await client.get(f"/api/data/vector/{ORG_PG}/links", headers=_auth())).json()

--- a/cli/README.md
+++ b/cli/README.md
@@ -131,10 +131,10 @@ python -m twine check dist/*        # must pass before anything is uploaded
 from source rather than trusted.
 
 **Versioning.** The CLI's number tracks the GeoDeploy release it ships with, so it must not claim a
-release that has not happened: the first upload is `1.3.0b1`, and `1.3.0` follows when v1.3 tags. A
-version on PyPI can never be re-uploaded — deleting it does not free the number — so a pre-release
-is the only way to test the real index without spending the one that matters. `pip install
-geodeploy` skips pre-releases unless asked with `--pre`.
+release that has not happened. `1.3.0b1` went up first for exactly that reason — a version on PyPI
+can never be re-uploaded, and deleting it does not free the number, so a pre-release is the only way
+to test the real index without spending the one that matters. `1.3.0` followed when v1.3 tagged.
+Do the same next time: `1.4.0bN` while v1.4 is unreleased, then the final.
 
 ## The row cap, and the two ways around it
 

--- a/cli/geodeploy/__init__.py
+++ b/cli/geodeploy/__init__.py
@@ -11,11 +11,10 @@ Zero runtime dependencies, Python 3.9+, so the QGIS plugin can vendor this packa
 """
 from __future__ import annotations
 
-# A PyPI version can never be re-uploaded, so the FIRST upload is a pre-release: it proves the
-# packaging against the real index without spending the number this ships under. `pip install
-# geodeploy` ignores it (pre-releases need --pre), so nobody gets it by accident. Becomes 1.3.0
-# when GeoDeploy v1.3 tags — the CLI's version tracks the release it belongs to.
-__version__ = "1.3.0b1"
+# The CLI's version tracks the GeoDeploy release it ships with. A PyPI version can never be
+# re-uploaded, so a number is only spent once the release it names exists: 1.3.0b1 proved the
+# packaging against the real index, and this is the release it was rehearsing for.
+__version__ = "1.3.0"
 
 from .client import Client  # noqa: E402  (after __version__ — the user agent reads it)
 from .errors import (  # noqa: E402

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -215,20 +215,20 @@ filtering, no transactions, no OGC API - Tiles or Records — and `/api/ogc/conf
 > field or an address bar. To load a layer *into QGIS*, use OGC API - Features — PMTiles is a
 > rendering format.
 >
-> **In QGIS, use the right dialog.** *Add Vector Tile Layer ▸ New Generic Connection* builds an XYZ
-> template (`type=xyz&url=…{z}/{x}/{y}`) and cannot describe a single-file archive — it answers
-> *"Invalid Data Source"*. What works, on GDAL 3.8+ (QGIS 3.34 and later), is opening the archive
-> directly:
+> **In QGIS, use *Add Vector Layer* — not *Add Vector Tile Layer*.** Paste the plain URL:
 >
-> ```python
-> # QGIS ▸ Plugins ▸ Python Console
-> from osgeo import ogr
-> ds = ogr.Open("/vsicurl/https://YOUR-HOST/api/data/vector/{uid}/pmtiles")
+> ```
+> https://YOUR-HOST/api/data/vector/{uid}/pmtiles
 > ```
 >
-> — verified against a live instance, returning the `geodeploy` layer. Older GDAL cannot read
-> PMTiles at all. For most QGIS work OGC API - Features is still the better route: it carries
-> attributes and is not generalized per zoom.
+> GDAL 3.8+ (QGIS 3.34 and later) opens it with its PMTiles driver — verified against a live
+> instance: `driver=PMTiles`, one layer, features readable. No `pmtiles://` prefix and no
+> `/vsicurl/` needed, though `/vsicurl/<url>` works too. *Add Vector **Tile** Layer* cannot open it
+> at all: that dialog builds an XYZ template (`type=xyz&url=…{z}/{x}/{y}`) and an archive is a single
+> file, so it answers *"Invalid Data Source"*. Older GDAL cannot read PMTiles at all.
+>
+> For most QGIS work OGC API - Features is still the better route: it carries full attributes and is
+> not generalized per zoom.
 
 ## Consuming the assets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,21 @@ directly, with no export step.
 
 [Access from other tools](data-access.md){ .md-button }
 
+## Or with a terminal, if you prefer one
+
+```bash
+pip install geodeploy
+geodeploy login https://your-instance.org --token gdp_…
+geodeploy upload roads.gpkg sites.csv dem.tif --wait
+geodeploy portals create "Field sites 2026" --publish
+```
+
+Everything the dashboard does, scriptable: uploads of any size, data-driven symbology, portals,
+publishing, the public catalog, and instance administration. No dependencies and Python 3.9+, so
+it is also the client a QGIS plugin can vendor as-is.
+
+[The command line](cli.md){ .md-button }
+
 ## Run it without a terminal
 
 Service logs, backups to a separate destination, an in-app restore, and one-button updates.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-GeoDeploy is at **v1.2**. Everything under *In v1.0* and in the releases after it is built and
+GeoDeploy is at **v1.3**. Everything under *In v1.0* and in the releases after it is built and
 running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
@@ -180,9 +180,9 @@ TileJSON was valid, and only the tile server's log knew otherwise.</p>
 
 </div>
 
-<div class="gd-rel now tail" markdown>
+<div class="gd-rel done" markdown>
 ### v1.3 — the CLI, and getting data back out
-<span class="gd-when">Next</span>
+<span class="gd-when">Shipped · 2026-08-14</span>
 
 <p class="gd-goal">v1.2 made the data readable by other tools. This one is about reaching an instance
 without a browser, and about being able to take a copy with you.</p>
@@ -190,21 +190,43 @@ without a browser, and about being able to take a copy with you.</p>
 - [x] **A real CLI**, not an example script — every argument the API takes, the v1.1 symbology
       included, with its own section in the docs and tests so it is verified without anyone
       checking by hand. Also the Python client the QGIS plugin is built on: zero dependencies,
-      Python 3.9+, so a plugin can vendor it
+      Python 3.9+, so a plugin can vendor it. On PyPI: `pip install geodeploy`
+- [x] **Download any layer, whole** — a PostGIS table built to GeoPackage/CSV/GeoJSON, a GeoParquet
+      layer straight from its own partition files (uncapped, lossless, no worker), a raster as its
+      COG. A built export that hits the row cap now SAYS so, in the archive, in the job status and
+      in the CLI's exit code
+- [x] **An anonymous index of what an instance publishes** (`/api/public`) — public portals and
+      public layers by kind, so a plugin can start from a URL alone
+- [x] **A legend anyone can read** (`/api/data/{kind}/{ref}/legend`) — the swatches and labels the
+      portal draws, served rather than re-derived by each renderer
+- [x] Collapsible legend entries in the layer list, with a collapse-all ([#9](https://github.com/bravemaster3/GeoDeploy/issues/9))
+- [x] Class count stops snapping back, and the ceiling agrees with the server ([#10](https://github.com/bravemaster3/GeoDeploy/issues/10))
+- [x] **Invert a colour ramp** ([#11](https://github.com/bravemaster3/GeoDeploy/issues/11))
+- [x] **A raster's zoom floor read from the file** — measured from its overview pyramid at ingest
+      instead of guessed from its extent ([#17](https://github.com/bravemaster3/GeoDeploy/issues/17))
+- [x] **Size from a field** — bigger markers for bigger values, thicker lines for busier roads ([#21](https://github.com/bravemaster3/GeoDeploy/issues/21))
+- [x] **Style a layer in My Data**, not only inside a portal — the same panel, reused ([#23](https://github.com/bravemaster3/GeoDeploy/issues/23))
+- [x] **Story maps that work on a phone** — portrait stacks the map above a sideways-scrolling
+      narrative; the control cluster stops running off a landscape screen ([#27](https://github.com/bravemaster3/GeoDeploy/issues/27))
+- [x] **Fixes found by using it**: a CSV with an `id` column could not be imported at all; the
+      legend 404'd for the owner of their own layer; the share links sent QGIS to a URL it cannot
+      open; and one failing schema migration silently disabled every migration after it
+
+</div>
+
+<div class="gd-rel now tail" markdown>
+### v1.4 — into the tools you already use
+<span class="gd-when">Next</span>
+
+<p class="gd-goal">The CLI made an instance reachable without a browser. This one puts it inside the
+desktop GIS people already have open.</p>
+
+- [ ] **A QGIS plugin** — browse the catalog, add a layer, style it, publish back. Built on the
+      packaged client, which is why that client has no dependencies and runs on Python 3.9
 - [ ] **Styling that travels** — portal and layer style interchange with GeoLibre and QGIS, for
-      every layer type. The CLI is the natural surface for it, so the two are designed together
+      every layer type
 - [ ] **Download a backup**, and **restore from disk** — state-only (small, covers a bad restore or
-      a botched update) separately from the full copy including objects. Restore uploads to a
-      staging prefix and reuses the existing restore path rather than growing a second one
-- [ ] Collapsible legend entries in the layer list, with a collapse-all ([#9](https://github.com/bravemaster3/GeoDeploy/issues/9))
-- [ ] Class count stops snapping back, and the 9-vs-12 ceiling agrees with the server ([#10](https://github.com/bravemaster3/GeoDeploy/issues/10))
-- [ ] **Invert a colour ramp** ([#11](https://github.com/bravemaster3/GeoDeploy/issues/11))
-- [ ] **A raster's zoom range read from the file, not guessed from its extent** — today a small
-      high-resolution layer stops drawing below a computed floor, with nothing saying why
-      ([#17](https://github.com/bravemaster3/GeoDeploy/issues/17))
-- [ ] **Size from a field** — bigger markers for bigger values, thicker lines for busier roads.
-      The instance already draws it and the CLI already sets it; what is missing is a control in
-      the dashboard ([#21](https://github.com/bravemaster3/GeoDeploy/issues/21))
+      a botched update) separately from the full copy including objects
 - [ ] **Labels** — the other half of data-driven symbology v1.1 did not ship, and unlike size this
       one does not exist anywhere yet
 
@@ -221,10 +243,10 @@ without a browser, and about being able to take a copy with you.</p>
 <p class="gd-goal">Your data can already leave GeoDeploy in open formats. This is the return
 trip — edit in the tool you prefer, publish back.</p>
 
-- [ ] **QGIS plugin** — browse the catalog, add a layer, publish back
+<p class="gd-goal">The QGIS plugin and style interchange moved UP into v1.4 above; what is left here
+is the rest of the round trip, not yet scheduled.</p>
+
 - [ ] **Push from GeoLibre** — a "Publish to GeoDeploy" plugin and a `.geolibre.json` importer
-- [ ] Style import from QGIS and GeoLibre, so nobody restyles from scratch
-- [ ] Style interchange — adopt an external MapLibre style, and emit one
 - [ ] Write-back: expose a layer as editable GeoJSON and re-ingest the edit
 - [ ] Catalog **search**, so a client can discover a dataset rather than fetch a known URL
 

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -1389,10 +1389,38 @@
         max-height: calc(100vh - 12px);
         align-content: flex-start;
       }
-      body[data-controls-side="left"] .maplibregl-ctrl-top-left { align-content: flex-start; }
-      .maplibregl-ctrl-group { margin-bottom: 4px !important; }
+      /* Extra columns must grow INWARD. The right-hand cluster is anchored to the right edge, so
+         wrapping forwards put the second column off-screen — which is why two columns still hid
+         controls. `wrap-reverse` stacks new columns towards the middle of the map instead. */
+      .maplibregl-ctrl-top-right { flex-wrap: wrap-reverse; align-content: flex-end; }
+      /* A GROUP is one flex item, so a group taller than the screen cannot be split by wrapping its
+         parent — the buttons at its bottom stay unreachable however many columns there are. Let the
+         group wrap its own buttons too. */
+      .maplibregl-ctrl-group {
+        margin-bottom: 4px !important;
+        display: flex; flex-direction: column; flex-wrap: wrap;
+        max-height: calc(100vh - 16px);
+      }
+      .maplibregl-ctrl-top-right .maplibregl-ctrl-group { flex-wrap: wrap-reverse; }
       /* A flyout must not run off a short screen either. */
       .gd-basemap-menu, .gd-tools-menu { max-height: calc(100vh - 24px); overflow-y: auto; }
+    }
+
+    /* PORTRAIT: the cluster is a tall single column over a short map, and the bottom of it ends up
+       behind the narrative strip (the screenshot showed the globe and zoom buttons under it). Cap it
+       to the map area and let it wrap inward there too. */
+    @media (max-width: 640px) and (orientation: portrait) {
+      body[data-archetype="storymap"] .maplibregl-ctrl-top-right,
+      body[data-archetype="storymap"] .maplibregl-ctrl-top-left {
+        display: flex; flex-direction: column; flex-wrap: wrap-reverse;
+        max-height: calc(56vh - 16px);        /* the map is 100vh - 44vh of strip */
+        align-content: flex-end;
+      }
+      body[data-archetype="storymap"] .maplibregl-ctrl-top-left { align-content: flex-start; }
+      body[data-archetype="storymap"] .maplibregl-ctrl-group {
+        display: flex; flex-direction: column; flex-wrap: wrap-reverse;
+        max-height: calc(56vh - 20px);
+      }
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -1499,6 +1499,15 @@
       const up = document.createElement('div'); up.className = 'gd-story-more gd-story-up'; up.innerHTML = chevron('up');
       const down = document.createElement('div'); down.className = 'gd-story-more gd-story-down'; down.innerHTML = chevron('down');
       mw.appendChild(up); mw.appendChild(down);
+      function setArrowGlyphs() {
+        // The CSS moves these to the sides in portrait; the SVG has to follow, or a "next section"
+        // control points downwards while the strip scrolls sideways.
+        const sideways = isSideways();
+        up.innerHTML = chevron(sideways ? 'left' : 'up');
+        down.innerHTML = chevron(sideways ? 'right' : 'down');
+      }
+      setArrowGlyphs();
+      try { horizontal.addEventListener('change', setArrowGlyphs); } catch (e) {}
       function updateArrows() {
         if (isSideways()) {
           up.classList.toggle('show', panel.scrollLeft > 6);
@@ -1524,7 +1533,10 @@
     }
   }
   function chevron(dir) {
-    const pts = dir === 'up' ? '6 15 12 9 18 15' : '6 9 12 15 18 9';
+    const pts = dir === 'up' ? '6 15 12 9 18 15'
+      : dir === 'down' ? '6 9 12 15 18 9'
+      : dir === 'left' ? '15 6 9 12 15 18'
+      : '9 6 15 12 9 18';
     return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="' + pts + '"/></svg>';
   }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "0.3.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Follow-ups to #26, all reported from a real phone — the verification CI cannot do.

## 1. The chevrons still pointed up and down

My mistake in #26: the CSS moved them to the sides in portrait, but `chevron()` kept drawing the
vertical polylines. A "next section" control that points **down** while the strip scrolls
**sideways** is worse than no control. `chevron()` now takes `left`/`right`, and the glyphs are
redrawn when the media query flips, so rotating the phone corrects them.

## 2. Two columns were not enough in landscape

Two separate causes, which is why the first attempt only half-worked:

- The right-hand cluster is anchored to the **right edge**, so wrapping forwards put the second
  column **off-screen**. It now uses `wrap-reverse`, growing inward across the map.
- A `.maplibregl-ctrl-group` is a **single flex item**. A group taller than the screen can never be
  split by wrapping its parent, however many columns exist — the buttons at its bottom stay
  unreachable. The group now wraps its own buttons too.

## 3. The strip covered the bottom of the cluster in portrait

Capped the cluster to the map area (`56vh`, the strip being `44vh`) and wrapped it inward there as
well.

Deliberately **not** solved with `z-index`: raising the controls above the narrative would put
buttons on top of the text someone is reading, trading one overlap for a worse one. Keeping the
cluster inside the map is the honest fix.

## Validation

`node --check` and balanced braces — which is all that can be checked here. The rest is visual, on a
phone, in both orientations. `templates/shared` is a bind mount, so it lands on **re-publish**, no
rebuild.