### PR TITLE
fix(restore): a failed DROP EXTENSION postgis is not a failed restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Notable changes, newest first. Versions are **major.minor** — `v1.0`, `v1.1`, 
 `v2.0`. The minor number moves for anything shipped, features or fixes; the major changes when an
 upgrade needs manual work.
 
+## v1.3.1 — 2026-08-14
+
+A hotfix, and the first patch-level release. The major.minor convention above holds for planned
+work; a restore that aborts on any instance with a PostGIS layer should not have to wait for v1.4.
+
+- **A restore no longer fails on `DROP EXTENSION postgis`.** `pg_restore --clean` emits a DROP for
+  everything the dump creates, and Postgres refuses to drop PostGIS while geometry columns still
+  exist — which is true of every instance with a PostGIS vector layer. That refusal is the outcome
+  we want and pg_restore continues past it, but we classified it as a fatal error and aborted the
+  whole restore. It went unnoticed because the path was proven on a GeoParquet-only instance: no
+  geometry columns, nothing depending on the extension, so the DROP succeeded. **Not a v1.3
+  regression** — the bug predates it and was found when a demo instance's hourly reset hit it.
+- **`/health` reports the real version.** It returned a hardcoded `0.3.0`, which had been wrong
+  since v1.0 — on the one endpoint whose job is to say what is running.
+
 ## v1.3 — 2026-08-14
 
 ### Reach your instance without a browser

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -316,7 +316,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.3.0",
+    version="1.3.1",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # nginx proxies ONLY `/api/` to this app; every other path falls through to the SPA. At

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -501,4 +501,7 @@ if os.path.exists(templates_dir):
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "version": "0.3.0"}
+    # Read the app's version rather than repeating it: this string was still "0.3.0" through v1.0,
+    # v1.1, v1.2 and v1.3, so the one endpoint you hit to ask "what is running?" answered with a
+    # number that had been wrong for four releases.
+    return {"status": "ok", "version": app.version}

--- a/api/geodeploy/services/restore.py
+++ b/api/geodeploy/services/restore.py
@@ -89,6 +89,30 @@ def download(cfg, key: str, name: str, dest_path: str) -> int:
     return os.path.getsize(dest_path)
 
 
+#: Lines pg_restore prints under `--clean` that are NOT failures.
+#:
+#: `cannot drop extension postgis because other objects depend on it` is the one that matters. The
+#: dump contains `CREATE EXTENSION postgis`, so `--clean` emits a matching DROP — which Postgres
+#: refuses whenever the live database still holds geometry columns, i.e. on ANY instance with a
+#: PostGIS vector layer. The refusal is the outcome we want: PostGIS must stay installed, and
+#: pg_restore carries on regardless. Treating it as fatal aborted the whole restore.
+#:
+#: It went unnoticed because a GeoParquet-only instance has no geometry columns, so nothing depends
+#: on the extension and the DROP succeeds — the restore path was proven on exactly the instance
+#: shape that cannot hit this.
+_BENIGN_RESTORE_ERRORS = (
+    "does not exist",
+    "cannot drop extension",
+    "must be owner of extension",       # a managed Postgres refuses the drop for a different reason
+    "extension \"postgis\" already exists",
+)
+
+
+def _benign(line: str) -> bool:
+    low = line.lower()
+    return any(marker.lower() in low for marker in _BENIGN_RESTORE_ERRORS)
+
+
 def restore_database(dump_path: str) -> dict:
     """`pg_restore --clean --if-exists` over the live database.
 
@@ -109,10 +133,11 @@ def restore_database(dump_path: str) -> dict:
     # failure is judged on stderr content, not the code alone.
     err = (proc.stderr or "").strip()
     fatal = [l for l in err.splitlines() if "error:" in l.lower()
-             and "does not exist" not in l.lower()]
+             and not _benign(l)]
     if fatal:
         raise RuntimeError("pg_restore failed: " + "; ".join(fatal[:5]))
-    return {"warnings": len(err.splitlines()), "fatal": 0}
+    tolerated = [l for l in err.splitlines() if "error:" in l.lower()]
+    return {"warnings": len(err.splitlines()), "fatal": 0, "tolerated": len(tolerated)}
 
 
 def restore_objects(cfg, key: str, on_progress=None) -> dict:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**Broke the demo instance's hourly reset**, and would break a restore onto any instance holding a
PostGIS vector layer.

```
pg_restore: error: could not execute query:
ERROR: cannot drop extension postgis because other objects depend on it
```

`pg_restore --clean` emits a DROP for everything the dump creates, including `DROP EXTENSION
postgis`. Postgres refuses that whenever the live database still has geometry columns — every
instance with a PostGIS layer. The refusal is **the outcome we want** (PostGIS must stay installed)
and pg_restore continues past it; we were the ones turning it into an exception, because
`restore_database` treated any stderr line containing `error:` as fatal.

## Why it was never caught

The restore path was proven on a **GeoParquet-only** instance. No geometry columns → nothing depends
on the extension → the DROP succeeds. The one instance shape that cannot hit this bug is the shape
it was tested on.

This is **not a v1.3 regression** — `services/restore.py` is unchanged since well before it.

## The fix

Benign lines are named explicitly rather than pattern-guessed: the extension drop, an ownership
refusal from a managed Postgres, and "already exists". The count of tolerated errors is reported in
the run detail, so a restore that skated past something stays visible instead of being silently
swallowed.

## Also

`/health` returned a hardcoded `"version": "0.3.0"` — wrong through v1.0, v1.1, v1.2 **and** v1.3,
on the one endpoint whose job is to answer "what is running?". It now reads the app's own version.
That is how the demo's state was misread during diagnosis.