### PR TITLE
docs(roadmap): dashboards as a fourth portal experience

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -283,8 +283,16 @@ which parts are worth having and where the numbers come from.
       `<iframe>`, and readable on a phone, where a dashboard is mostly numbers and the map is
       smallest.
 
-Worth settling before building: whether an element's data source is a LAYER or a saved query, since
-that decides whether a dashboard can outlive the layer it was built on.
+- [ ] **Linked or detached, chosen per dashboard and explained where the choice is made.** A
+      *linked* dashboard reads its layers live, so when the data is updated the numbers move with
+      it — that is the interesting one, and the default. A *detached* dashboard is built on saved
+      queries: it keeps reporting what it reported, and changes at the source do not reach it,
+      which is what a published figure sometimes has to do. The distinction has to be stated in the
+      editor in those terms, because "layer or saved query" is a storage detail and "does this
+      update itself?" is the actual question being asked.
+
+The linked case is the one that earns the feature: a dashboard that goes stale the moment the data
+moves is a screenshot with extra steps.
 
 </div>
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,6 +253,42 @@ is the rest of the round trip, not yet scheduled.</p>
 </div>
 
 <div class="gd-rel" markdown>
+### A fourth experience: dashboards
+<span class="gd-when">Planned</span>
+
+<p class="gd-goal">Today a portal is a map with panels around it. A dashboard inverts that: the map
+becomes one small element among charts, indicators and filters, for the questions a reader asks of
+the DATA rather than of the geography.</p>
+
+The shape is well established — indicators, charts, selectors and a map, where interacting with one
+element filters the others — so the work is less about inventing an interface than about deciding
+which parts are worth having and where the numbers come from.
+
+- [ ] **The archetype itself**: `dashboard` alongside webmap / storymap / catalog, with a layout of
+      resizable cells rather than a map plus panels. `resolve_layout` already carries archetypes and
+      regions, so this is a new layout rather than a new renderer.
+- [ ] **Elements**: indicator (one number, optionally against a target), chart (bar, line, pie),
+      table, text, and the map. Each bound to a layer and an aggregate — count, sum, mean, min, max,
+      grouped by a field.
+- [ ] **Cross-filtering — the thing that makes a dashboard a dashboard.** Selecting a bar, a table
+      row or features on the map filters every other element. Without it this is a page of pictures.
+- [ ] **Filter by the map's extent**, so panning re-computes the numbers for what is on screen.
+- [ ] **Selectors** — a dropdown, a date range, a search box — that filter elements without needing
+      a click on the map.
+- [ ] **Aggregates computed server-side.** `/field-stats` already does this for both backends
+      (SQL for PostGIS, DuckDB for GeoParquet); a dashboard needs the same idea generalised to
+      grouped aggregates with a filter. Sending a million features to the browser to count them is
+      the failure mode to design against.
+- [ ] **Published like any other portal** — one URL, the four access tiers, embeddable in an
+      `<iframe>`, and readable on a phone, where a dashboard is mostly numbers and the map is
+      smallest.
+
+Worth settling before building: whether an element's data source is a LAYER or a saved query, since
+that decides whether a dashboard can outlive the layer it was built on.
+
+</div>
+
+<div class="gd-rel" markdown>
 ### Cartography and portal tools
 <span class="gd-when">Planned</span>
 


### PR DESCRIPTION
A portal today is a map with panels around it. A **dashboard** inverts that — the map becomes one
small element among charts, indicators and filters — for the questions a reader asks of the **data**
rather than of the geography.

Roadmap only; nothing is built. Written from how established spatial dashboards work, so the entry
names the parts that matter rather than "add charts":

- **Elements** bound to a layer and an aggregate: indicator, chart, table, text, map.
- **Cross-filtering**, which is the defining feature — selecting a bar, a table row or features on
  the map filters every other element. Without it this is a page of pictures.
- **Filter by map extent**, so panning re-computes the numbers for what is on screen.
- **Selectors** — dropdown, date range, search — that filter without needing a map click.
- **Aggregates computed server-side.** `/field-stats` already does exactly this for both backends
  (SQL for PostGIS, DuckDB for GeoParquet); the work is generalising it to *grouped* aggregates
  with a filter. Sending a million features to the browser to count them is the failure mode to
  design against.
- **Published like any other portal**: one URL, the four access tiers, embeddable, and readable on
  a phone — where a dashboard is mostly numbers and the map is smallest.

Also recorded: the question worth settling **before** building — whether an element's data source is
a *layer* or a *saved query*, since that decides whether a dashboard can outlive the layer it was
built on.

`resolve_layout` already carries archetypes and regions, so this is a new layout rather than a new
renderer.

Docs build clean under `--strict`.