### PR TITLE
fix(api): one NaN must not empty every list

### DIFF
--- a/api/geodeploy/json_safe.py
+++ b/api/geodeploy/json_safe.py
@@ -1,0 +1,75 @@
+"""A JSON response that cannot be broken by a number.
+
+JSON has no literal for NaN or infinity, and Starlette serialises with `allow_nan=False`. The
+ValueError that follows is raised while the RESPONSE is being built — after the handler has already
+returned successfully — so the failure is never "one bad value": the whole endpoint returns 500 and
+the client sees nothing at all. On a live instance this emptied My Data, took down `/api/public`,
+`/api/ogc/collections` and a layer's `/legend` together, and left the QGIS plugin reporting
+"HTTP 500" with no layers, all from a single uploaded raster whose nodata was NaN.
+
+Guarding individual fields cannot close this. A non-finite float can arrive from anywhere:
+
+  * a float32 raster's nodata, which is NaN more often than not;
+  * bounds, when reprojection fails to converge;
+  * classification breaks stored in a layer's style — `json.dumps` WRITES NaN by default and
+    `json.loads` reads it back without complaint, so it round-trips into the database unnoticed;
+  * any float column in the user's own data, served through OGC API - Features.
+
+That last one is the argument for fixing it here: user data is not ours to validate, and a column
+of measurements with gaps in it is not an error.
+
+The scrub is not free, so it is not paid unless it is needed: serialise strictly first — the fast C
+path, and the overwhelmingly common case — and only walk the content when that raises. A response
+with no non-finite float in it costs exactly what it did before.
+
+`null` is the right substitute. It is what every JSON dialect that has faced this chose (orjson,
+simplejson's `ignore_nan`, JavaScript's own `JSON.stringify`), it parses everywhere, and a client
+that checks for null already handles "no value" — which is what NaN meant.
+"""
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+from starlette.responses import JSONResponse
+
+
+def scrub(value: Any) -> Any:
+    """Replace every non-finite float with None, structurally.
+
+    Containers are rebuilt rather than mutated: the content may be a cached object, or a Pydantic
+    dump someone else still holds a reference to.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: scrub(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [scrub(v) for v in value]
+    return value
+
+
+class SafeJSONResponse(JSONResponse):
+    """`JSONResponse`, except a NaN costs a value instead of the whole response."""
+
+    def render(self, content: Any) -> bytes:
+        try:
+            return json.dumps(
+                content,
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=None,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except ValueError:
+            # Only reachable when the content holds NaN or +/-Infinity. Walk it, then serialise
+            # strictly again — so anything the scrub misses still fails loudly rather than
+            # emitting invalid JSON that a browser would refuse to parse.
+            return json.dumps(
+                scrub(content),
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=None,
+                separators=(",", ":"),
+            ).encode("utf-8")

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -9,6 +9,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import Response
 
 from .config import get_settings
+from .json_safe import SafeJSONResponse
 from . import database
 from .database import Base
 from .routers import (public, setup, auth, auth_oidc, portals, stac, templates, admin, basemaps, users,
@@ -319,6 +320,9 @@ app = FastAPI(
     version="1.3.1",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
+    # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to
+    # 500 the whole endpoint while it was being serialised. See geodeploy/json_safe.py.
+    default_response_class=SafeJSONResponse,
     # nginx proxies ONLY `/api/` to this app; every other path falls through to the SPA. At
     # FastAPI's defaults (`/openapi.json`, `/docs`) the schema was therefore unreachable from
     # outside — the request returned the UI's index.html with content-type text/html. That broke

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -440,7 +440,7 @@ async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
     layer" work in GeoLibre/QGIS. Bounds come from the stored EPSG:4326 bbox (see
     `cog_converter.inspect` — it reprojects); when a legacy row has none we ask TiTiler once."""
     import json
-    from fastapi.responses import JSONResponse
+    from ...json_safe import SafeJSONResponse
 
     result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
     layer = result.scalar_one_or_none()
@@ -477,7 +477,7 @@ async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
     if bbox:
         tj["bounds"] = bbox
         tj["center"] = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2, 0]
-    return JSONResponse(tj, headers={"Access-Control-Allow-Origin": "*",
+    return SafeJSONResponse(tj, headers={"Access-Control-Allow-Origin": "*",
                                      "Cache-Control": "public, max-age=300"})
 
 

--- a/api/geodeploy/routers/data/sources.py
+++ b/api/geodeploy/routers/data/sources.py
@@ -7,7 +7,7 @@ CORS). The provider's licence applies — `attribution` is surfaced on the map.
 import json
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import JSONResponse
+from ...json_safe import SafeJSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -150,4 +150,4 @@ async def source_features(source_id: int, db: AsyncSession = Depends(get_db)):
         gj = await ext.fetch_wfs_geojson(src)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(502, f"Upstream WFS error: {exc}") from exc
-    return JSONResponse(gj)
+    return SafeJSONResponse(gj)

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -649,7 +649,7 @@ async def vector_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
     It carries the absolute {z}/{x}/{y} tile URL (https-aware), bounds, and the `vector_layers` entry
     with the source-layer name + fields — so the consumer doesn't have to know any of that. CORS-open
     (public metadata), like /tiles/."""
-    from fastapi.responses import JSONResponse
+    from ...json_safe import SafeJSONResponse
 
     result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
     layer = result.scalar_one_or_none()
@@ -683,7 +683,7 @@ async def vector_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
     if bbox:
         tj["bounds"] = bbox
         tj["center"] = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2, 0]
-    return JSONResponse(tj, headers={"Access-Control-Allow-Origin": "*",
+    return SafeJSONResponse(tj, headers={"Access-Control-Allow-Origin": "*",
                                      "Cache-Control": "public, max-age=300"})
 
 

--- a/api/geodeploy/routers/ogcapi.py
+++ b/api/geodeploy/routers/ogcapi.py
@@ -24,7 +24,7 @@ import json
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
+from ..json_safe import SafeJSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.concurrency import run_in_threadpool
@@ -156,7 +156,7 @@ def _collection(layer, base: str) -> dict:
 @router.get("")
 async def landing(request: Request):
     base = _base(request)
-    return JSONResponse({
+    return SafeJSONResponse({
         "title": "GeoDeploy — OGC API - Features",
         "description": "Publicly shared vector layers of this GeoDeploy instance, served as OGC "
                        "API - Features collections (GeoJSON, EPSG:4326).",
@@ -179,13 +179,13 @@ async def landing(request: Request):
 
 @router.get("/conformance")
 async def conformance():
-    return JSONResponse({"conformsTo": CONFORMS}, headers=CORS)
+    return SafeJSONResponse({"conformsTo": CONFORMS}, headers=CORS)
 
 
 @router.get("/collections")
 async def collections(request: Request, db: AsyncSession = Depends(get_db)):
     base = _base(request)
-    return JSONResponse({
+    return SafeJSONResponse({
         "collections": [_collection(l, base) for l in await _public_layers(db)],
         "links": [
             {"rel": "self", "href": f"{_root(base)}/collections", "type": "application/json"},
@@ -197,7 +197,7 @@ async def collections(request: Request, db: AsyncSession = Depends(get_db)):
 @router.get("/collections/{cid}")
 async def collection(cid: str, request: Request, db: AsyncSession = Depends(get_db)):
     layer = await _get_layer(cid, db)
-    return JSONResponse(_collection(layer, _base(request)), headers=CORS)
+    return SafeJSONResponse(_collection(layer, _base(request)), headers=CORS)
 
 
 # ── Features ─────────────────────────────────────────────────────────────────────────────────
@@ -246,7 +246,7 @@ async def items(cid: str, request: Request, bbox: str | None = None, limit: int 
     }
     if matched is not None:
         doc["numberMatched"] = matched
-    return JSONResponse(doc, media_type=GEOJSON, headers=CORS)
+    return SafeJSONResponse(doc, media_type=GEOJSON, headers=CORS)
 
 
 @router.get("/collections/{cid}/items/{fid}")
@@ -266,7 +266,7 @@ async def item(cid: str, fid: str, request: Request, db: AsyncSession = Depends(
         {"rel": "self", "href": f"{_root(base)}/collections/{cid}/items/{fid}", "type": GEOJSON},
         {"rel": "collection", "href": f"{_root(base)}/collections/{cid}", "type": "application/json"},
     ]
-    return JSONResponse(feature, media_type=GEOJSON, headers=CORS)
+    return SafeJSONResponse(feature, media_type=GEOJSON, headers=CORS)
 
 
 # ── PostGIS backend ──────────────────────────────────────────────────────────────────────────

--- a/api/geodeploy/schemas.py
+++ b/api/geodeploy/schemas.py
@@ -1,7 +1,34 @@
 import json
+import math
 from datetime import datetime
-from typing import Any, Literal
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated, Any, Literal
+from pydantic import AfterValidator, BaseModel, EmailStr, Field, field_validator
+
+
+# ── Non-finite floats ────────────────────────────────────────────────────────
+# NaN and infinity have no JSON literal, and Starlette serialises responses with `allow_nan=False`.
+# So ONE of them anywhere in a LIST response raises ValueError while the response is being built:
+# the endpoint 500s entirely and the client sees no layers at all, not one bad layer. A float32
+# GeoTIFF's nodata is very often NaN — which is how a single upload emptied My Data — and
+# reprojecting bounds can yield inf. Both are scrubbed on the way out.
+
+def _finite(value: float | None) -> float | None:
+    """A number that cannot be transmitted is worth less than no number at all."""
+    if value is None:
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _finite_bbox(value: list[float] | None) -> list[float] | None:
+    """Bounds are all-or-nothing: three good corners and one NaN cannot be fitted to, and a
+    partial box would silently mis-zoom a map rather than fall back to a default view."""
+    if not value:
+        return value
+    return value if all(isinstance(v, (int, float)) and math.isfinite(v) for v in value) else None
+
+
+FiniteFloat = Annotated[float | None, AfterValidator(_finite)]
+BBox = Annotated[list[float] | None, AfterValidator(_finite_bbox)]
 
 
 # ── Setup ────────────────────────────────────────────────────────────────────
@@ -387,7 +414,7 @@ class VectorLayerOut(BaseModel):
     schema_name: str
     crs: str | None
     feature_count: int | None
-    bbox: list[float] | None
+    bbox: BBox
     columns: list[dict[str, str]] | None
     geometry_type: str | None
     file_size: int | None
@@ -444,9 +471,9 @@ class RasterLayerOut(BaseModel):
     name: str
     s3_key: str
     crs: str | None
-    bbox: list[float] | None
+    bbox: BBox
     band_count: int | None
-    nodata_value: float | None
+    nodata_value: FiniteFloat
     # Whether a zoomed-out tile is cheap for this file (issue #17). Exposed so the CLI and a
     # plugin can explain why a layer does or does not draw at low zoom, rather than the
     # answer living only inside the published style.
@@ -503,7 +530,7 @@ class ExternalSourceOut(BaseModel):
     image_format: str | None
     attribution: str | None
     geometry_type: str | None
-    bbox: list[float] | None
+    bbox: BBox
     visibility: str = "organization"
     created_at: datetime
     tile_url: str | None = None       # raster sources: MapLibre tiles[] template

--- a/api/geodeploy/services/cog_converter.py
+++ b/api/geodeploy/services/cog_converter.py
@@ -1,4 +1,5 @@
 """Cloud-Optimised GeoTIFF conversion and inspection using rasterio."""
+import math
 import os
 import tempfile
 
@@ -107,11 +108,19 @@ def _read_meta(ds) -> dict:
             bbox = [b.left, b.bottom, b.right, b.top]  # fall back to source CRS
     else:
         bbox = [b.left, b.bottom, b.right, b.top]
+    if not all(math.isfinite(v) for v in bbox):
+        bbox = [b.left, b.bottom, b.right, b.top]  # reprojection produced inf/NaN — keep source CRS
+    # A float raster's nodata is very often NaN, which cannot be transmitted as JSON and is not a
+    # value anyone can act on. Store nothing rather than a number that breaks every response that
+    # includes this layer. TiTiler reads nodata from the file itself, so nothing renders differently.
+    nodata_f = float(nodata) if nodata is not None else None
+    if nodata_f is not None and not math.isfinite(nodata_f):
+        nodata_f = None
     return {
         "crs": crs_str,
         "bbox": bbox,
         "band_count": ds.count,
-        "nodata_value": float(nodata) if nodata is not None else None,
+        "nodata_value": nodata_f,
         "width": ds.width,
         "height": ds.height,
         # Overview decimation factors ([2, 4, 8, …]) of band 1. What they answer is "how cheaply can

--- a/api/tests/test_nonfinite_json.py
+++ b/api/tests/test_nonfinite_json.py
@@ -1,0 +1,99 @@
+"""One NaN must not empty a whole list.
+
+A float32 GeoTIFF's nodata is very often NaN. Postgres stores it without complaint, but JSON has
+no literal for it and Starlette serialises with `allow_nan=False` — so the ValueError is raised
+while the RESPONSE is being built, after the handler has returned successfully. The client does
+not get one broken layer among many; it gets HTTP 500 and no layers at all, which is how a single
+raster upload made My Data look empty for every kind of layer at once.
+
+These tests assert at the two places it can be stopped: the metadata read at ingest (so nothing
+non-finite is ever stored) and the response schema (so rows already in the database, written by
+earlier versions, still serialise).
+"""
+import json
+import math
+
+from starlette.responses import JSONResponse
+import pytest
+
+from geodeploy.schemas import RasterLayerOut, VectorLayerOut
+
+
+def _raster(**over):
+    base = dict(
+        id=1, name="dem", s3_key="rasters/dem.tif", crs="EPSG:4326",
+        bbox=[11.0, 55.0, 12.0, 56.0], band_count=1, nodata_value=None,
+        file_size=1024, status="ready", error_message=None, default_style=None,
+        created_at="2026-08-15T00:00:00",
+    )
+    base.update(over)
+    return base
+
+
+def test_nan_nodata_does_not_reach_json():
+    """The exact shape of the reported failure: nodata=NaN on one raster."""
+    obj = RasterLayerOut(**_raster(nodata_value=float("nan")))
+    assert obj.nodata_value is None
+    # The real assertion is not the None — it is that the response can be BUILT.
+    JSONResponse(content=json.loads(obj.model_dump_json()))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_every_non_finite_float_is_dropped(bad):
+    assert RasterLayerOut(**_raster(nodata_value=bad)).nodata_value is None
+
+
+def test_finite_nodata_is_preserved():
+    """The guard must not eat legitimate values — -9999 is the commonest nodata there is."""
+    assert RasterLayerOut(**_raster(nodata_value=-9999.0)).nodata_value == -9999.0
+    assert RasterLayerOut(**_raster(nodata_value=0.0)).nodata_value == 0.0
+
+
+def test_bbox_is_all_or_nothing():
+    """Three good corners and one NaN cannot be fitted to. Dropping the whole box makes the map
+    fall back to a default view; keeping a partial one would silently mis-zoom."""
+    assert RasterLayerOut(**_raster(bbox=[11.0, 55.0, float("nan"), 56.0])).bbox is None
+    assert RasterLayerOut(**_raster(bbox=[11.0, 55.0, 12.0, 56.0])).bbox == [11.0, 55.0, 12.0, 56.0]
+
+
+def test_vector_bbox_is_guarded_too():
+    """Reprojection can yield inf for any layer kind, not only rasters."""
+    v = VectorLayerOut(
+        id=1, name="roads", table_name="t", schema_name="s", crs="EPSG:4326",
+        feature_count=5, bbox=[float("-inf"), 55.0, 12.0, 56.0], columns=None,
+        geometry_type="LineString", file_size=1, storage_backend="postgis",
+        status="ready", error_message=None, default_style=None,
+        created_at="2026-08-15T00:00:00",
+    )
+    assert v.bbox is None
+
+
+def test_list_response_survives_one_bad_row():
+    """The regression itself: a good layer must still arrive when a bad one shares the list."""
+    rows = [RasterLayerOut(**_raster(id=1, nodata_value=float("nan"))),
+            RasterLayerOut(**_raster(id=2, name="ok", nodata_value=-9999.0))]
+    body = JSONResponse(content=[json.loads(r.model_dump_json()) for r in rows]).body
+    assert len(json.loads(body)) == 2
+
+
+def test_metadata_never_returns_non_finite():
+    """Root cause, at the ingest end: rasterio hands back nan for a float32 nodata."""
+    from geodeploy.services.cog_converter import _read_meta
+
+    class _Bounds:
+        left, bottom, right, top = 11.0, 55.0, 12.0, 56.0
+
+    class _DS:
+        crs = None
+        bounds = _Bounds()
+        nodata = float("nan")
+        count = 1
+        width = height = 256
+        dtypes = ("float32",)
+
+        def overviews(self, _b):
+            return []
+
+    meta = _read_meta(_DS())
+    assert meta["nodata_value"] is None
+    assert all(math.isfinite(v) for v in meta["bbox"])

--- a/api/tests/test_nonfinite_json.py
+++ b/api/tests/test_nonfinite_json.py
@@ -97,3 +97,47 @@ def test_metadata_never_returns_non_finite():
     meta = _read_meta(_DS())
     assert meta["nodata_value"] is None
     assert all(math.isfinite(v) for v in meta["bbox"])
+
+
+# ── The response layer ────────────────────────────────────────────────────────
+# Field guards cannot close this: a non-finite float also arrives from stored style breaks and
+# from the user's OWN data, served through OGC API - Features. These cover the general case.
+
+def test_safe_response_survives_nan_anywhere():
+    from geodeploy.json_safe import SafeJSONResponse
+
+    body = SafeJSONResponse({
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature",
+                      "properties": {"depth": float("nan"), "name": "site 1", "n": 3},
+                      "geometry": {"type": "Point", "coordinates": [11.0, 55.0]}}],
+    }).body
+    parsed = json.loads(body)                      # strict: json.loads rejects nothing, but…
+    assert "NaN" not in body.decode()              # …the wire must not carry a bare NaN token
+    props = parsed["features"][0]["properties"]
+    assert props["depth"] is None
+    assert props["name"] == "site 1" and props["n"] == 3
+
+
+def test_safe_response_leaves_ordinary_content_untouched():
+    """The scrub is only paid when it is needed; normal responses must be byte-identical."""
+    from starlette.responses import JSONResponse
+    from geodeploy.json_safe import SafeJSONResponse
+
+    content = {"a": [1, 2.5, "x", None, True], "b": {"c": -0.0}}
+    assert SafeJSONResponse(content).body == JSONResponse(content).body
+
+
+def test_scrub_handles_nesting_and_infinity():
+    from geodeploy.json_safe import scrub
+
+    assert scrub({"a": [float("inf"), {"b": float("-inf")}]}) == {"a": [None, {"b": None}]}
+    assert scrub((1.0, float("nan"))) == [1.0, None]
+
+
+def test_the_app_uses_it_by_default():
+    """Wiring, not behaviour: without this the guard silently protects nothing."""
+    from geodeploy.json_safe import SafeJSONResponse
+    from geodeploy.main import app
+
+    assert app.router.default_response_class.__name__ == SafeJSONResponse.__name__


### PR DESCRIPTION
Uploading a float32 GeoTIFF took a live instance down. My Data showed **nothing** — no rasters and
no vectors — and several public surfaces returned 500 together:

```
GET /api/data/raster      500
GET /api/public           500
GET /api/ogc/collections  500
GET /api/data/vector/{id}/legend  500
ValueError: Out of range float values are not JSON compliant: nan
```

## Why one value breaks a whole endpoint

JSON has no literal for NaN, and Starlette serialises with `allow_nan=False`. The `ValueError` is
raised while the **response is being built** — after the handler has already returned successfully.
The client therefore does not get one broken layer among many; it gets 500 and an empty workspace.

## Why field guards are not enough

A non-finite float arrives from places outside our control:

- a float32 raster's **nodata**, which is NaN more often than not — the reported trigger;
- **bounds**, when reprojection fails to converge;
- **classification breaks in a stored style** — `json.dumps` writes NaN by default and `json.loads`
  reads it back without complaint, so it round-trips into the database unnoticed;
- **any float column in the user's own data**, served through OGC API - Features. A column of
  measurements with gaps is not an error, and validating user data is not our place.

## The fix

**At the response layer**, where all of those paths meet. `SafeJSONResponse` serialises strictly
first — the fast C path, and virtually every response — and only walks the content when that
raises, substituting `null`. A response with no non-finite float costs exactly what it did before,
and is byte-identical (asserted in a test).

Routes that build `JSONResponse` by hand (OGC API, TileJSON, the GeoJSON proxy) were converted too:
`default_response_class` does not reach them, and they were exactly the ones failing.

**At the source**, ingest no longer stores a non-finite nodata or bbox. TiTiler reads nodata from
the file itself, so nothing renders differently.

**In the schemas**, so rows already written by earlier versions serialise instead of 500ing — this
is what heals an affected instance on deploy, with no data surgery. Bounds are all-or-nothing:
three good corners and one NaN cannot be fitted to, and a partial box would silently mis-zoom a map
rather than fall back to a default view.

## Verification

- 7 of the 9 field-level tests fail on the code before this change.
- 13 new tests, including that ordinary responses stay byte-identical.
- 116 pass across every endpoint rewired (`test_ogcapi`, `test_public_index`, `test_legend_endpoint`,
  `test_cors_public_surface`, `test_share_link_scope`).
- Full suite: 669 passed. The 7 failures are updater/backup tests that need a `.git` in the mount;
  they fail identically without this change.