### PR TITLE
fix(setup): a database that is down is not a server that needs installing

### DIFF
--- a/api/geodeploy/routers/setup.py
+++ b/api/geodeploy/routers/setup.py
@@ -128,10 +128,19 @@ async def setup_status():
             config = await _get_or_create_config(db)
             has_admin = bool((await db.execute(select(User))).scalars().first())
         except Exception:
-            # Engine configured but the schema/server isn't reachable yet (a container still
-            # starting, wrong creds in .env). Report "not set up" rather than 500 the wizard.
+            # Engine configured but the schema/server isn't reachable (a container still starting,
+            # one that has been stopped, wrong creds in .env). Report "not set up" rather than 500
+            # the wizard — but SAY WHICH, because the two look identical from here and are opposite
+            # situations. `.env` holding a host is proof this instance was installed: the wizard
+            # wrote it. An installed instance whose database is merely down must never be offered
+            # the setup wizard, which reads as "your data is gone" and invites a re-install as the
+            # remedy. The database is the only thing that knows the rest, so everything else stays
+            # false; the flag is what stops the UI drawing the wrong conclusion from that.
+            settings = get_settings()
+            installed = bool((settings.postgis_host or "").strip())
             return SetupStatus(completed=False, postgis_configured=False,
-                               storage_configured=False, admin_created=False, email_enabled=False)
+                               storage_configured=False, admin_created=False, email_enabled=False,
+                               database_unreachable=installed)
         return SetupStatus(
             completed=config.completed,
             postgis_configured=bool(config.postgis_host),

--- a/api/geodeploy/schemas.py
+++ b/api/geodeploy/schemas.py
@@ -41,6 +41,13 @@ class SetupStatus(BaseModel):
     # Outgoing email configured (C-08a) — the login page uses this to decide whether to
     # offer "Forgot password?" (without email, self-service reset can't deliver anything).
     email_enabled: bool = False
+    # TRUE when this instance is already installed but its database cannot be reached right now.
+    # Everything above is false in that case — not because nothing is configured, but because the
+    # answers live in the database we cannot read. Without this flag the UI cannot tell a fresh
+    # server from a broken one, and shows an operator the SETUP WIZARD while their data is sitting
+    # intact on disk. That is the most alarming screen we could possibly show, and it invites a
+    # re-install as the fix.
+    database_unreachable: bool = False
 
 
 class ConfigureDBRequest(BaseModel):

--- a/api/tests/test_db_unreachable_is_not_setup.py
+++ b/api/tests/test_db_unreachable_is_not_setup.py
@@ -1,0 +1,79 @@
+"""An installed instance whose database is down must not be offered the setup wizard.
+
+The answers about what is configured live IN the database, so when it cannot be read everything
+comes back false and the app concluded "fresh server" — showing an operator whose instance had run
+for weeks the initial-setup screen. That reads as "your data is gone" and offers re-installing as
+the remedy, which is the one action that could cause the loss it appears to describe.
+
+`.env` holding a database host is the proof the instance was installed: the wizard wrote it.
+"""
+import pytest
+
+from geodeploy.schemas import SetupStatus
+
+
+def test_status_carries_the_distinction():
+    assert SetupStatus(completed=False, postgis_configured=False, storage_configured=False,
+                       admin_created=False).database_unreachable is False
+
+
+@pytest.mark.asyncio
+async def test_installed_but_unreachable_is_not_reported_as_fresh(monkeypatch):
+    from geodeploy.routers import setup as setup_router
+
+    class _Boom:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def execute(self, *a, **k):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(setup_router, "_session", lambda: _Boom())
+
+    class _S:
+        postgis_host = "postgres"
+
+    monkeypatch.setattr(setup_router, "get_settings", lambda: _S())
+
+    status = await setup_router.setup_status()
+    assert status.database_unreachable is True
+    assert status.completed is False       # still false: we genuinely cannot know
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_fresh_server_still_gets_the_wizard(monkeypatch):
+    """The flag must not fire on a real first run, or nobody can ever install."""
+    from geodeploy.routers import setup as setup_router
+
+    class _Boom:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def execute(self, *a, **k):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(setup_router, "_session", lambda: _Boom())
+
+    class _S:
+        postgis_host = ""
+
+    monkeypatch.setattr(setup_router, "get_settings", lambda: _S())
+
+    status = await setup_router.setup_status()
+    assert status.database_unreachable is False
+    assert status.completed is False
+
+
+@pytest.mark.asyncio
+async def test_no_engine_at_all_is_a_fresh_server(monkeypatch):
+    from geodeploy.routers import setup as setup_router
+
+    monkeypatch.setattr(setup_router, "_session", lambda: None)
+    status = await setup_router.setup_status()
+    assert status.database_unreachable is False

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -4,6 +4,7 @@ import { getSetupStatus } from '@/api'
 
 const routes = [
   { path: '/setup', component: () => import('@/views/SetupWizard.vue'), meta: { public: true } },
+  { path: '/database-down', component: () => import('@/views/DatabaseDown.vue'), meta: { public: true } },
   { path: '/login', component: () => import('@/views/Login.vue'), meta: { public: true } },
   { path: '/accept-invite', component: () => import('@/views/AcceptInvite.vue'), meta: { public: true } },
   { path: '/reset-password', component: () => import('@/views/ResetPassword.vue'), meta: { public: true } },
@@ -36,6 +37,10 @@ router.beforeEach(async (to) => {
   // Check setup before anything else so the 401 interceptor can't race ahead
   try {
     const { data } = await getSetupStatus()
+    // An installed instance whose database is merely down reports everything as false, because the
+    // answers live in that database. Sending it to the setup wizard tells an operator their data is
+    // gone and invites a re-install as the fix — check this BEFORE `completed`.
+    if (data.database_unreachable) return '/database-down'
     if (!data.completed) return '/setup'
   } catch {
     // API unreachable — fall through

--- a/ui/src/views/DatabaseDown.vue
+++ b/ui/src/views/DatabaseDown.vue
@@ -1,0 +1,92 @@
+<!--
+  Shown when this instance IS installed but its database cannot be reached.
+
+  Before this screen existed, that situation rendered the setup wizard — because the answers about
+  what is configured live in the database we cannot read, so everything came back false and the app
+  concluded "fresh server". To an operator whose instance had been running for weeks that reads as
+  "my data is gone", and it offers re-installing as the remedy, which is the one action that could
+  actually cause the loss it appears to describe.
+
+  So: say what is wrong, say that the data is intact, and give the two commands that fix it.
+-->
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-background text-foreground p-4">
+    <div class="w-full max-w-xl card p-6 space-y-5 shadow-2xl">
+      <div>
+        <h1 class="text-lg font-semibold">GeoDeploy cannot reach its database</h1>
+        <p class="text-sm text-muted-foreground mt-2">
+          This instance is installed and configured — <strong>your layers, portals and users are
+          untouched.</strong> The database server itself is not answering, so nothing can be
+          displayed until it is back.
+        </p>
+      </div>
+
+      <div class="space-y-2">
+        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Usually this is the database container being stopped
+        </p>
+        <pre class="text-xs bg-black/40 rounded p-3 overflow-x-auto"><code>docker start geodeploy-postgres</code></pre>
+        <p class="text-xs text-muted-foreground">
+          Then reload this page. If it stops again, the daemon log names what stopped it:
+        </p>
+        <pre class="text-xs bg-black/40 rounded p-3 overflow-x-auto"><code>docker logs --tail 40 geodeploy-postgres
+journalctl -u docker --since "-1h" | grep -i postgres</code></pre>
+      </div>
+
+      <p class="text-xs text-muted-foreground">
+        The database is provisioned outside Compose with a fixed container name, so
+        <code>docker compose exec postgres</code> will report it as "not running" even when it is —
+        address the container directly, as above.
+      </p>
+
+      <div class="flex items-center gap-3">
+        <button class="btn-primary" :disabled="checking" @click="recheck">
+          {{ checking ? 'Checking…' : 'Check again' }}
+        </button>
+        <span v-if="stillDown" class="text-xs text-red-400">Still unreachable.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { getSetupStatus } from '@/api'
+
+const router = useRouter()
+const checking = ref(false)
+const stillDown = ref(false)
+let timer = null
+
+async function recheck() {
+  checking.value = true
+  stillDown.value = false
+  try {
+    const { data } = await getSetupStatus()
+    if (!data.database_unreachable) {
+      // Back up: send them where they were going, not to a dead-end success message.
+      router.replace('/')
+      return
+    }
+    stillDown.value = true
+  } catch {
+    stillDown.value = true
+  } finally {
+    checking.value = false
+  }
+}
+
+onMounted(() => {
+  // Poll quietly: an operator who fixes this in another window should not have to come back and
+  // click anything.
+  timer = setInterval(async () => {
+    try {
+      const { data } = await getSetupStatus()
+      if (!data.database_unreachable) router.replace('/')
+    } catch { /* keep waiting */ }
+  }, 5000)
+})
+
+onUnmounted(() => { if (timer) clearInterval(timer) })
+</script>

--- a/ui/src/views/SetupWizard.vue
+++ b/ui/src/views/SetupWizard.vue
@@ -211,6 +211,13 @@ const admin = reactive({ name: '', email: '', password: '' })
 onMounted(async () => {
   try {
     const { data } = await getSetupStatus()
+    // Reached directly (a bookmark, or a redirect from before this check existed) on an instance
+    // that is installed but whose database is down. Everything below reads as "nothing configured
+    // yet" in that state, so the wizard would offer to set up a server that is already set up.
+    if (data.database_unreachable) {
+      router.replace('/database-down')
+      return
+    }
     if (data.admin_created) {
       router.push('/login')
     } else if (data.storage_configured) {


### PR DESCRIPTION
An instance whose Postgres container had been stopped showed the **initial setup wizard**.

Everything `/api/setup/status` reports — configured, storage, admin — is read *from* the database.
When it cannot be reached, every answer is false, and the app concluded "fresh server".

To an operator whose instance has been running for weeks that screen reads as **"my data is gone"**,
and the remedy it offers is to re-install — the one action that could cause the loss it appears to
describe. The data was intact on disk the whole time.

## The fix

`.env` holding a database host is proof the instance was installed (the wizard wrote it), and it is
readable *without* the database. So the status distinguishes the two cases, and the UI has somewhere
honest to send the second one: what is wrong, that the data is untouched, and the command that fixes
it.

Guarded in three places, because `/setup` is a public route a bookmark reaches directly:

- the router checks `database_unreachable` **before** `completed`;
- the wizard redirects out of itself on mount;
- the new screen polls, so an operator who fixes it in another window is not left on a stale page.

The screen also names the trap that cost real time here: the database is provisioned outside Compose
with a fixed container name, so `docker compose exec postgres` reports **"not running" even when it
is running**. The container has to be addressed directly.

## Tests

Four, including the one that matters in the other direction — a genuinely fresh server must still
get the wizard, or nobody can install.