### PR TITLE
feat(api,qgis): style a PUBLIC layer without a token

### DIFF
--- a/api/geodeploy/services/symbology.py
+++ b/api/geodeploy/services/symbology.py
@@ -591,11 +591,17 @@ def pillar_radius(style: dict, bbox=None) -> float:
 
 
 def legend_entries(style: dict) -> list[dict]:
-    """What a legend should show for this layer: `[{color, label}]`, or [] for single symbols.
+    """What a legend should show for this layer: `[{color, label, …}]`, or [] for single symbols.
 
     Built here rather than in each renderer for the same reason as the expressions: a legend that
     disagrees with the map is worse than no legend, and the only way to guarantee it agrees is to
     derive both from one description.
+
+    Graduated entries also carry the raw `min`/`max`, and categorized entries the raw `value`,
+    alongside the formatted label. A renderer that has to REBUILD symbology — the QGIS plugin, for
+    a layer it can only see anonymously — otherwise has to parse those numbers back out of a
+    display string containing an EN dash and `≥`, which is precisely the re-derivation this
+    function exists to stop. Drawing a legend needs the label; being the map needs the number.
     """
     mode = style.get("color_mode") or "single"
     if mode == "graduated":
@@ -610,13 +616,16 @@ def legend_entries(style: dict) -> list[dict]:
                 label = f"≥ {_num(lo)}"
             else:
                 label = f"{_num(lo)} – {_num(hi)}"
-            out.append({"color": c.get("color"), "label": label})
+            out.append({"color": c.get("color"), "label": label, "min": lo, "max": hi})
         return out
     if mode == "categorized":
-        out = [{"color": c.get("color"), "label": str(c.get("value"))}
+        out = [{"color": c.get("color"), "label": str(c.get("value")), "value": c.get("value")}
                for c in style.get("categories") or []]
         if out:
-            out.append({"color": style.get("other_color") or DEFAULT_OTHER_COLOR, "label": "Other"})
+            # "Other" carries no value on purpose: it is the fallback for everything NOT listed,
+            # and a renderer needs to be able to tell it apart from a category whose value is null.
+            out.append({"color": style.get("other_color") or DEFAULT_OTHER_COLOR, "label": "Other",
+                        "value": None, "other": True})
         return out
     return []
 

--- a/api/tests/test_legend_raw_values.py
+++ b/api/tests/test_legend_raw_values.py
@@ -1,0 +1,47 @@
+"""A legend has to be usable as a legend AND as a source of truth for a renderer.
+
+The QGIS plugin can only see a public layer anonymously, and `default_style` is on the
+authenticated endpoints — so `/legend` is the only style it can read. Entries used to carry just
+`{color, label}`, which meant rebuilding a graduated renderer required parsing numbers back out of
+a display string containing an EN dash and `≥`. That re-derivation is exactly what this endpoint
+exists to prevent.
+"""
+from geodeploy.services.symbology import legend_entries
+
+
+def test_graduated_entries_carry_the_raw_bounds():
+    style = {"color_mode": "graduated", "color_field": "pop",
+             "classes": [{"min": None, "max": 10, "color": "#111111"},
+                         {"min": 10, "max": 20.5, "color": "#222222"},
+                         {"min": 20.5, "max": None, "color": "#333333"}]}
+    entries = legend_entries(style)
+    assert [e["min"] for e in entries] == [None, 10, 20.5]
+    assert [e["max"] for e in entries] == [10, 20.5, None]
+    # The formatted label is still there and still formatted.
+    assert entries[0]["label"] == "< 10"
+    assert entries[2]["label"] == "≥ 20.5"
+
+
+def test_categorized_entries_carry_the_raw_value():
+    style = {"color_mode": "categorized", "color_field": "kind",
+             "categories": [{"value": "road", "color": "#111111"},
+                            {"value": 3, "color": "#222222"}]}
+    entries = legend_entries(style)
+    assert entries[0]["value"] == "road"
+    # An integer category must survive as an integer: str(3) would never match feature value 3.
+    assert entries[1]["value"] == 3 and not isinstance(entries[1]["value"], str)
+
+
+def test_other_is_distinguishable_from_a_null_category():
+    """"Other" is the fallback for everything unlisted. A renderer must be able to tell it apart
+    from a category whose value happens to be null, which QGIS renders very differently."""
+    style = {"color_mode": "categorized", "color_field": "kind",
+             "categories": [{"value": None, "color": "#111111"}]}
+    entries = legend_entries(style)
+    assert entries[-1]["other"] is True
+    assert "other" not in entries[0]
+
+
+def test_single_symbol_still_returns_nothing():
+    """The endpoint substitutes a one-entry legend itself; this function must not start guessing."""
+    assert legend_entries({"color": "#abcdef"}) == []

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -252,12 +252,15 @@ class GeoDeployDock(QDockWidget):
         if self.styled.isChecked() and source["kind"] != "cog":
             style = (row.get("default_style") or {}).get("style") if row.get("default_style") else None
             if style is None and self.instance:
-                # A public row carries no style; ask for the layer's legend-bearing style instead.
+                # A public row carries no style. `layers.resolve` needs a token, so for anonymous
+                # browsing — the plugin's headline promise — it can only fail, and every public
+                # layer arrived unstyled. `/legend` is PUBLIC and is what the portal draws from.
                 try:
                     ref = row.get("uid") or row.get("id")
-                    style = ((self.instance.client.layers.resolve(ref) or {})
-                             .get("default_style") or {}).get("style")
-                except GeoDeployError:
+                    legend = self.instance.client.layers.legend(ref)
+                    style = symbology.style_from_legend(legend)
+                except GeoDeployError as exc:
+                    symbology._log(f"Could not read the legend for {name}: {exc}")
                     style = None
             if style:
                 applied = (", styled as the portal draws it"

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -103,6 +103,49 @@ def _label(lo, hi) -> str:
     return f"{num(lo)} – {num(hi)}"
 
 
+def style_from_legend(legend: dict) -> dict:
+    """Rebuild a style dict from the PUBLIC legend endpoint.
+
+    Anonymous browsing is the plugin's headline promise, and styling it used to be impossible: the
+    style lives on `default_style`, which only the authenticated layer endpoints return, so every
+    public layer arrived in QGIS unstyled. `/legend` is public and is what the portal itself draws
+    from, so it is the right source — and since it now carries the raw `min`/`max`/`value` next to
+    each formatted label, nothing has to be parsed back out of a display string.
+    """
+    if not legend:
+        return {}
+    entries = legend.get("entries") or []
+    mode = legend.get("color_mode") or "single"
+    style = {}
+    size = legend.get("size") or {}
+    if size.get("field") and size.get("stops"):
+        style["size_mode"] = "proportional"
+        style["size_field"] = size["field"]
+        style["size_stops"] = size["stops"]
+
+    if mode == "graduated":
+        classes = [{"min": e.get("min"), "max": e.get("max"), "color": e.get("color")}
+                   for e in entries if not e.get("other")]
+        if classes:
+            style.update(color_mode="graduated", color_field=legend.get("field"), classes=classes)
+            return style
+    elif mode == "categorized":
+        cats = [{"value": e.get("value"), "color": e.get("color")}
+                for e in entries if not e.get("other")]
+        other = next((e for e in entries if e.get("other")), None)
+        if cats:
+            style.update(color_mode="categorized", color_field=legend.get("field"),
+                         categories=cats)
+            if other:
+                style["other_color"] = other.get("color")
+            return style
+
+    # Single symbol — the legend carries one swatch built from the layer's own colour.
+    if entries:
+        style["color"] = entries[0].get("color")
+    return style
+
+
 def _log(message: str) -> None:
     """Into QGIS's Log Messages panel, under our own tab — the place a user can be pointed to."""
     try:


### PR DESCRIPTION
Anonymous browsing is the QGIS plugin's headline promise, and styling was excluded from it by
accident.

The style lives on `default_style`, which only the **authenticated** layer endpoints return. Without
a token that call can only fail — so every public layer arrived in QGIS unstyled, and (until the
previous commit) with nothing logged to say why.

## Why the legend needed completing first

`/legend` is public and is what the portal itself draws from, so it is the right source. But entries
carried only `{color, label}`, and rebuilding a graduated renderer from that means parsing numbers
back out of a display string containing an EN dash and `≥` — precisely the re-derivation this
endpoint exists to prevent.

Entries now carry the raw values beside the formatted label:

- `min` / `max` on graduated entries
- `value` on categorized ones
- `other: true` on the catch-all

Drawing a legend needs the label; **being** the map needs the number. Existing consumers read
`color` and `label` and are untouched.

`other` is a flag rather than "the last entry", because a renderer must distinguish the catch-all
from a category whose value happens to be `null` — QGIS draws those very differently.

## Verification

A **round trip**, server to plugin and back, with QGIS out of the loop — graduated, categorized and
single-symbol each rebuild identically from the legend the server would serve:

```
graduated round-trip OK -> [{'min': None, 'max': 10, ...}, {'min': 10, 'max': 20.5, ...}]
categorized round-trip OK -> [{'value': 'road', ...}, {'value': 3, ...}] #999999
single round-trip OK -> {'color': '#e2c712'}
```

That last one matters more than it looks: an integer category **stays an integer**. `str(value)`
in the label would have turned `3` into `"3"`, which would never match a feature again.

Plus 20 tests passing across the legend surface.