### PR TITLE
feat(ui,qgis): upload several files at once

### DIFF
--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -48,8 +48,14 @@ class _Job(QgsTask):
 
 
 class GeoDeployDock(QDockWidget):
+    # Progress arrives from the QgsTask's worker thread, and Qt widgets may only be touched on the
+    # GUI thread. A signal is the crossing: emitting is safe from anywhere, and the connected slot
+    # runs where the widgets live.
+    _progress = pyqtSignal(str)
+
     def __init__(self, iface):
         super().__init__(PLUGIN_NAME)
+        self._progress.connect(lambda text: self._say(text, bar=False))
         self.iface = iface
         self.instance: Instance | None = None
         self._rows: list[dict] = []
@@ -104,7 +110,11 @@ class GeoDeployDock(QDockWidget):
         outer.addWidget(add)
 
         # -- upload -------------------------------------------------------------------------------
-        self.upload_btn = QPushButton("Upload the active layer…")
+        self.upload_btn = QPushButton("Upload selected layer(s)…")
+        self.upload_btn.setToolTip(
+            "Uploads every layer selected in the Layers panel, one after another — or the active "
+            "layer if nothing is selected. A layer that cannot be sent is named and skipped; the "
+            "rest still go.")
         self.upload_btn.clicked.connect(self.upload_active)
         outer.addWidget(self.upload_btn)
 
@@ -282,38 +292,67 @@ class GeoDeployDock(QDockWidget):
             self._say("Uploading needs a token with data:write. Public browsing does not.",
                       Qgis.Warning)
             return
-        layer = self.iface.activeLayer()
-        if layer is None:
-            self._say("Select a layer in the Layers panel first.", Qgis.Warning)
-            return
-        try:
-            # Not `layer.source()`: a filtered layer's file holds MORE than the layer does, and a
-            # memory or PostGIS layer has no file at all. `prepare` writes those out first.
-            path, temporary = export.prepare(layer, on_status=lambda t: self._say(t, bar=False))
-        except export.NotUploadable as exc:
-            self._say(str(exc), Qgis.Warning)
+        # Whatever is SELECTED in the Layers panel, falling back to the active layer. Sending five
+        # layers is a normal thing to want, and doing it one at a time means five round trips
+        # through this dialog.
+        layers = list(self.iface.layerTreeView().selectedLayers() or [])
+        if not layers:
+            active = self.iface.activeLayer()
+            if active is None:
+                self._say("Select one or more layers in the Layers panel first.", Qgis.Warning)
+                return
+            layers = [active]
+
+        jobs = []           # (name, path, temporary, style)
+        refused = []
+        for layer in layers:
+            try:
+                # Not `layer.source()`: a filtered layer's file holds MORE than the layer does, and
+                # a memory or PostGIS layer has no file at all. `prepare` writes those out first.
+                path, temporary = export.prepare(
+                    layer, on_status=lambda t: self._say(t, bar=False))
+            except export.NotUploadable as exc:
+                refused.append("{0}: {1}".format(layer.name(), exc))
+                continue
+            style = symbology.from_qgis(layer) if self.push_style.isChecked() else {}
+            jobs.append((layer.name(), path, temporary, style))
+
+        if not jobs:
+            # Everything was refused — say why, for each, rather than a generic failure.
+            self._say(" | ".join(refused) or "Nothing could be uploaded.", Qgis.Warning)
             return
 
-        style = symbology.from_qgis(layer) if self.push_style.isChecked() else {}
         client = self.instance.client
+        total = len(jobs)
 
         def work():
-            try:
-                result = client.uploads.upload(path, wait=True)
-            finally:
-                if temporary:
-                    # A multi-gigabyte export is not left behind in temp because an upload failed.
-                    shutil.rmtree(os.path.dirname(path), ignore_errors=True)
-            if style and getattr(result, "layer_id", None):
-                # Styling travels with the upload: the portal then shows what the author saw,
-                # instead of the next default colour in the palette.
-                api = client.layers.api(result.plan.layer_type)
-                api.set_default_style(result.layer_id, {"opacity": 1.0, "style": style,
-                                                        "popup_fields": []})
-            return result
+            uploaded, failed = [], list(refused)
+            for index, (name, path, temporary, style) in enumerate(jobs, start=1):
+                # Reported from the worker thread: a queue that looks frozen for four of five files
+                # is worse than no progress at all.
+                self._progress.emit("Uploading {0} ({1} of {2})…".format(name, index, total))
+                try:
+                    result = client.uploads.upload(path, wait=True)
+                    if style and getattr(result, "layer_id", None):
+                        # Styling travels with the upload: the portal then shows what the author
+                        # saw, instead of the next default colour in the palette.
+                        api = client.layers.api(result.plan.layer_type)
+                        api.set_default_style(result.layer_id,
+                                              {"opacity": 1.0, "style": style,
+                                               "popup_fields": []})
+                    uploaded.append(name)
+                except Exception as exc:            # noqa: BLE001 - one bad layer, not the batch
+                    # Four good layers must still arrive when the third one is broken.
+                    failed.append("{0}: {1}".format(name, exc))
+                finally:
+                    if temporary:
+                        # A multi-gigabyte export is not left behind in temp because upload failed.
+                        shutil.rmtree(os.path.dirname(path), ignore_errors=True)
+            return {"uploaded": uploaded, "failed": failed}
 
         self._busy(True)
-        self._say(f"Uploading {layer.name()}… large files go straight to storage.", bar=False)
+        self._say("Uploading {0} layer(s)… large files go straight to storage.".format(total),
+                  bar=False)
         self._run(_Job("GeoDeploy: uploading", work), self._uploaded)
 
     def _uploaded(self, job):
@@ -321,11 +360,23 @@ class GeoDeployDock(QDockWidget):
         if job.error:
             self._say(job.error, Qgis.Critical)
             return
-        result = job.result
-        name = getattr(getattr(result, "plan", None), "name", "the layer")
-        self._say(f"Uploaded {name}." + (" Styling sent with it." if self.push_style.isChecked()
-                                         else ""))
-        self.refresh_layers()
+        result = job.result or {}
+        uploaded = result.get("uploaded") or []
+        failed = result.get("failed") or []
+        styling = " Styling sent with them." if (uploaded and self.push_style.isChecked()) else ""
+
+        if uploaded and not failed:
+            what = uploaded[0] if len(uploaded) == 1 else f"{len(uploaded)} layers"
+            self._say(f"Uploaded {what}.{styling}")
+        elif uploaded and failed:
+            # Partial success is its own outcome. Reporting it as failure hides work that landed;
+            # reporting it as success hides work that did not.
+            self._say(f"Uploaded {len(uploaded)}, but {len(failed)} did not: " + " | ".join(failed),
+                      Qgis.Warning)
+        else:
+            self._say(" | ".join(failed) or "Nothing was uploaded.", Qgis.Critical)
+        if uploaded:
+            self.refresh_layers()
 
     # -- task plumbing ------------------------------------------------------------------------------
 

--- a/ui/src/components/data/UploadModal.vue
+++ b/ui/src/components/data/UploadModal.vue
@@ -9,8 +9,41 @@
         <button @click="$emit('close')" class="text-muted-foreground/70 hover:text-foreground text-xl leading-none">&times;</button>
       </div>
 
+      <!-- Batch: one row per file, so a failure in the middle is visible and named rather than
+           replaced by whatever the last file did. -->
+      <div v-if="batch.length" class="space-y-2">
+        <p class="text-sm text-muted-foreground">
+          {{ batch.filter(b => b.state === 'done').length }} of {{ batch.length }} uploaded
+        </p>
+        <ul class="space-y-1 max-h-56 overflow-y-auto">
+          <li v-for="(item, i) in batch" :key="item.name + i"
+              class="flex items-center gap-2 text-sm">
+            <span class="w-4 flex-shrink-0 text-center" aria-hidden="true">
+              <span v-if="item.state === 'done'" class="text-emerald-400">✓</span>
+              <span v-else-if="item.state === 'failed'" class="text-red-400">✕</span>
+              <span v-else-if="item.state === 'uploading'" class="text-primary">•</span>
+              <span v-else class="text-muted-foreground/50">·</span>
+            </span>
+            <span class="truncate" :class="item.state === 'failed' ? 'text-red-400' : ''">
+              {{ item.name }}
+            </span>
+            <span v-if="item.state === 'uploading'" class="ml-auto text-xs text-muted-foreground">
+              {{ uploadProgress }}%
+            </span>
+          </li>
+        </ul>
+        <p v-if="batchIndex >= 0" class="text-xs text-muted-foreground">
+          Uploading one at a time — each is processed in the background as it arrives.
+        </p>
+        <!-- The queue has finished and something failed. Without a way back the list is a
+             dead end: the only exit would be closing the modal and starting over. -->
+        <div v-else class="flex justify-end pt-1">
+          <button @click="resetBatch" class="btn-secondary text-sm">Upload more</button>
+        </div>
+      </div>
+
       <!-- Upload progress -->
-      <div v-if="uploading" class="space-y-3">
+      <div v-else-if="uploading" class="space-y-3">
         <div class="flex justify-between text-sm">
           <span class="text-muted-foreground">{{ fileName }}</span>
           <span class="font-medium">{{ uploadProgress }}%</span>
@@ -138,7 +171,7 @@ import { UploadIcon } from '@/views/icons'
 import { useUpload, LARGE_UPLOAD_THRESHOLD } from '@/composables/useUpload'
 import { useDataStore } from '@/stores/data'
 import { uploadCsvFile } from '@/api'
-import { buildZip, inspectShapefileSelection } from '@/lib/zip'
+import { planSelection, zipShapefileSet } from '@/lib/zip'
 
 const props = defineProps({ type: String })
 const emit = defineEmits(['close'])
@@ -148,6 +181,10 @@ const fileName = ref('')
 // Zipping a shapefile set happens before any request, so it needs its own "busy": `uploading`
 // belongs to the upload itself and a large .dbf takes a visible moment to read and compress.
 const packaging = ref(false)
+// One row per file when several were selected, so a batch shows what succeeded and what did not
+// instead of collapsing to a single "uploading…".
+const batch = ref([])
+const batchIndex = ref(-1)
 // A missing .prj does not stop the upload — it changes what the user should check afterwards.
 const warning = ref('')
 // True from the instant an upload succeeds until the modal closes. `uploading` goes false as soon as
@@ -207,49 +244,58 @@ function parseCsvHeader(file) {
 }
 
 async function handleFile(file) {
+  const ok = await uploadOne(file)
+  if (ok) finishAndClose()
+}
+
+/**
+ * Upload ONE file and report whether it worked. Does not close the modal: in a batch, the next file
+ * follows, and closing on the first success would abandon the rest mid-flight.
+ *
+ * Returns false for CSV, which cannot be uploaded unattended — it needs its X/Y columns and CRS
+ * chosen first, and `handleFile`'s caller shows that form.
+ */
+async function uploadOne(file) {
   const lower = file.name.toLowerCase()
   // CSV needs X/Y/CRS first — show the options form instead of uploading immediately.
   if (props.type === 'vector' && lower.endsWith('.csv')) {
     csvFile.value = file
     csvName.value = file.name.replace(/\.csv$/i, '')
     parseCsvHeader(file)
-    return
+    return false
   }
   // GeoParquet uploads DIRECT to storage (presigned) — never through the API.
   if (props.type === 'vector' && (lower.endsWith('.parquet') || lower.endsWith('.geoparquet'))) {
     if (file.size > MAX_GEOPARQUET) {
       error.value = 'File exceeds the 10 GB limit.'
-      return
+      return false
     }
     fileName.value = file.name
     try {
       await uploadGeoParquet(file, file.name.replace(/\.(geo)?parquet$/i, ''))
-      finishAndClose()
-    } catch { /* error shown via `error` */ }
-    return
+      return true
+    } catch { return false }
   }
   fileName.value = file.name
   // Big RASTERS also bypass the API: a GeoTIFF over the CDN's request-body cap never reaches it.
   if (props.type === 'raster' && file.size >= LARGE_UPLOAD_THRESHOLD) {
     try {
       await uploadLargeRaster(file, file.name.replace(/\.[^.]+$/, ''))
-      finishAndClose()
-    } catch { /* error shown via `error` */ }
-    return
+      return true
+    } catch { return false }
   }
   // Vector files too big for a single request upload direct-to-storage and convert to GeoParquet
   // in the background instead of being rejected.
   if (props.type === 'vector' && file.size >= LARGE_UPLOAD_THRESHOLD) {
     try {
       await uploadLargeVector(file, file.name.replace(/\.[^.]+$/, ''))
-      finishAndClose()
-    } catch { /* error shown via `error` */ }
-    return
+      return true
+    } catch { return false }
   }
   try {
     await uploadFile(file, props.type)
-    finishAndClose()
-  } catch { /* error shown via `error` */ }
+    return true
+  } catch { return false }
 }
 
 async function importCsv() {
@@ -304,43 +350,93 @@ function onFileChange(e) {
 async function takeSelection(fileList) {
   const files = Array.from(fileList || [])
   if (!files.length) return
-  const shapefile = inspectShapefileSelection(files)
-  if (!shapefile) {
-    handleFile(files[0])
-    return
-  }
-  if (shapefile.error) {
-    error.value = shapefile.error
-    return
-  }
-  if (shapefile.missing.length) {
-    error.value =
-      `A shapefile needs its sidecar files: ${shapefile.missing.join(' and ')} ` +
-      `${shapefile.missing.length > 1 ? 'are' : 'is'} missing. Select them together with the ` +
-      '.shp — they are one dataset, not one file.'
-    return
-  }
   error.value = ''
-  packaging.value = true
-  try {
-    const entries = []
-    for (const f of shapefile.files) {
-      entries.push({ name: f.name, data: new Uint8Array(await f.arrayBuffer()) })
-    }
-    const blob = await buildZip(entries)
-    // Named after the .shp, so the layer is called what the user expects.
-    const zipped = new File([blob], `${shapefile.stem}.zip`, { type: 'application/zip' })
-    if (!shapefile.files.some((f) => f.name.toLowerCase().endsWith('.prj'))) {
-      // Recoverable — the CRS can be set after upload — but silence becomes a mystery when the
-      // layer draws in the wrong hemisphere.
-      warning.value = 'No .prj was included, so this layer has no CRS of its own. You may need to ' +
-        'set it after upload.'
-    }
-    handleFile(zipped)
-  } catch (err) {
-    error.value = err.message || 'Could not package the shapefile.'
-  } finally {
-    packaging.value = false
+  warning.value = ''
+
+  const { shapefiles, others } = planSelection(files)
+
+  // Refuse an incomplete shapefile before anything is sent: a .shp without its .shx/.dbf cannot
+  // ingest, so uploading it only moves the failure somewhere less useful.
+  const broken = shapefiles.filter((set) => set.missing.length)
+  if (broken.length) {
+    error.value = broken.map((set) =>
+      `${set.stem}: missing ${set.missing.join(' and ')}`).join('; ') +
+      '. A shapefile needs its sidecar files — select them together with the .shp.'
+    return
   }
+
+  // CSV cannot ride along in a batch: it needs its X/Y columns and CRS chosen, per file.
+  const csvs = others.filter((f) => f.name.toLowerCase().endsWith('.csv'))
+  if (csvs.length && (others.length + shapefiles.length) > 1) {
+    error.value = 'A CSV has to be imported on its own — it needs its X/Y columns and CRS chosen ' +
+      'first. Upload the others, then the CSV separately.'
+    return
+  }
+
+  let queue = []
+  if (shapefiles.length) {
+    packaging.value = true
+    try {
+      for (const set of shapefiles) {
+        queue.push(await zipShapefileSet(set))
+        if (!set.files.some((f) => f.name.toLowerCase().endsWith('.prj'))) {
+          // Recoverable — the CRS can be set afterwards — but silence about it becomes a mystery
+          // when the layer draws in the wrong hemisphere.
+          warning.value = `${set.stem} has no .prj, so it carries no CRS of its own. ` +
+            'You may need to set it after upload.'
+        }
+      }
+    } catch (err) {
+      error.value = err.message || 'Could not package the shapefile.'
+      return
+    } finally {
+      packaging.value = false
+    }
+  }
+  queue = queue.concat(others)
+
+  if (queue.length === 1) {
+    handleFile(queue[0])           // one file: the CSV form and every existing path, unchanged
+    return
+  }
+  await runQueue(queue)
 }
+
+/**
+ * Upload several files one after another.
+ *
+ * Sequentially on purpose. Each upload already parallelises its own parts for anything large, so
+ * running files concurrently would compete for the same bandwidth without finishing the set any
+ * sooner — and it would make the progress bar meaningless.
+ *
+ * One failure does not stop the rest. Eight files where the third is corrupt should upload seven
+ * and tell you about the third, not stop at two.
+ */
+function resetBatch() {
+  batch.value = []
+  batchIndex.value = -1
+  error.value = ''
+  warning.value = ''
+  fileName.value = ''
+}
+
+async function runQueue(files) {
+  batch.value = files.map((f) => ({ name: f.name, state: 'pending' }))
+  for (let i = 0; i < files.length; i++) {
+    batchIndex.value = i
+    batch.value[i].state = 'uploading'
+    error.value = ''
+    const ok = await uploadOne(files[i])
+    batch.value[i].state = ok ? 'done' : 'failed'
+    batch.value[i].message = ok ? '' : (error.value || 'Upload failed.')
+  }
+  batchIndex.value = -1
+  const failed = batch.value.filter((b) => b.state === 'failed')
+  error.value = failed.length
+    ? `${failed.length} of ${files.length} did not upload: ` +
+      failed.map((f) => f.name).join(', ')
+    : ''
+  if (!failed.length) finishAndClose()
+}
+
 </script>

--- a/ui/src/lib/zip.js
+++ b/ui/src/lib/zip.js
@@ -164,19 +164,54 @@ const extOf = (name) => name.slice(name.lastIndexOf('.')).toLowerCase()
  * uploading a fragment that cannot possibly ingest.
  */
 export function inspectShapefileSelection(fileList) {
-  const files = Array.from(fileList || [])
-  const shp = files.filter((f) => extOf(f.name) === '.shp')
-  if (shp.length === 0) return null
-  if (shp.length > 1) {
+  const sets = groupShapefiles(fileList)
+  if (!sets.length) return null
+  if (sets.length > 1) {
     return { stem: null, files: [], missing: [], error:
-      'Select one shapefile at a time — this selection has ' + shp.length + ' .shp files.' }
+      'Select one shapefile at a time — this selection has ' + sets.length + ' .shp files.' }
   }
+  return { ...sets[0], error: null }
+}
 
-  const stem = stemOf(shp[0].name)
-  // Case-insensitively: half the world's shapefiles are called ROADS.SHP.
-  const lower = stem.toLowerCase()
-  const members = files.filter((f) => stemOf(f.name).toLowerCase() === lower)
-  const present = new Set(members.map((f) => extOf(f.name)))
-  const missing = REQUIRED_PARTS.filter((p) => !present.has(p))
-  return { stem, files: members, missing, error: null }
+/**
+ * EVERY shapefile in a selection, one entry per `.shp`, as `{stem, files, missing}`.
+ *
+ * A batch upload of five shapefiles is a normal thing to want, and grouping by stem is the only
+ * way to know which sidecar belongs to which dataset — the files arrive as one flat list with no
+ * folder structure, because that is all a file input gives you.
+ */
+export function groupShapefiles(fileList) {
+  const files = Array.from(fileList || [])
+  const out = []
+  for (const shp of files.filter((f) => extOf(f.name) === '.shp')) {
+    const stem = stemOf(shp.name)
+    // Case-insensitively: half the world's shapefiles are called ROADS.SHP.
+    const lower = stem.toLowerCase()
+    const members = files.filter((f) => stemOf(f.name).toLowerCase() === lower)
+    const present = new Set(members.map((f) => extOf(f.name)))
+    out.push({ stem, files: members, missing: REQUIRED_PARTS.filter((p) => !present.has(p)) })
+  }
+  return out
+}
+
+/**
+ * Split a selection into what to upload: each shapefile as one zip-to-be, everything else as
+ * itself. Files belonging to a shapefile are consumed, so a stray `.dbf` is never uploaded alone.
+ */
+export function planSelection(fileList) {
+  const files = Array.from(fileList || [])
+  const sets = groupShapefiles(files)
+  const claimed = new Set()
+  for (const set of sets) for (const f of set.files) claimed.add(f)
+  return { shapefiles: sets, others: files.filter((f) => !claimed.has(f)) }
+}
+
+/** Zip one grouped shapefile into a `File` named after its stem. */
+export async function zipShapefileSet(set) {
+  const entries = []
+  for (const f of set.files) {
+    entries.push({ name: f.name, data: new Uint8Array(await f.arrayBuffer()) })
+  }
+  const blob = await buildZip(entries)
+  return new File([blob], `${set.stem}.zip`, { type: 'application/zip' })
 }


### PR DESCRIPTION
One file per trip through the dialog is the wrong unit of work. Someone with a folder of
GeoPackages, or five layers open in QGIS, has to repeat themselves once per dataset.

## Web

The selection is **planned** before anything is sent: each `.shp` claims its sidecars by stem,
everything else passes through as itself, and a stray `.dbf` can no longer be uploaded on its own.
Several shapefiles in one selection now become several zips instead of being refused.

A queue then uploads them one at a time, with a row per file showing what succeeded and what did
not — and a way back when something fails, instead of a dead-end list.

## QGIS

Uploads every layer **selected** in the Layers panel, falling back to the active layer. Progress
crosses from the task's worker thread by signal, because Qt widgets may only be touched on the GUI
thread and a queue that looks frozen for four of five files is worse than no progress at all.

## Three decisions worth keeping

- **Sequentially.** Each upload already runs four parallel part uploads for anything large, so
  file-level concurrency mostly redistributes the same bandwidth while making progress unreadable.
  The client's `upload_many` reached the same conclusion and defaults the same way.
- **One failure does not stop the rest.** Eight files where the third is corrupt should upload seven
  and name the third. Partial success is reported as itself: calling it failure hides work that
  landed, calling it success hides work that did not.
- **CSV stays single-file.** It needs its X/Y columns and CRS chosen per file, and there is no
  honest way to ask that for eight files at once. A CSV inside a multi-selection is refused with
  that explanation rather than silently skipped.

## Verification

Selection planning checked against the case most likely to be subtly wrong — two complete
shapefiles, one GeoPackage and a stray file in one selection:

```
sets:   [ 'roads[4] missing=', 'RIVERS[3] missing=' ]
others: [ 'cities.gpkg', 'notes.txt' ]
```

Plus incomplete sets, lone sidecars (never uploaded alone), plain selections passing through
untouched, and stems differing only by case staying separate.