### PR TITLE
feat(legend,qgis): size symbology, the column names, and raster styling on upload

### DIFF
--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -221,6 +221,12 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
                 # the same call (`symbology.legend_entries`, which also feeds the editor).
                 # Empty for a single-symbol layer, which is what the swatch already covers.
                 "geodeploy:legend": symbology.legend_entries(cfg.get("style") or {}),
+                # The COLUMN behind the colours, and the size scale — both baked here for the same
+                # reason as the entries: the runtime must not re-derive what the map already knows.
+                # Added as separate keys rather than folded into the array above so that a portal
+                # published by an older version stays readable (they are simply absent).
+                "geodeploy:legendField": symbology.color_field(cfg.get("style") or {}),
+                "geodeploy:sizeLegend": symbology.size_legend(cfg.get("style") or {}),
                 # 3D is worth announcing: the runtime opens the map tilted when any layer has it.
                 "geodeploy:extruded": symbology.is_extruded(cfg.get("style") or {}),
             }

--- a/api/geodeploy/services/symbology.py
+++ b/api/geodeploy/services/symbology.py
@@ -630,6 +630,47 @@ def legend_entries(style: dict) -> list[dict]:
     return []
 
 
+def size_legend(style: dict) -> dict | None:
+    """What a legend must show about SIZE, or None when size does not vary.
+
+    Colour and size are independent dimensions — colouring by population while sizing by area is a
+    normal thing to want, and `color_mode` is deliberately separate from `size_mode`. A legend that
+    shows only the colours therefore describes half the map, and the half it omits is the one
+    driving how big things are.
+
+    Returned as the two ENDS plus the field, not every stop: the size expression interpolates
+    linearly (see `_size_expression`), so the ends define the whole scale, and a legend that listed
+    intermediate stops would imply steps that the map does not draw.
+    """
+    if (style.get("size_mode") or "fixed") != "proportional":
+        return None
+    field = (style.get("size_field") or "").strip()
+    stops = [s for s in (style.get("size_stops") or [])
+             if isinstance(s, (list, tuple)) and len(s) == 2]
+    if not field or len(stops) < 2:
+        return None
+    ordered = sorted(stops, key=lambda s: s[0])
+    lo, hi = ordered[0], ordered[-1]
+    return {
+        "field": field,
+        "min_value": lo[0], "min_size": lo[1],
+        "max_value": hi[0], "max_size": hi[1],
+        "min_label": _num(lo[0]), "max_label": _num(hi[0]),
+    }
+
+
+def color_field(style: dict) -> str | None:
+    """The column driving colour, or None for a single symbol.
+
+    A legend that shows five colours without naming what they measure is a puzzle: the reader can
+    see that something varies but not what.
+    """
+    mode = style.get("color_mode") or "single"
+    if mode in ("graduated", "categorized"):
+        return (style.get("color_field") or "").strip() or None
+    return None
+
+
 def _num(v) -> str:
     """Legend numbers: trim a float that is really an integer, and keep the rest short."""
     try:

--- a/api/tests/test_legend_size_and_field.py
+++ b/api/tests/test_legend_size_and_field.py
@@ -1,0 +1,60 @@
+"""A legend that shows only colour describes half of a map.
+
+Colour and size are independent dimensions on purpose — `color_mode` is separate from `size_mode`
+so that colouring by population while sizing by area is possible — which means a legend has to be
+able to show size ALONE, colour alone, or both. And a row of swatches that never names the column
+it measures shows THAT something varies without saying what.
+"""
+from geodeploy.services.symbology import color_field, size_legend
+
+
+def _sized(**over):
+    style = {"size_mode": "proportional", "size_field": "pop",
+             "size_stops": [[100, 4], [5000, 20]]}
+    style.update(over)
+    return style
+
+
+def test_size_legend_reports_both_ends():
+    out = size_legend(_sized())
+    assert out["field"] == "pop"
+    assert (out["min_value"], out["min_size"]) == (100, 4)
+    assert (out["max_value"], out["max_size"]) == (5000, 20)
+    assert (out["min_label"], out["max_label"]) == ("100", "5000")
+
+
+def test_stops_out_of_order_are_sorted_not_trusted():
+    """A legend showing 5000 at the small end would be worse than no legend."""
+    out = size_legend(_sized(size_stops=[[5000, 20], [100, 4]]))
+    assert out["min_value"] == 100 and out["max_value"] == 5000
+
+
+def test_no_size_legend_when_size_is_fixed():
+    assert size_legend({"size_mode": "fixed", "size_field": "pop"}) is None
+    assert size_legend({}) is None
+
+
+def test_no_size_legend_without_enough_to_interpolate():
+    """One stop is a fixed size wearing a costume — there is no scale to draw."""
+    assert size_legend(_sized(size_stops=[[100, 4]])) is None
+    assert size_legend(_sized(size_field="")) is None
+
+
+def test_size_and_graduated_colour_coexist():
+    """The combination the report was about: both dimensions on one layer."""
+    style = _sized(color_mode="graduated", color_field="area",
+                   classes=[{"min": 0, "max": 5, "color": "#111111"}])
+    assert size_legend(style)["field"] == "pop"
+    assert color_field(style) == "area"
+
+
+def test_colour_field_is_none_for_a_single_symbol():
+    """Naming a field on a layer whose colour does not vary would be a lie."""
+    assert color_field({"color": "#abcdef"}) is None
+    assert color_field({"color_mode": "single", "color_field": "leftover"}) is None
+
+
+def test_colour_field_is_reported_for_both_data_driven_modes():
+    assert color_field({"color_mode": "graduated", "color_field": "pop"}) == "pop"
+    assert color_field({"color_mode": "categorized", "color_field": "kind"}) == "kind"
+    assert color_field({"color_mode": "graduated", "color_field": "  "}) is None

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -297,6 +297,33 @@ moves is a screenshot with extra steps.
 </div>
 
 <div class="gd-rel" markdown>
+### A page for a layer
+<span class="gd-when">Planned</span>
+
+<p class="gd-goal">My Data lists layers but never shows you one. To actually LOOK at a layer today
+you have to build a portal around it — which is a strange price for answering "what is in this
+file?"</p>
+
+- [ ] **Click a layer, get its page.** A map of just that layer, at its own extent, with the
+      basemap and the ordinary map controls.
+- [ ] **What it is**: geometry type, feature count, CRS, extent, size on disk, when it was
+      uploaded and by whom, and the fields with their types.
+- [ ] **How it is served**: whether it is tiled and how far, whether a GeoParquet layer is
+      partitioned, whether a raster has overviews and what its zoom floor is — the facts that
+      decide whether it draws well, currently visible only through the API.
+- [ ] **Its symbology, edited and saved here** — the same panel the portal editor uses, writing the
+      same default style. Styling a layer already works from My Data; this puts it next to the map
+      it affects instead of in a modal with nothing to preview against.
+- [ ] **The attribute table**, paged, with a click-through from a feature on the map.
+- [ ] **Everything that already exists about a layer, in one place**: its share links, its
+      download formats, which portals use it, and its sharing settings.
+
+The page has no new backend behind it — layer metadata, `/field-stats`, `/legend`, share links and
+the tile URLs are all already served. This is about giving them somewhere to be seen together.
+
+</div>
+
+<div class="gd-rel" markdown>
 ### Cartography and portal tools
 <span class="gd-when">Planned</span>
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -152,6 +152,21 @@ class GeoDeployDock(QDockWidget):
         duration = 0 if level in (Qgis.Warning, Qgis.Critical) else 6
         bar_widget.pushMessage(PLUGIN_NAME, text, level=level, duration=duration)
 
+    def _colormaps(self):
+        """The colormap names this instance actually has, fetched once.
+
+        A QGIS ramp name is only sent as a colormap when the server confirms it knows one by that
+        name — the two catalogues overlap but are not the same, and a wrong colormap is worse than
+        the default. Cached because it cannot change during a session, and returned empty on
+        failure so a styling nicety never costs an upload.
+        """
+        if getattr(self, "_colormap_cache", None) is None:
+            try:
+                self._colormap_cache = set(self.instance.client.raster.colormaps() or [])
+            except Exception:           # noqa: BLE001 - no colormap is not a failed upload
+                self._colormap_cache = set()
+        return self._colormap_cache
+
     def _busy(self, on: bool):
         self.progress.setVisible(on)
         self.progress.setRange(0, 0 if on else 1)
@@ -314,7 +329,15 @@ class GeoDeployDock(QDockWidget):
             except export.NotUploadable as exc:
                 refused.append("{0}: {1}".format(layer.name(), exc))
                 continue
-            style = symbology.from_qgis(layer) if self.push_style.isChecked() else {}
+            # A raster's default style is a DIFFERENT shape — {colormap, rescale, bidx}, not
+            # classes — so it needs its own translation. Sending the vector shape is what made
+            # "Send its styling too" quietly do nothing for a GeoTIFF.
+            if not self.push_style.isChecked():
+                style = {}
+            elif isinstance(layer, QgsRasterLayer):
+                style = symbology.raster_from_qgis(layer, self._colormaps())
+            else:
+                style = symbology.from_qgis(layer)
             jobs.append((layer.name(), path, temporary, style))
 
         if not jobs:
@@ -326,7 +349,7 @@ class GeoDeployDock(QDockWidget):
         total = len(jobs)
 
         def work():
-            uploaded, failed = [], list(refused)
+            uploaded, styled, failed = [], [], list(refused)
             for index, (name, path, temporary, style) in enumerate(jobs, start=1):
                 # Reported from the worker thread: a queue that looks frozen for four of five files
                 # is worse than no progress at all.
@@ -336,10 +359,14 @@ class GeoDeployDock(QDockWidget):
                     if style and getattr(result, "layer_id", None):
                         # Styling travels with the upload: the portal then shows what the author
                         # saw, instead of the next default colour in the palette.
-                        api = client.layers.api(result.plan.layer_type)
-                        api.set_default_style(result.layer_id,
-                                              {"opacity": 1.0, "style": style,
-                                               "popup_fields": []})
+                        kind = result.plan.layer_type
+                        api = client.layers.api(kind)
+                        # The two kinds take different bodies. A raster's IS the style; a vector's
+                        # wraps it, alongside opacity and popup fields.
+                        body = (dict(style, opacity=1.0) if kind == "raster"
+                                else {"opacity": 1.0, "style": style, "popup_fields": []})
+                        api.set_default_style(result.layer_id, body)
+                        styled.append(name)
                     uploaded.append(name)
                 except Exception as exc:            # noqa: BLE001 - one bad layer, not the batch
                     # Four good layers must still arrive when the third one is broken.
@@ -348,7 +375,7 @@ class GeoDeployDock(QDockWidget):
                     if temporary:
                         # A multi-gigabyte export is not left behind in temp because upload failed.
                         shutil.rmtree(os.path.dirname(path), ignore_errors=True)
-            return {"uploaded": uploaded, "failed": failed}
+            return {"uploaded": uploaded, "styled": styled, "failed": failed}
 
         self._busy(True)
         self._say("Uploading {0} layer(s)… large files go straight to storage.".format(total),
@@ -363,7 +390,17 @@ class GeoDeployDock(QDockWidget):
         result = job.result or {}
         uploaded = result.get("uploaded") or []
         failed = result.get("failed") or []
-        styling = " Styling sent with them." if (uploaded and self.push_style.isChecked()) else ""
+        styled = result.get("styled") or []
+        # Only claim what was actually sent. A renderer we cannot translate produces no style, and
+        # saying "styling sent" anyway is how a silent no-op passes for a feature.
+        if styled and len(styled) == len(uploaded):
+            styling = " Styling sent with " + ("it." if len(styled) == 1 else "them.")
+        elif styled:
+            styling = f" Styling sent for {len(styled)} of {len(uploaded)}."
+        elif uploaded and self.push_style.isChecked():
+            styling = " No styling was sent — this renderer has no GeoDeploy equivalent."
+        else:
+            styling = ""
 
         if uploaded and not failed:
             what = uploaded[0] if len(uploaded) == 1 else f"{len(uploaded)} layers"

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -25,7 +25,9 @@ try:                                    # pragma: no cover - only present inside
     from qgis.core import (QgsCategorizedSymbolRenderer, QgsGraduatedSymbolRenderer,
                            QgsRendererCategory, QgsRendererRange, QgsSimpleFillSymbolLayer,
                            QgsSimpleLineSymbolLayer, QgsSimpleMarkerSymbolLayer, QgsSymbol,
-                           QgsSingleSymbolRenderer, QgsClassificationRange)
+                           QgsSingleSymbolRenderer, QgsClassificationRange,
+                           QgsMultiBandColorRenderer, QgsSingleBandGrayRenderer,
+                           QgsSingleBandPseudoColorRenderer)
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtGui import QColor
     QGIS = True
@@ -217,6 +219,110 @@ def apply_to_qgis(qgis_layer, style: dict) -> bool:
 
 def _hex(color) -> str:
     return color.name() if hasattr(color, "name") else str(color)
+
+
+def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
+    """A GeoDeploy RASTER default style from a QGIS raster renderer.
+
+    A different shape entirely from the vector one — `{colormap, rescale, bidx}`, not classes — so
+    it is a separate function rather than a branch inside `from_qgis`. Sending the vector shape for
+    a raster is what made "Send its styling too" silently do nothing for GeoTIFFs.
+
+    What travels, in order of how faithfully it survives:
+
+    * **`rescale`** — exact, and the part that matters most. Non-8-bit data renders BLACK on a tile
+      server that assumes 0–255, so the min/max stretch is the difference between a visible layer
+      and a black rectangle. QGIS knows the numbers; there is no reason to make the server guess
+      them again.
+    * **`bidx`** — exact. Which band, or which three for an RGB composite.
+    * **`colormap`** — best effort. QGIS colour ramps and TiTiler colormaps are different
+      catalogues that happen to share many names (viridis, magma, terrain, …), so the name is sent
+      ONLY when the server confirms it has one by that name. `colormaps` is that list; without it
+      no colormap is claimed, because a wrong one is worse than the default.
+    """
+    if not QGIS or qgis_layer is None:
+        return {}
+    renderer = qgis_layer.renderer() if hasattr(qgis_layer, "renderer") else None
+    if renderer is None:
+        return {}
+    style = {}
+    try:
+        if isinstance(renderer, QgsMultiBandColorRenderer):
+            bands = [renderer.redBand(), renderer.greenBand(), renderer.blueBand()]
+            if all(isinstance(b, int) and b > 0 for b in bands):
+                style["bidx"] = bands
+            # One stretch for the composite: TiTiler takes a single rescale, and the red band's is
+            # the closest honest single answer when the three differ.
+            lo, hi = _enhancement_range(renderer.redContrastEnhancement())
+            if lo is not None:
+                style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
+            return style
+
+        if isinstance(renderer, QgsSingleBandGrayRenderer):
+            band = renderer.grayBand()
+            if isinstance(band, int) and band > 0:
+                style["bidx"] = [band]
+            lo, hi = _enhancement_range(renderer.contrastEnhancement())
+            if lo is not None:
+                style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
+            return style
+
+        if isinstance(renderer, QgsSingleBandPseudoColorRenderer):
+            band = renderer.band()
+            if isinstance(band, int) and band > 0:
+                style["bidx"] = [band]
+            lo, hi = renderer.classificationMin(), renderer.classificationMax()
+            if _finite(lo) and _finite(hi) and hi > lo:
+                style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
+            name = _ramp_name(renderer)
+            if name and colormaps and name in colormaps:
+                style["colormap"] = name
+            elif name:
+                _log("QGIS ramp {0!r} has no colormap of that name on the instance — sending the "
+                     "stretch without it.".format(name))
+            return style
+    except Exception as exc:            # noqa: BLE001 - never block an upload over styling
+        _log("Could not read this raster's symbology: {0}: {1}".format(type(exc).__name__, exc))
+        return {}
+    return style
+
+
+def _finite(v) -> bool:
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return False
+    return f == f and f not in (float("inf"), float("-inf"))
+
+
+def _trim(v) -> str:
+    """A stretch is a URL parameter — keep it short and free of float noise."""
+    f = float(v)
+    return str(int(f)) if f == int(f) else repr(round(f, 6))
+
+
+def _enhancement_range(enhancement):
+    """`(min, max)` from a contrast enhancement, or `(None, None)` when it has no usable one."""
+    if enhancement is None:
+        return (None, None)
+    lo, hi = enhancement.minimumValue(), enhancement.maximumValue()
+    if _finite(lo) and _finite(hi) and hi > lo:
+        return (lo, hi)
+    return (None, None)
+
+
+def _ramp_name(renderer) -> str | None:
+    """The lower-cased name of the renderer's colour ramp, if it has a named one."""
+    try:
+        shader = renderer.shader()
+        fn = shader.rasterShaderFunction() if shader else None
+        ramp = fn.sourceColorRamp() if fn and hasattr(fn, "sourceColorRamp") else None
+        # `type()` is the ramp KIND ("gradient", "cpt-city", …); cpt-city ramps carry a real name.
+        name = getattr(ramp, "schemeName", None)
+        name = name() if callable(name) else None
+        return (name or "").strip().lower() or None
+    except Exception:                   # noqa: BLE001 - a missing ramp is not an error
+        return None
 
 
 def from_qgis(qgis_layer) -> dict:

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -409,6 +409,25 @@
       font-size: 10.5px; color: var(--text-muted); white-space: nowrap;
       overflow: hidden; text-overflow: ellipsis; font-variant-numeric: tabular-nums;
     }
+    /* "Colour by <field>" / "Size by <field>". A row of swatches without the column name shows
+       THAT something varies without saying what — the caption is what makes a legend a statement
+       rather than a puzzle. Quiet, because it is context and not the content. */
+    .legend-by {
+      font-size: 10px; color: var(--muted, #6b7280); margin: 1px 0 3px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .legend-field { color: var(--text-muted); font-weight: 600; }
+    /* Size symbology is a second dimension and can appear WITH graduated colour, so it sits below
+       the classes with a rule between rather than replacing them. */
+    .legend-size { margin-top: 5px; padding-top: 4px; border-top: 1px solid var(--border); }
+    .legend-size-row { display: flex; align-items: flex-end; gap: 14px; }
+    .legend-size-item { display: flex; flex-direction: column; align-items: center; gap: 3px; }
+    /* Fixed height so the two ends sit on one baseline however different their sizes are —
+       otherwise the small end floats in the middle of the row. */
+    .legend-size-swatch {
+      display: flex; align-items: flex-end; justify-content: center;
+      min-height: 30px; min-width: 30px;
+    }
     .legend-bar { height: 10px; border-radius: 3px; border: 1px solid var(--border); }
     .legend-range {
       display: flex; justify-content: space-between;

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -1720,7 +1720,8 @@
         '</div>' +
         (type === 'raster' && !meta['geodeploy:external']
           ? '<div class="layer-legend" data-legend="' + layer.id + '">' + rasterLegendHtml(layer) + '</div>'
-          : vectorLegendHtml(meta['geodeploy:legend'], geom));
+          : vectorLegendHtml(meta['geodeploy:legend'], geom,
+                             meta['geodeploy:legendField'], meta['geodeploy:sizeLegend'], color));
       container.appendChild(card);
     });
 
@@ -2459,14 +2460,47 @@
    * Empty for a single-symbol layer: the swatch beside the name already says everything there is
    * to say, and a one-row legend repeating it is noise.
    */
-  function vectorLegendHtml(entries, geom) {
-    if (!Array.isArray(entries) || !entries.length) return '';
+  // A size scale, drawn as the two ENDS of the ramp. The size expression interpolates linearly, so
+  // the ends describe the whole scale; listing intermediate stops would imply steps the map does
+  // not draw. Points show as circles of the real radius, lines as strokes of the real width — the
+  // legend has to look like the map, not merely report numbers about it.
+  function sizeLegendHtml(size, geom, color) {
+    if (!size || !size.field) return '';
+    const swatch = function (px) {
+      const d = Math.max(2, Math.min(28, Number(px) || 2));
+      if (geom === 'line')
+        return '<span class="legend-size-swatch"><span style="display:block;width:26px;height:' +
+          d + 'px;border-radius:' + (d / 2) + 'px;background:' + escHtml(color || '#999') + '"></span></span>';
+      return '<span class="legend-size-swatch"><span style="display:block;width:' + (d * 2) +
+        'px;height:' + (d * 2) + 'px;border-radius:50%;background:' + escHtml(color || '#999') +
+        '"></span></span>';
+    };
+    return '<div class="legend-size">' +
+      '<div class="legend-by">Size by <span class="legend-field">' + escHtml(size.field) + '</span></div>' +
+      '<div class="legend-size-row">' +
+        '<span class="legend-size-item">' + swatch(size.min_size) +
+          '<span class="legend-label">' + escHtml(String(size.min_label)) + '</span></span>' +
+        '<span class="legend-size-item">' + swatch(size.max_size) +
+          '<span class="legend-label">' + escHtml(String(size.max_label)) + '</span></span>' +
+      '</div></div>';
+  }
+
+  function vectorLegendHtml(entries, geom, field, size, color) {
+    const sizeHtml = sizeLegendHtml(size, geom, color);
+    // Size can vary while colour does not — they are independent dimensions — so a layer with no
+    // classes may still have a legend worth showing.
+    if (!Array.isArray(entries) || !entries.length)
+      return sizeHtml ? '<div class="layer-legend legend-classes">' + sizeHtml + '</div>' : '';
     const rows = entries.map(function (e) {
       return '<div class="legend-class">' +
         '<span class="legend-chip" style="background:' + escHtml(e.color || '#999') + '"></span>' +
         '<span class="legend-label">' + escHtml(e.label == null ? '' : String(e.label)) + '</span>' +
         '</div>';
     }).join('');
+    // Naming the COLUMN turns a row of colours into a statement: without it a reader can see that
+    // something varies but not what.
+    const by = field ? '<div class="legend-by">Colour by <span class="legend-field">' +
+      escHtml(field) + '</span></div>' : '';
     // A count button, then the classes. Collapsing is a DISPLAY state and nothing else: the entries
     // come from `geodeploy:legend`, baked at publish from the same class list the map draws, and are
     // never rebuilt here — that is what stops a published legend drifting from its map.
@@ -2475,7 +2509,7 @@
       '<span class="legend-caret" aria-hidden="true">▾</span>' +
       '<span class="legend-count">' + entries.length + ' classes</span></button>';
     return '<div class="layer-legend legend-classes">' + head +
-      '<div class="legend-body">' + rows + '</div></div>';
+      '<div class="legend-body">' + by + rows + sizeHtml + '</div></div>';
   }
 
   function rasterLegendHtml(layer) {

--- a/ui/src/components/portal/LayerPanel.vue
+++ b/ui/src/components/portal/LayerPanel.vue
@@ -124,6 +124,11 @@
 
                 <!-- The legend, editable. Each swatch is the actual colour the map will use, so this
                      doubles as the preview of the classification. -->
+                <!-- Name the COLUMN. Swatches alone show that something varies without saying
+                     what, and the published legend now says it — these two must agree. -->
+                <p v-if="legend.length && colorField" class="text-[11px] text-muted-foreground/70">
+                  Colour by <span class="font-medium text-muted-foreground">{{ colorField }}</span>
+                </p>
                 <div v-if="legend.length" class="space-y-0.5 max-h-40 overflow-y-auto pr-1">
                   <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-1.5">
                     <input type="color" :value="e.color" @input="setEntryColor(i, $event.target.value)"
@@ -276,6 +281,30 @@
               <p v-else-if="sizeField && sizeBusy" class="text-[11px] text-muted-foreground/70">
                 Reading the field…
               </p>
+              <!-- The same two-ended scale the published legend draws, so what is configured here
+                   and what a reader sees there are visibly the same thing. Two ends only: the size
+                   expression interpolates linearly, and drawing intermediate steps would imply
+                   classes the map does not have. -->
+              <div v-if="sizeField && sizeRange" class="flex items-end gap-4 pt-1">
+                <div v-for="(end, i) in [0, 1]" :key="i"
+                  class="flex flex-col items-center gap-1 min-w-[34px]">
+                  <span class="flex items-end justify-center" style="min-height:30px">
+                    <span v-if="geomType === 'line'" :style="{
+                      display: 'block', width: '26px',
+                      height: Math.max(2, Math.min(28, sizePx[end])) + 'px',
+                      borderRadius: (Math.max(2, Math.min(28, sizePx[end])) / 2) + 'px',
+                      background: baseColor }" />
+                    <span v-else :style="{
+                      display: 'block',
+                      width: (Math.max(2, Math.min(28, sizePx[end])) * 2) + 'px',
+                      height: (Math.max(2, Math.min(28, sizePx[end])) * 2) + 'px',
+                      borderRadius: '50%', background: baseColor }" />
+                  </span>
+                  <span class="text-[10.5px] text-muted-foreground tabular-nums">
+                    {{ sizeRange[end] }}
+                  </span>
+                </div>
+              </div>
             </div>
 
             <!-- 3D. Polygons extrude directly (MapLibre raises a fill); POINTS become pillars —
@@ -634,6 +663,17 @@ const numericFields = computed(() => styleFields.value.filter(
 // offered for both because a numeric-looking code (a zone, a year) is legitimately categorical.
 const colorFields = computed(() =>
   colorMode.value === 'graduated' ? numericFields.value : styleFields.value)
+
+// The column actually driving colour — null for a single symbol, where naming a field would be a
+// lie. Mirrors `services/symbology.color_field`, which is what the published legend uses.
+const colorField = computed(() =>
+  colorMode.value === 'single' ? null : (props.config.style?.color_field || null))
+
+// The colour a size swatch is drawn in. A data-driven layer has no single colour, so the first
+// class stands for the layer — the swatch is demonstrating SIZE, and an arbitrary blue would read
+// as if the layer were blue.
+const baseColor = computed(() =>
+  (legend.value[0] && legend.value[0].color) || props.config.style?.color || '#3b82f6')
 
 const legend = computed(() => {
   const entries = legendEntries(props.config.style || {})


### PR DESCRIPTION
Three gaps found by using the thing.

## A legend showed only colour

Size is an independent dimension — `size_mode` is deliberately separate from `color_mode`, so that
colouring by population while sizing by area is possible. A legend showing only the classes
therefore describes half the map, and omits the half deciding how big things are.

Size now appears in the **published legend** and the **editor**: the two ends of the scale, drawn at
the real radius or line width, and rendered *alongside* graduated colour — the combination that
prompted this.

Two ends only, on purpose: the size expression interpolates linearly, so listing intermediate stops
would imply classes the map does not draw.

## No legend named its column

A row of swatches shows *that* something varies without saying what. Both legends now caption
**"Colour by `<field>`"** and **"Size by `<field>`"**.

Baked as separate keys (`geodeploy:legendField`, `geodeploy:sizeLegend`) rather than folded into the
entries array, so a portal published by an older version stays readable — the keys are simply absent
and nothing renders.

## A raster uploaded from QGIS lost its symbology entirely

`from_qgis` only understands vector renderers, so a GeoTIFF produced `{}` — and the payload was the
vector shape (`{opacity, style, popup_fields}`) where a raster needs `{colormap, rescale, bidx}`.
**"Send its styling too" was a silent no-op for every raster.**

Now translated, in order of how faithfully each part survives:

- **`rescale`** — exact, and the part that matters most. Non-8-bit data renders **black** on a tile
  server that assumes 0–255, so the stretch is the difference between a visible layer and a black
  rectangle. QGIS knows the numbers; there is no reason to make the server guess them again.
- **`bidx`** — exact, including the three bands of an RGB composite.
- **`colormap`** — best effort, and **only when the server confirms it has one by that name**. QGIS
  ramps and TiTiler colormaps are different catalogues that merely overlap, and a wrong colormap is
  worse than the default.

The dock also stops claiming styling it did not send: an untranslatable renderer now says so.

## Verification

27 tests over the legend helpers (size ends, stop ordering, fixed-size layers, single symbols, and
colour+size together), plus the raster translation exercised against stand-in renderers:

```
RGB composite      -> {'bidx': [3, 2, 1], 'rescale': '0,3000'}
single-band gray   -> {'bidx': [1], 'rescale': '-12.5,47.25'}
pseudocolor+ramp   -> {'bidx': [2], 'rescale': '0,1', 'colormap': 'viridis'}
unknown ramp       -> no colormap claimed
degenerate ranges  -> refused
unknown renderer   -> {}
```

## Also

Roadmap: **a page for a layer** — click a layer in My Data to get its own page with a map, its
metadata, how it is served, its symbology edited in place, and its attribute table. Requested
separately; no new backend behind it, since all of it is already served.