### PR TITLE
fix: 3D shapefiles, private layers in QGIS, size-by-field, and portals

### DIFF
--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -53,6 +53,7 @@ async def list_layers(user: User = Depends(require_scope("data:read")), db: Asyn
                 algorithm=ds.get("algorithm"),
                 zfactor=ds.get("zfactor"),
                 bidx=ds.get("bidx"),
+                color_classes=ds.get("color_classes"),
                 band_count=l.band_count,
             )
         out.append(obj)
@@ -401,12 +402,20 @@ async def raster_legend(layer_ref: str, request: Request, db: AsyncSession = Dep
         if not allowed:
             raise HTTPException(404, "No shared raster for this layer.")
 
+    # A RASTER's default style is stored FLAT — {opacity, colormap, rescale, …} — where a vector's
+    # nests the visual part under "style". This route was written against the vector shape, so
+    # `.get("style")` was always missing and every field came back null: verified on a live
+    # instance, where a raster with `rescale: "0.0,2.0"` reported `rescale: null`. The legend has
+    # therefore never told a renderer anything it did not already have to guess.
+    #
+    # Both shapes are read, flat first, so nothing depends on which version wrote the row.
     style = {}
     if layer.default_style:
         try:
-            style = json.loads(layer.default_style).get("style") or {}
+            stored = json.loads(layer.default_style) or {}
         except ValueError:
-            style = {}
+            stored = {}
+        style = stored if "style" not in stored else (stored.get("style") or {})
     rescale = style.get("rescale")
     if isinstance(rescale, str):
         # Stored as TiTiler wants it ("min,max"); a client wants numbers.
@@ -418,7 +427,13 @@ async def raster_legend(layer_ref: str, request: Request, db: AsyncSession = Dep
         "layer": layer.name,
         "ref": layer.uid or str(layer.id),
         "kind": "raster",
-        "ramp": True,                       # continuous, so `entries` would be a lie
+        # A CLASSIFIED raster is not a ramp. Saying it is would make every renderer draw a
+        # gradient over land-cover codes — a legend that disagrees with the map it describes.
+        "ramp": not bool(style.get("color_classes")),
+        "entries": [{"value": c.get("value"), "color": c.get("color"),
+                     "label": str(c.get("label") or c.get("value"))}
+                    for c in (style.get("color_classes") or [])],
+        "color_classes": style.get("color_classes") or None,
         "colormap": style.get("colormap"),
         "rescale": rescale,
         "algorithm": style.get("algorithm"),
@@ -458,6 +473,7 @@ async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
         "tiles": [base + raster_tile_url(
             layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
             algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
+            color_classes=ds.get("color_classes"),
             band_count=layer.band_count)],
         "minzoom": 0,
         "maxzoom": 22,
@@ -541,6 +557,7 @@ async def raster_wmts(layer_ref: str, request: Request, db: AsyncSession = Depen
     tmpl = base + raster_tile_url(
         layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
         algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
+        color_classes=ds.get("color_classes"),
         band_count=layer.band_count)
     tmpl = (tmpl.replace("{z}", "{TileMatrix}").replace("{x}", "{TileCol}")
                 .replace("{y}", "{TileRow}"))
@@ -652,7 +669,19 @@ async def save_default_style(
     layer = result.scalar_one_or_none()
     if not layer:
         raise HTTPException(404, "Layer not found.")
-    layer.default_style = json.dumps(body.model_dump())
+    # MERGE, do not replace. `model_dump()` fills every field the model knows about, so a client
+    # that has not been taught about a newer one — the web UI's raster panel does not yet edit
+    # `color_classes` — silently sent null for it and DESTROYED a paletted raster's palette just by
+    # saving an unrelated change. `exclude_unset` keeps only what the caller actually sent, so a
+    # field can still be cleared deliberately (send it as null) but never by omission.
+    stored = {}
+    if layer.default_style:
+        try:
+            stored = json.loads(layer.default_style) or {}
+        except ValueError:
+            stored = {}
+    stored.update(body.model_dump(exclude_unset=True))
+    layer.default_style = json.dumps(stored)
     await db.commit()
     await db.refresh(layer)
     return RasterLayerOut.from_orm_json(layer)

--- a/api/geodeploy/routers/ogcapi.py
+++ b/api/geodeploy/routers/ogcapi.py
@@ -32,7 +32,8 @@ from starlette.concurrency import run_in_threadpool
 from ..config import get_settings
 from ..database import get_db
 from ..models import VectorLayer
-from .common import by_ref
+from .common import by_ref, visible_to
+from ..deps import resolve_optional_user
 
 router = APIRouter(prefix="/ogc", tags=["ogc-api-features"])
 
@@ -105,20 +106,54 @@ def _parse_bbox(raw: str | None) -> list[float] | None:
     return parts
 
 
-async def _public_layers(db: AsyncSession) -> list[VectorLayer]:
-    result = await db.execute(select(VectorLayer).where(
-        VectorLayer.status == "ready", VectorLayer.is_public == True))  # noqa: E712
+async def _readable_layers(request: Request, db: AsyncSession) -> list[VectorLayer]:
+    """Public layers, PLUS whatever the caller's credential lets them see.
+
+    This surface used to be public-only, whatever you sent with it. Someone holding an editor token
+    could list a private layer everywhere else in GeoDeploy and then be told it did not exist here
+    — and since this is how QGIS adds a layer with full attributes, "add my own layer to QGIS" only
+    worked if the layer was published to the world first. A token is an identity; the answer should
+    depend on it.
+    """
+    user = await resolve_optional_user(request, db)
+    where = (VectorLayer.is_public == True) if user is None else visible_to(user, VectorLayer)  # noqa: E712
+    result = await db.execute(select(VectorLayer).where(VectorLayer.status == "ready", where))
     return list(result.scalars().all())
 
 
-async def _get_layer(cid: str, db: AsyncSession) -> VectorLayer:
+async def _get_layer(cid: str, request: Request, db: AsyncSession) -> VectorLayer:
     # `by_ref` accepts the uid AND the legacy integer id (with or without the `vector-` prefix),
     # so collection URLs shared before the uid migration keep working.
     result = await db.execute(select(VectorLayer).where(by_ref(VectorLayer, cid)))
     layer = result.scalar_one_or_none()
-    if not layer or layer.status != "ready" or not layer.is_public:
+    if not layer or layer.status != "ready":
         raise HTTPException(404, "No such collection.")
+    if not layer.is_public:
+        user = await resolve_optional_user(request, db)
+        if user is None:
+            raise HTTPException(404, "No such collection.")
+        # Re-ask with the visibility rule applied, so this route cannot become the one place where
+        # sharing is decided differently from everywhere else.
+        allowed = await db.execute(select(VectorLayer.id).where(
+            VectorLayer.id == layer.id, visible_to(user, VectorLayer)))
+        if allowed.scalar_one_or_none() is None:
+            raise HTTPException(404, "No such collection.")
     return layer
+
+
+def _cors(layer_or_none=None) -> dict:
+    """CORS + cache headers for a response whose CONTENT may depend on the credential.
+
+    `Vary: Authorization` is not optional here. A CDN sits in front of these instances, and without
+    it the first authenticated response would be cached and then served to anonymous callers — a
+    private layer handed out to the world by the cache, from code that filtered correctly.
+    A response carrying anything non-public is marked `private` so it is not stored at all.
+    """
+    headers = dict(CORS)
+    headers["Vary"] = "Authorization"
+    if layer_or_none is not None and not getattr(layer_or_none, "is_public", False):
+        headers["Cache-Control"] = "private, no-store"
+    return headers
 
 
 def _collection(layer, base: str) -> dict:
@@ -186,18 +221,18 @@ async def conformance():
 async def collections(request: Request, db: AsyncSession = Depends(get_db)):
     base = _base(request)
     return SafeJSONResponse({
-        "collections": [_collection(l, base) for l in await _public_layers(db)],
+        "collections": [_collection(l, base) for l in await _readable_layers(request, db)],
         "links": [
             {"rel": "self", "href": f"{_root(base)}/collections", "type": "application/json"},
             {"rel": "root", "href": _root(base), "type": "application/json"},
         ],
-    }, headers=CORS)
+    }, headers=_cors())
 
 
 @router.get("/collections/{cid}")
 async def collection(cid: str, request: Request, db: AsyncSession = Depends(get_db)):
-    layer = await _get_layer(cid, db)
-    return SafeJSONResponse(_collection(layer, _base(request)), headers=CORS)
+    layer = await _get_layer(cid, request, db)
+    return SafeJSONResponse(_collection(layer, _base(request)), headers=_cors(layer))
 
 
 # ── Features ─────────────────────────────────────────────────────────────────────────────────
@@ -210,7 +245,7 @@ async def items(cid: str, request: Request, bbox: str | None = None, limit: int 
     `limit` is capped at MAX_LIMIT — a client that wants everything follows `rel="next"` (which is
     what QGIS/ogr2ogr do). `numberMatched` is best-effort: exact for a bbox query, the stored
     feature count for an unfiltered one, and omitted when counting would be too expensive."""
-    layer = await _get_layer(cid, db)
+    layer = await _get_layer(cid, request, db)
     qb = _parse_bbox(bbox)
     limit = max(1, min(int(limit), MAX_LIMIT))
     offset = max(0, int(offset))
@@ -246,7 +281,7 @@ async def items(cid: str, request: Request, bbox: str | None = None, limit: int 
     }
     if matched is not None:
         doc["numberMatched"] = matched
-    return SafeJSONResponse(doc, media_type=GEOJSON, headers=CORS)
+    return SafeJSONResponse(doc, media_type=GEOJSON, headers=_cors(layer))
 
 
 @router.get("/collections/{cid}/items/{fid}")
@@ -254,7 +289,7 @@ async def item(cid: str, fid: str, request: Request, db: AsyncSession = Depends(
     """A single feature by its id. The id is the table's primary key for a PostGIS layer; for a
     file-backed (GeoParquet) layer it is an `id`-like column when the dataset has one — otherwise
     single-feature access isn't addressable and this 404s (the collection still pages fine)."""
-    layer = await _get_layer(cid, db)
+    layer = await _get_layer(cid, request, db)
     if layer.storage_backend == "geoparquet":
         feature = await _geoparquet_item(layer, fid)
     else:
@@ -266,7 +301,7 @@ async def item(cid: str, fid: str, request: Request, db: AsyncSession = Depends(
         {"rel": "self", "href": f"{_root(base)}/collections/{cid}/items/{fid}", "type": GEOJSON},
         {"rel": "collection", "href": f"{_root(base)}/collections/{cid}", "type": "application/json"},
     ]
-    return SafeJSONResponse(feature, media_type=GEOJSON, headers=CORS)
+    return SafeJSONResponse(feature, media_type=GEOJSON, headers=_cors(layer))
 
 
 # ── PostGIS backend ──────────────────────────────────────────────────────────────────────────

--- a/api/geodeploy/routers/stac.py
+++ b/api/geodeploy/routers/stac.py
@@ -225,7 +225,8 @@ def _raster_assets(layer, base: str) -> dict:
         layer.s3_key,
         colormap=default.get("colormap"), rescale=default.get("rescale"),
         algorithm=default.get("algorithm"), zfactor=default.get("zfactor"),
-        bidx=default.get("bidx"), band_count=layer.band_count,
+        bidx=default.get("bidx"), color_classes=default.get("color_classes"),
+        band_count=layer.band_count,
     )
     return {
         "cog": {

--- a/api/geodeploy/schemas.py
+++ b/api/geodeploy/schemas.py
@@ -468,6 +468,12 @@ class RasterDefaultStyle(BaseModel):
     algorithm: str | None = None     # e.g. "hillshade" (single-band)
     zfactor: float | None = None     # hillshade vertical exaggeration
     bidx: list[int] | None = None    # band selection: [n] single-band, [r,g,b] RGB composite
+    # A colour per pixel VALUE, for data that is classified rather than continuous — land cover,
+    # soil types, a QGIS paletted raster. `colormap` names a gradient, and a gradient cannot
+    # describe a classification: interpolating between class 3 and class 4 means nothing. Shaped
+    # like the vector `categories` list on purpose, so both kinds of "this value is that colour"
+    # read the same way.
+    color_classes: list[dict] | None = None
 
 
 class RasterLayerOut(BaseModel):

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -259,6 +259,7 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
                     algorithm=rstyle.get("algorithm"),
                     zfactor=rstyle.get("zfactor"),
                     bidx=rstyle.get("bidx"),
+                    color_classes=rstyle.get("color_classes"),
                     band_count=layer.band_count,
                 )],
                 "tileSize": 256,

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -155,6 +155,7 @@ def raster_links(layer, base: str, default_style: dict | None = None) -> list[di
     tile_url = base + titiler_svc.get_tile_url(
         layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
         algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
+        color_classes=ds.get("color_classes"),
         band_count=getattr(layer, "band_count", None))
     return [
         _link("tilejson", "TileJSON — raster tiles", f"{api}/tilejson",

--- a/api/geodeploy/services/titiler.py
+++ b/api/geodeploy/services/titiler.py
@@ -1,4 +1,7 @@
 """TiTiler integration — raster tile URL construction."""
+import json
+from urllib.parse import quote
+
 from ..config import get_settings
 
 COLORMAPS = [
@@ -15,6 +18,7 @@ def get_tile_url(
     zfactor: float | str | None = None,
     bidx: list | None = None,
     band_count: int | None = None,
+    color_classes: list | None = None,
     settings=None,
 ) -> str:
     """
@@ -24,6 +28,9 @@ def get_tile_url(
       output (a colormap may apply); three bands → an RGB composite (colormap ignored).
       Empty/None lets TiTiler pick its default bands.
     - colormap: a TiTiler colormap name (single-band data only).
+    - color_classes: [{"value": n, "color": "#rrggbb"}] — an EXPLICIT colour per pixel value, for
+      data that is classified rather than continuous (land cover, soil types, a QGIS paletted
+      raster). Takes precedence over `colormap`, which can only describe a gradient.
     - rescale: "min,max" stretch applied before display (needed for non-8-bit data).
     - algorithm: a TiTiler algorithm such as "hillshade" (single-band DEM data).
     - zfactor: vertical exaggeration for hillshade — applied as a pre-scale expression
@@ -63,9 +70,68 @@ def get_tile_url(
                 url += f"&expression=b1*{z}"
     # colormap only makes sense for single-band output (one selected band, or a
     # single-band raster). It is ignored when an algorithm or an RGB composite is active.
-    elif colormap and len(bands) != 3:
-        url += f"&colormap_name={colormap}"
+    elif len(bands) != 3:
+        explicit = _explicit_colormap(color_classes)
+        if explicit:
+            # A CLASSIFIED raster — land cover, soil types, a QGIS paletted layer — has a colour
+            # per VALUE, which no named gradient can express: interpolating between class 3 and
+            # class 4 is meaningless. TiTiler takes the mapping itself as JSON.
+            url += f"&colormap={quote(explicit, safe='')}"
+        elif colormap:
+            url += f"&colormap_name={colormap}"
     return url
+
+
+#: Every class travels in the URL of EVERY tile request, so the mapping cannot be unbounded — and
+#: the limit is set by what a proxy will accept, not by taste. Percent-encoded JSON costs ~36 bytes
+#: per class, so 256 classes produced a 9.2 kB request line: past nginx's default 8 kB
+#: `large_client_header_buffers`, which would have meant every tile failing and the layer silently
+#: never drawing. 128 lands near 4.6 kB, with room for a long object key.
+#:
+#: It is also far more than real classifications need — CORINE has 44 classes, NLCD about 20,
+#: ESA WorldCover 11. Data with more distinct values than this is continuous in all but name, and a
+#: named colormap is the right tool for it.
+MAX_COLOR_CLASSES = 128
+
+
+def _explicit_colormap(color_classes) -> str | None:
+    """`{"3": [r,g,b,a], …}` as compact JSON, or None when there is nothing usable.
+
+    Silently skips entries that are not a number-plus-colour rather than failing the whole tile
+    URL: a single bad class must not take the layer off the map.
+    """
+    if not color_classes:
+        return None
+    mapping = {}
+    for entry in color_classes[:MAX_COLOR_CLASSES]:
+        if not isinstance(entry, dict):
+            continue
+        rgba = _rgba(entry.get("color"))
+        value = entry.get("value")
+        if rgba is None or value is None:
+            continue
+        try:
+            key = int(value)
+        except (TypeError, ValueError):
+            continue
+        mapping[str(key)] = rgba
+    if not mapping:
+        return None
+    return json.dumps(mapping, separators=(",", ":"))
+
+
+def _rgba(color) -> list | None:
+    """`#rrggbb` (or `#rrggbbaa`) to `[r, g, b, a]`. TiTiler wants 0–255 with alpha."""
+    if not isinstance(color, str):
+        return None
+    text = color.strip().lstrip("#")
+    if len(text) not in (6, 8):
+        return None
+    try:
+        parts = [int(text[i:i + 2], 16) for i in range(0, len(text), 2)]
+    except ValueError:
+        return None
+    return parts if len(parts) == 4 else parts + [255]
 
 
 def get_tilejson_url(s3_key: str, settings=None) -> str:

--- a/api/geodeploy/tasks/vector_ingest.py
+++ b/api/geodeploy/tasks/vector_ingest.py
@@ -81,6 +81,26 @@ def _store_geom_sql(store_srid: int) -> str:
     )
 
 
+def _geom_column(store_srid: int, has_z: bool) -> str:
+    """The geometry column type for the destination table.
+
+    `geometry(Geometry, srid)` is TWO-dimensional. One 3D feature — most shapefiles digitised from
+    a DEM, every GPS track — made the whole INSERT fail with "Geometry has Z dimension but column
+    does not", after the untyped staging table had accepted it without complaint.
+    """
+    return f"geometry(GeometryZ,{store_srid})" if has_z else f"geometry(Geometry,{store_srid})"
+
+
+def _geom_value(geom_sql: str, has_z: bool) -> str:
+    """The INSERT expression: forced to 3D when the layer has any Z at all.
+
+    Force3D even though Z was DETECTED, because one file can mix 2D and 3D features and the typmod
+    rejects the 2D ones just as firmly. Padding a missing Z with 0 keeps the layer loadable;
+    flattening everything to match the 2D features would discard real measurements.
+    """
+    return f"ST_Force3D({geom_sql})" if has_z else geom_sql
+
+
 def _srid_of(crs_wkt) -> int | None:
     if not crs_wkt:
         return None
@@ -594,10 +614,28 @@ def _ingest_via_copy(dsn: str, schema: str, table: str, src_path: str, data_dir:
         with open(tmp_csv, "r", encoding="utf-8", newline="") as fh:
             cur.copy_expert(
                 f"COPY {_q(schema)}.{_q(stg)} ({copycols}, geom) FROM STDIN WITH (FORMAT csv)", fh)
+        # Z, IF THE DATA HAS IT.
+        #
+        # `geometry(Geometry, srid)` is a TWO-dimensional type, so a single 3D feature made the
+        # whole INSERT fail with "Geometry has Z dimension but column does not" — which is most
+        # shapefiles digitised from a DEM, and every GPS track. The staging table is untyped and
+        # accepted them happily; the failure only appeared on the way into the real one.
+        #
+        # Asking the loaded rows is the only reliable answer: a shapefile header declares a type
+        # that the features do not have to honour (see the geometry-type note below, same lesson).
+        cur.execute(f"SELECT bool_or(ST_NDims(geom) > 2) FROM {_q(schema)}.{_q(stg)} "
+                    f"WHERE geom IS NOT NULL")
+        row = cur.fetchone()
+        has_z = bool(row and row[0])
+        # Force3D even though Z was detected: one file can mix 2D and 3D features, and the typmod
+        # rejects the 2D ones just as firmly. Padding a missing Z with 0 keeps the whole layer
+        # loadable; dropping Z from everything to match the 2D features would discard real data.
+        geom_expr = _geom_value(geom_sql, has_z)
+        geom_col = _geom_column(store_srid, has_z)
         cur.execute(f"CREATE TABLE {_q(schema)}.{_q(table)} "
-                    f"(id serial primary key, {coldefs}, geom geometry(Geometry,{store_srid}))")
+                    f"(id serial primary key, {coldefs}, geom {geom_col})")
         cur.execute(f"INSERT INTO {_q(schema)}.{_q(table)} ({copycols}, geom) "
-                    f"SELECT {copycols}, {geom_sql} FROM {_q(schema)}.{_q(stg)}")
+                    f"SELECT {copycols}, {geom_expr} FROM {_q(schema)}.{_q(stg)}")
         cur.execute(f"DROP TABLE {_q(schema)}.{_q(stg)}")
         cur.execute(f"CREATE INDEX {_q(table + '_geom_idx')} ON {_q(schema)}.{_q(table)} USING GIST (geom)")
         # bbox is stored in EPSG:4326 app-wide (map fit / viewport), even when the geometry is native —

--- a/api/tests/test_ingest_z_dimension.py
+++ b/api/tests/test_ingest_z_dimension.py
@@ -1,0 +1,48 @@
+"""A 3D shapefile must import, not fail at the last step.
+
+Uploading one produced:
+
+    Geometry has Z dimension but column does not
+
+`geometry(Geometry, srid)` is a TWO-dimensional type. The staging table is untyped and took the
+features happily, so nothing looked wrong until the INSERT into the real table — which is most
+shapefiles digitised from a DEM, and every GPS track.
+
+Verified against PostGIS 16/3.4 as well as here: the old column type reproduces that exact message,
+and the new one loads a file MIXING 2D and 3D features, keeping srid 4326 and reporting
+coord_dimension 3 in `geometry_columns` (which Martin reads to serve tiles).
+"""
+from geodeploy.tasks.vector_ingest import _geom_column, _geom_value
+
+
+def test_a_layer_with_z_gets_a_three_dimensional_column():
+    assert _geom_column(4326, has_z=True) == "geometry(GeometryZ,4326)"
+    assert _geom_column(3006, has_z=True) == "geometry(GeometryZ,3006)"
+
+
+def test_a_flat_layer_is_unchanged():
+    """The 2D path must stay exactly as it was — this fix is additive or it is a regression."""
+    assert _geom_column(4326, has_z=False) == "geometry(Geometry,4326)"
+    assert _geom_value("ST_SetSRID(geom, 4326)", has_z=False) == "ST_SetSRID(geom, 4326)"
+
+
+def test_z_forces_every_row_to_three_dimensions():
+    """One file can mix 2D and 3D features, and the typmod rejects the 2D ones just as firmly."""
+    assert _geom_value("ST_SetSRID(geom, 4326)", has_z=True) == "ST_Force3D(ST_SetSRID(geom, 4326))"
+
+
+def test_the_mercator_clamp_survives_the_wrapping():
+    """The pole clamp is a CASE expression; Force3D must wrap it whole rather than mangle it."""
+    from geodeploy.tasks.vector_ingest import _store_geom_sql
+
+    clamped = _store_geom_sql(4326)
+    wrapped = _geom_value(clamped, has_z=True)
+    assert wrapped.startswith("ST_Force3D(CASE WHEN") and wrapped.endswith("END)")
+    assert "ST_Intersection" in wrapped        # the clamp is still in there, not replaced
+
+
+def test_srid_is_preserved_in_the_typmod():
+    """Losing the srid here would leave Martin reading srid 0 and serving no tiles at all."""
+    for srid in (4326, 3857, 3006, 32633):
+        assert str(srid) in _geom_column(srid, has_z=True)
+        assert str(srid) in _geom_column(srid, has_z=False)

--- a/api/tests/test_ogcapi.py
+++ b/api/tests/test_ogcapi.py
@@ -391,3 +391,69 @@ async def test_uid_is_generated_for_new_layers(db):
     await db.commit()
     layer = (await db.execute(sel(VL).where(VL.id == 99))).scalar_one()
     assert layer.uid and len(layer.uid) == 12 and layer.uid != "99"
+
+
+# ── The credential decides what exists ────────────────────────────────────────────────────────
+# This surface was public-only whatever you sent with it. Someone holding an editor token could
+# list a private layer everywhere else in GeoDeploy and be told it did not exist here — and since
+# OAPIF is how QGIS adds a layer with full attributes, "add my own layer to QGIS" only worked if
+# the layer had been published to the world first. Measured on a live instance before the fix: the
+# token could see 14 layers; OAPIF offered 8, with or without it.
+
+@pytest.mark.asyncio
+async def test_a_token_widens_the_collection_list(client, db):
+    await _seed(db)
+    # By TITLE, not id: a layer seeded without an explicit uid gets a generated one, and the
+    # document always reports the canonical uid rather than whatever was asked for.
+    anon = {c["title"] for c in (await client.get("/api/ogc/collections")).json()["collections"]}
+    owner = {c["title"] for c in
+             (await client.get("/api/ogc/collections", headers=_auth())).json()["collections"]}
+    assert "Internal" not in anon
+    assert "Internal" in owner
+    assert anon < owner, "a credential must only ever ADD to what is visible"
+
+
+@pytest.mark.asyncio
+async def test_a_private_collection_is_readable_with_a_token(client, db):
+    await _seed(db)
+    cid = f"vector-{ORG_PG}"
+    assert (await client.get(f"/api/ogc/collections/{cid}")).status_code == 404
+    r = await client.get(f"/api/ogc/collections/{cid}", headers=_auth())
+    assert r.status_code == 200
+    # Requested by the legacy integer id; answered with the canonical uid, as elsewhere.
+    assert r.json()["title"] == "Internal"
+    assert r.json()["id"].startswith("vector-")
+
+
+@pytest.mark.asyncio
+async def test_an_unready_layer_is_404_even_with_a_token(client, db):
+    """Authentication widens visibility, not readiness — a half-ingested table has nothing to serve."""
+    await _seed(db)
+    r = await client.get(f"/api/ogc/collections/vector-{PROCESSING}", headers=_auth())
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_private_response_is_never_stored_by_a_shared_cache(client, db):
+    """A CDN sits in front of these instances. Without `Vary`, the first authenticated response
+    would be cached and then handed to anonymous callers — correct filtering undone by the cache."""
+    await _seed(db)
+    r = await client.get(f"/api/ogc/collections/vector-{ORG_PG}", headers=_auth())
+    assert r.status_code == 200
+    assert r.headers.get("vary", "").lower() == "authorization"
+    cache = r.headers.get("cache-control", "")
+    assert "private" in cache and "no-store" in cache
+
+
+@pytest.mark.asyncio
+async def test_the_collections_list_varies_on_authorization(client, db):
+    await _seed(db)
+    r = await client.get("/api/ogc/collections")
+    assert r.headers.get("vary", "").lower() == "authorization"
+
+
+def test_public_responses_stay_shared_cacheable():
+    """The public path keeps its shared caching — that is what makes the anonymous catalog cheap,
+    and nothing about it depends on a credential."""
+    headers = ogcapi._cors(type("L", (), {"is_public": True})())
+    assert "public" in headers["Cache-Control"] and headers["Vary"] == "Authorization"

--- a/api/tests/test_paletted_raster.py
+++ b/api/tests/test_paletted_raster.py
@@ -1,0 +1,190 @@
+"""A classified raster keeps its per-value colours.
+
+`colormap` names a GRADIENT, and a gradient cannot describe a classification: interpolating between
+class 3 and class 4 means nothing. Land cover, soil types and a QGIS paletted layer all give each
+pixel VALUE its own colour, so the mapping itself has to travel — TiTiler takes it as JSON.
+
+The cap matters as much as the feature: this mapping rides in the URL of every single tile request,
+so an unbounded one would put kilobytes on the wire per tile and eventually exceed what a proxy
+will accept.
+"""
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from jose import jwt
+from passlib.context import CryptContext
+
+from geodeploy.config import get_settings
+from geodeploy.models import RasterLayer, User
+from geodeploy.services.titiler import MAX_COLOR_CLASSES, get_tile_url
+
+_pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+OWNER = 1
+_next_id = [500]
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer " + jwt.encode({"sub": str(OWNER)},
+                                                    get_settings().secret_key, algorithm="HS256")}
+
+
+async def _seed_raster(db, style: dict, public: bool = False) -> RasterLayer:
+    """One ready raster owned by OWNER, carrying `style` as its default style."""
+    existing = await db.get(User, OWNER)
+    if existing is None:
+        db.add(User(id=OWNER, email="o@example.com", name="O", hashed_password=_pwd.hash("pw"),
+                    is_admin=True, role="owner"))
+        await db.flush()
+    _next_id[0] += 1
+    layer = RasterLayer(id=_next_id[0], user_id=OWNER, name="Land cover",
+                        s3_key="rasters/1/x/landcover.tif", status="ready", band_count=1,
+                        visibility="public" if public else "organization", is_public=public,
+                        default_style=json.dumps(style))
+    db.add(layer)
+    await db.commit()
+    await db.refresh(layer)
+    return layer
+
+
+class _S:
+    storage_bucket = "geodeploy"
+
+
+def _params(url):
+    return parse_qs(urlparse(url).query)
+
+
+CLASSES = [{"value": 1, "color": "#ff0000"},
+           {"value": 2, "color": "#00ff00"},
+           {"value": 3, "color": "#0000ff"}]
+
+
+def test_classes_become_an_explicit_colormap():
+    url = get_tile_url("r/x.tif", color_classes=CLASSES, settings=_S())
+    cm = json.loads(_params(url)["colormap"][0])
+    assert cm == {"1": [255, 0, 0, 255], "2": [0, 255, 0, 255], "3": [0, 0, 255, 255]}
+    assert "colormap_name" not in _params(url)
+
+
+def test_explicit_classes_beat_a_named_ramp():
+    """Both set is not a conflict to resolve arbitrarily: the classes are the more specific
+    statement, and a gradient over classified data is simply wrong."""
+    url = get_tile_url("r/x.tif", colormap="viridis", color_classes=CLASSES, settings=_S())
+    assert "colormap_name" not in _params(url)
+    assert "colormap" in _params(url)
+
+
+def test_a_named_ramp_still_works_when_there_are_no_classes():
+    url = get_tile_url("r/x.tif", colormap="viridis", settings=_S())
+    assert _params(url)["colormap_name"] == ["viridis"]
+
+
+def test_alpha_is_preserved_and_defaulted():
+    """A class can be transparent — "no data" in a land-cover raster usually is."""
+    url = get_tile_url("r/x.tif", settings=_S(),
+                       color_classes=[{"value": 0, "color": "#00000000"},
+                                      {"value": 1, "color": "#abcdef"}])
+    cm = json.loads(_params(url)["colormap"][0])
+    assert cm["0"] == [0, 0, 0, 0]          # fully transparent, as written
+    assert cm["1"] == [171, 205, 239, 255]  # opaque by default
+
+
+def test_junk_entries_are_skipped_not_fatal():
+    """One malformed class must not take the whole layer off the map."""
+    url = get_tile_url("r/x.tif", settings=_S(), color_classes=[
+        {"value": 1, "color": "#ff0000"},
+        {"value": "not a number", "color": "#00ff00"},
+        {"value": 3, "color": "nonsense"},
+        {"color": "#0000ff"},               # no value
+        "not even a dict",
+    ])
+    cm = json.loads(_params(url)["colormap"][0])
+    assert cm == {"1": [255, 0, 0, 255]}
+
+
+def test_no_usable_classes_falls_back_to_the_named_ramp():
+    url = get_tile_url("r/x.tif", colormap="magma", settings=_S(),
+                       color_classes=[{"value": None, "color": None}])
+    assert _params(url)["colormap_name"] == ["magma"]
+
+
+def test_the_mapping_is_capped():
+    """It rides in EVERY tile URL. 256 covers a byte-valued classification, which is what this is
+    for; past that the data is continuous in all but name."""
+    many = [{"value": i, "color": "#010203"} for i in range(MAX_COLOR_CLASSES + 50)]
+    cm = json.loads(_params(get_tile_url("r/x.tif", color_classes=many, settings=_S()))["colormap"][0])
+    assert len(cm) == MAX_COLOR_CLASSES
+
+
+def test_a_full_cap_url_stays_within_a_sane_request_line():
+    """nginx's default large_client_header_buffers line limit is 8 kB. A tile URL at the cap has to
+    fit inside it with room to spare, or every tile 414s and the layer silently never draws."""
+    many = [{"value": i, "color": "#010203"} for i in range(MAX_COLOR_CLASSES)]
+    url = get_tile_url("rasters/1/deadbeef/landcover.tif", color_classes=many, settings=_S())
+    assert len(url) < 6000, f"tile URL is {len(url)} bytes"
+
+
+def test_rgb_composites_ignore_classes():
+    """Three bands are already colours; a per-value mapping has no meaning there."""
+    url = get_tile_url("r/x.tif", bidx=[3, 2, 1], color_classes=CLASSES, settings=_S())
+    assert "colormap" not in _params(url)
+
+
+def test_hillshade_ignores_classes():
+    """A hillshade is a finished relief image — the same reason `colormap` is dropped for it."""
+    url = get_tile_url("r/x.tif", algorithm="hillshade", color_classes=CLASSES, settings=_S())
+    assert "colormap" not in _params(url)
+    assert _params(url)["algorithm"] == ["hillshade"]
+
+
+# ── The two API-side gaps a classified raster exposes ─────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_saving_a_style_does_not_wipe_fields_the_client_never_sent(client, db, auth):
+    """The web UI's raster panel does not edit `color_classes`. A full-replace PUT therefore
+    destroyed a paletted raster's palette as a side effect of changing the opacity — data loss
+    caused by a client being older than the schema, which is the normal state of affairs."""
+    layer = await _seed_raster(db, {"colormap": "viridis", "rescale": "0,100",
+                                    "color_classes": [{"value": 1, "color": "#ff0000"}]})
+    r = await client.put(f"/api/data/raster/{layer.id}/default-style",
+                         json={"opacity": 0.5}, headers=auth)
+    assert r.status_code == 200
+    await db.refresh(layer)
+    stored = json.loads(layer.default_style)
+    assert stored["color_classes"] == [{"value": 1, "color": "#ff0000"}], "the palette was wiped"
+    assert stored["colormap"] == "viridis"
+    assert stored["opacity"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_a_field_can_still_be_cleared_on_purpose(client, db, auth):
+    """Merging must not make a field unclearable — sending it as null is the way to mean it."""
+    layer = await _seed_raster(db, {"color_classes": [{"value": 1, "color": "#ff0000"}]})
+    r = await client.put(f"/api/data/raster/{layer.id}/default-style",
+                         json={"color_classes": None}, headers=auth)
+    assert r.status_code == 200
+    await db.refresh(layer)
+    assert json.loads(layer.default_style)["color_classes"] is None
+
+
+@pytest.mark.asyncio
+async def test_the_legend_says_a_classified_raster_is_not_a_ramp(client, db, auth):
+    """Reporting `ramp: true` for classified data makes every renderer draw a gradient over land
+    cover codes — a legend that disagrees with the map it describes."""
+    layer = await _seed_raster(db, {"color_classes": [
+        {"value": 1, "color": "#ff0000"}, {"value": 2, "color": "#00ff00"}]}, public=True)
+    body = (await client.get(f"/api/data/raster/{layer.id}/legend")).json()
+    assert body["ramp"] is False
+    assert [e["value"] for e in body["entries"]] == [1, 2]
+    assert body["color_classes"]
+
+
+@pytest.mark.asyncio
+async def test_a_continuous_raster_is_still_a_ramp(client, db, auth):
+    layer = await _seed_raster(db, {"colormap": "viridis", "rescale": "0,100"}, public=True)
+    body = (await client.get(f"/api/data/raster/{layer.id}/legend")).json()
+    assert body["ramp"] is True
+    assert body["entries"] == []
+    assert body["colormap"] == "viridis"

--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -69,6 +69,23 @@ class Instance:
                 pass
         return (self.client.catalog.public() or {}).get("portals") or []
 
+    def published_style(self, slug: str) -> dict:
+        """A published portal's own style.json — served to anyone, no credential involved.
+
+        Reading a portal through `/api/portals/<id>` needs a token. A PUBLISHED portal is public by
+        definition, and this is the document its own web page loads, so it is the honest source for
+        "show me this portal" without an account.
+        """
+        import json
+        from urllib.request import urlopen
+
+        url = "{0}/portals/{1}/style.json".format(self.url.rstrip("/"), slug)
+        try:
+            with urlopen(url, timeout=30) as response:      # noqa: S310 - our own instance URL
+                return json.loads(response.read().decode("utf-8"))
+        except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
+            raise GeoDeployError("Could not read the published portal at {0}: {1}".format(url, exc))
+
     def check(self) -> dict:
         """Prove the connection works, and say what kind it is — shown in the dock's header.
 

--- a/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
@@ -59,8 +59,20 @@ def confirm(parent, portal_title: str, plan: dict, creating: bool):
     dialog.setWindowTitle(("Create portal " if creating else "Update portal ") + portal_title)
     layout = QVBoxLayout(dialog)
 
-    headline = ("This will CREATE the portal “{0}”." if creating
-                else "This will UPDATE the published portal “{0}”.").format(portal_title)
+    uploads_n = len(plan.get("uploads") or [])
+    existing_n = (len(plan.get("unchanged") or []) + len(plan.get("restyled") or [])
+                  + len(plan.get("added") or []))
+    if creating and uploads_n and not existing_n:
+        # The "start in QGIS, end with a URL" case. Everything here is a local file, so the whole
+        # group is about to be UPLOADED before the portal can exist — that is a much bigger action
+        # than "publish a portal", and the headline should say so before the file sizes do.
+        headline = ("None of these {0} layer(s) are on the instance yet. All of them will be "
+                    "UPLOADED, then the portal “{1}” will be created and published.").format(
+                        uploads_n, portal_title)
+    elif creating:
+        headline = "This will CREATE the portal “{0}”.".format(portal_title)
+    else:
+        headline = "This will UPDATE the published portal “{0}”.".format(portal_title)
     label = QLabel(headline)
     label.setWordWrap(True)
     layout.addWidget(label)

--- a/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
@@ -1,0 +1,106 @@
+"""What pushing this group would do, shown before it happens.
+
+Republishing a portal from QGIS is a write with several distinct consequences — layers added,
+layers removed, styles changed, and possibly files uploaded — and they are not equally reversible.
+Deleting a layer from a portal is a click to undo; uploading a 2 GB file is not, and neither is
+discovering afterwards that a layer you were only inspecting has been published.
+
+So the push is never silent. It states each change in the user's own vocabulary (the layer names
+they see in the panel), and the two consequential ones — uploading new files, dropping removed
+layers — are separate opt-ins rather than one blanket "OK". Unchanged layers are shown too: seeing
+"6 unchanged" is what tells you the other three lines are the whole story.
+"""
+from __future__ import annotations
+
+try:                                    # pragma: no cover - only present inside QGIS
+    from qgis.PyQt.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QLabel, QVBoxLayout,
+                                     QTextEdit)
+    QGIS = True
+except ImportError:                     # pragma: no cover - importable for tests
+    QGIS = False
+
+
+def summarise(plan: dict) -> str:
+    """The plan as plain text. Separated from the dialog so it can be tested without a GUI."""
+    lines = []
+    rename = plan.get("rename")
+    if rename:
+        lines.append("Rename the portal:")
+        lines.append("    {0}  ->  {1}".format(rename[0] or "(untitled)", rename[1]))
+        lines.append("")
+
+    def section(title, items):
+        if items:
+            lines.append("{0} ({1}):".format(title, len(items)))
+            lines.extend("    " + name for name in items)
+            lines.append("")
+
+    section("Unchanged", plan.get("unchanged") or [])
+    section("Restyled", plan.get("restyled") or [])
+    section("Added — already on the instance", plan.get("added") or [])
+    section("New — not on the instance yet", plan.get("uploads") or [])
+    section("Removed from the portal", plan.get("removed") or [])
+    if not lines:
+        lines = ["Nothing would change."]
+    return "\n".join(lines).rstrip()
+
+
+def confirm(parent, portal_title: str, plan: dict, creating: bool):
+    """Show the plan. Returns `(go_ahead, upload_new, drop_removed)`.
+
+    The two checkboxes default to ON — they are what the user is asking for by pushing a group they
+    have edited — but they are visible and separable, so "publish my restyle without uploading that
+    scratch layer" is one click rather than a reorganisation of the project.
+    """
+    if not QGIS:                        # pragma: no cover - no GUI in tests
+        return (False, False, False)
+
+    dialog = QDialog(parent)
+    dialog.setWindowTitle(("Create portal " if creating else "Update portal ") + portal_title)
+    layout = QVBoxLayout(dialog)
+
+    headline = ("This will CREATE the portal “{0}”." if creating
+                else "This will UPDATE the published portal “{0}”.").format(portal_title)
+    label = QLabel(headline)
+    label.setWordWrap(True)
+    layout.addWidget(label)
+
+    body = QTextEdit()
+    body.setReadOnly(True)
+    body.setPlainText(summarise(plan))
+    body.setMinimumSize(460, 260)
+    layout.addWidget(body)
+
+    uploads = plan.get("uploads") or []
+    removed = plan.get("removed") or []
+
+    upload_box = QCheckBox("Upload the {0} new layer(s) and add them".format(len(uploads)))
+    upload_box.setChecked(True)
+    upload_box.setEnabled(bool(uploads))
+    if not uploads:
+        upload_box.setText("No new layers to upload")
+    layout.addWidget(upload_box)
+
+    drop_box = QCheckBox("Remove the {0} layer(s) taken out of the group".format(len(removed)))
+    drop_box.setChecked(True)
+    drop_box.setEnabled(bool(removed))
+    if not removed:
+        drop_box.setText("No layers to remove")
+    else:
+        drop_box.setToolTip("Only removes them FROM THE PORTAL. The layers stay on the instance.")
+    layout.addWidget(drop_box)
+
+    note = QLabel("Removing a layer from a portal does not delete it from GeoDeploy.")
+    note.setWordWrap(True)
+    layout.addWidget(note)
+
+    buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+    buttons.button(QDialogButtonBox.Ok).setText("Publish" if not creating else "Create and publish")
+    buttons.accepted.connect(dialog.accept)
+    buttons.rejected.connect(dialog.reject)
+    layout.addWidget(buttons)
+
+    if dialog.exec_() != QDialog.Accepted:
+        return (False, False, False)
+    return (True, upload_box.isChecked() and bool(uploads),
+            drop_box.isChecked() and bool(removed))

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -59,6 +59,7 @@ class GeoDeployDock(QDockWidget):
         self.iface = iface
         self.instance: Instance | None = None
         self._rows: list[dict] = []
+        self._portals: list[dict] = []
 
         body = QWidget()
         outer = QVBoxLayout(body)
@@ -105,11 +106,12 @@ class GeoDeployDock(QDockWidget):
             "geometry and every attribute, at a server round-trip per pan.")
         outer.addWidget(self.attributes)
 
-        add = QPushButton("Add to map")
-        add.clicked.connect(self.add_selected)
-        outer.addWidget(add)
+        self.add_btn = QPushButton("Add to map")
+        self.add_btn.clicked.connect(self.add_selected)
+        outer.addWidget(self.add_btn)
+        self.tree.itemSelectionChanged.connect(self._on_selection_changed)
 
-        # -- upload -------------------------------------------------------------------------------
+    # -- upload -------------------------------------------------------------------------------
         self.upload_btn = QPushButton("Upload selected layer(s)…")
         self.upload_btn.setToolTip(
             "Uploads every layer selected in the Layers panel, one after another — or the active "
@@ -151,6 +153,49 @@ class GeoDeployDock(QDockWidget):
         # fine for the one message that explains why the thing you asked for did not happen.
         duration = 0 if level in (Qgis.Warning, Qgis.Critical) else 6
         bar_widget.pushMessage(PLUGIN_NAME, text, level=level, duration=duration)
+
+    def _install_auth(self):
+        """Attach the token to QGIS's OWN requests for this instance's host.
+
+        A layer added as OGC API - Features is fetched by QGIS, not by us — so our token never
+        reached it, and a private layer could not be opened however valid the credential was.
+        QGIS's provider URI has no documented way to carry a header, but the network manager
+        accepts a request PREPROCESSOR, which is the supported way for a plugin to add one.
+
+        Scoped to the exact host of the connected instance. A preprocessor sees every request QGIS
+        makes — basemaps, other servers, plugin updates — and a bearer token must never leave the
+        host it belongs to.
+        """
+        if not self.instance or not self.instance.token:
+            return
+        try:
+            from qgis.core import QgsNetworkAccessManager
+            from qgis.PyQt.QtCore import QUrl
+        except ImportError:             # pragma: no cover - QGIS always has these
+            return
+        if not hasattr(QgsNetworkAccessManager, "setRequestPreprocessor"):
+            # Older QGIS: private layers over OAPIF will not open, but everything else works.
+            self._say("This QGIS is too old to attach a token to its own requests, so private "
+                      "layers cannot be added as OGC API - Features. Public layers are fine.",
+                      Qgis.Warning)
+            return
+        host = (QUrl(self.instance.url).host() or "").lower()
+        token = self.instance.token
+        if not host:
+            return
+
+        def add_token(request):
+            try:
+                if (request.url().host() or "").lower() == host:
+                    request.setRawHeader(b"Authorization",
+                                         ("Bearer " + token).encode("utf-8"))
+            except Exception:           # noqa: BLE001 - never break QGIS networking
+                pass
+
+        try:
+            QgsNetworkAccessManager.setRequestPreprocessor(add_token)
+        except Exception as exc:        # noqa: BLE001
+            symbology._log("Could not install the auth preprocessor: {0}".format(exc))
 
     def _colormaps(self):
         """The colormap names this instance actually has, fetched once.
@@ -200,6 +245,9 @@ class GeoDeployDock(QDockWidget):
             self._say(job.error, Qgis.Critical)
             return
         info = job.result or {}
+        # Before any layer is added: an OAPIF layer is fetched by QGIS itself, so the token has to
+        # be on QGIS's requests, not only on ours.
+        self._install_auth()
         who = f"signed in as {info.get('user')}" if info.get("authenticated") else "not signed in"
         extra = ("" if info.get("index_available")
                  else " — this instance does not publish an index, so only what your token can see "
@@ -220,14 +268,26 @@ class GeoDeployDock(QDockWidget):
         if not self.instance:
             return
         self._busy(True)
-        self._run(_Job("GeoDeploy: listing layers", self.instance.layers), self._listed)
+
+        def work():
+            layers = self.instance.layers()
+            try:
+                portals = self.instance.portals()
+            except GeoDeployError:
+                # A portal listing that fails must not cost you the layer listing.
+                portals = []
+            return {"layers": layers, "portals": portals}
+
+        self._run(_Job("GeoDeploy: listing", work), self._listed)
 
     def _listed(self, job):
         self._busy(False)
         if job.error:
             self._say(job.error, Qgis.Critical)
             return
-        self._rows = job.result or []
+        result = job.result or {}
+        self._rows = result.get("layers") or []
+        self._portals = result.get("portals") or []
         self.tree.clear()
         groups: dict[str, QTreeWidgetItem] = {}
         for row in self._rows:
@@ -244,7 +304,22 @@ class GeoDeployDock(QDockWidget):
                                             row.get("geometry_type") or backend,
                                             f"{count:,}" if isinstance(count, int) else ""])
             item.setData(0, Qt.UserRole, row)
-        if not self._rows:
+        # Portals last: they are things to LOOK at rather than add, so they sit below the data.
+        if self._portals:
+            parent = QTreeWidgetItem(self.tree, ["Portals"])
+            parent.setExpanded(True)
+            for portal in self._portals:
+                slug = portal.get("slug") or ""
+                published = portal.get("is_published", portal.get("published"))
+                item = QTreeWidgetItem(parent, [
+                    portal.get("title") or portal.get("name") or slug,
+                    portal.get("experience") or portal.get("archetype") or "portal",
+                    "published" if published else "draft"])
+                # Marked so a double-click opens it instead of trying to add it as a layer.
+                item.setData(0, Qt.UserRole, {"_portal": True, "slug": slug,
+                                              "_base": self.instance.url if self.instance else ""})
+
+        if not self._rows and not self._portals:
             self._say("Nothing to list. Public data needs no account; a token shows the rest.")
 
     # -- add ---------------------------------------------------------------------------------------
@@ -253,10 +328,18 @@ class GeoDeployDock(QDockWidget):
         items = self.tree.selectedItems()
         return items[0].data(0, Qt.UserRole) if items else None
 
+    def _on_selection_changed(self):
+        """A portal cannot be added to the map, so the button says what it WILL do instead."""
+        row = self._selected_row() or {}
+        self.add_btn.setText("Open portal in browser" if row.get("_portal") else "Add to map")
+
     def add_selected(self):
         row = self._selected_row()
         if not row:
             self._say("Pick a layer first.", Qgis.Warning)
+            return
+        if row.get("_portal"):
+            self._open_portal(row)
             return
         source = sources.describe(row, prefer_attributes=self.attributes.isChecked())
         if not source:
@@ -298,6 +381,22 @@ class GeoDeployDock(QDockWidget):
         self._say(f"Added {name} — {source['why']}{applied}.")
 
     # -- upload ------------------------------------------------------------------------------------
+
+    def _open_portal(self, row):
+        """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
+        base = (row.get("_base") or "").rstrip("/")
+        slug = row.get("slug") or ""
+        if not base or not slug:
+            self._say("That portal has no address yet — publish it first.", Qgis.Warning)
+            return
+        url = f"{base}/p/{slug}"
+        try:
+            from qgis.PyQt.QtCore import QUrl
+            from qgis.PyQt.QtGui import QDesktopServices
+            QDesktopServices.openUrl(QUrl(url))
+            self._say(f"Opened {url} in your browser.")
+        except Exception as exc:        # noqa: BLE001 - still give them the address
+            self._say(f"Open it at {url} ({exc}).", Qgis.Warning)
 
     def upload_active(self):
         if not self.instance:

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -438,9 +438,26 @@ class GeoDeployDock(QDockWidget):
         if not self.instance:
             return
         ref = row.get("id") or row.get("slug")
+        slug = row.get("slug")
+        instance = self.instance
 
         def work():
-            return self.instance.client.portals.get(ref)
+            # With a token, ask the API — it is authoritative and covers unpublished portals.
+            if instance.token and ref is not None:
+                try:
+                    return instance.client.portals.get(ref)
+                except GeoDeployError:
+                    pass                # fall through: a published portal is readable anyway
+            # Without one, read what the portal PUBLISHES. Looking at a public portal should never
+            # require an account; only changing it should.
+            if not slug:
+                raise GeoDeployError("This portal has no published address to read.")
+            doc = instance.published_style(slug)
+            return {"id": row.get("id"), "slug": slug,
+                    "title": row.get("title") or row.get("name") or slug,
+                    "layer_configs": portal_sync.configs_from_published_style(
+                        doc, symbology.style_from_legend),
+                    "_anonymous": True}
 
         self._busy(True)
         self._say("Opening " + str(row.get("title") or "the portal") + "...", bar=False)
@@ -459,32 +476,57 @@ class GeoDeployDock(QDockWidget):
 
         project = QgsProject.instance()
         group = project.layerTreeRoot().insertGroup(0, doc.get("title") or "GeoDeploy portal")
-        group.setCustomProperty(portal_sync.P_PORTAL_ID, str(doc.get("id")))
+        # Only tag the portal id when we could actually write back to it. Tagging a read-only copy
+        # would offer an "update" that is going to be refused, which is worse than not offering it.
+        if doc.get("id") is not None and self.instance and self.instance.token:
+            group.setCustomProperty(portal_sync.P_PORTAL_ID, str(doc.get("id")))
         group.setCustomProperty(portal_sync.P_PORTAL_TITLE, doc.get("title") or "")
 
         added, missing = 0, []
-        # In order: layer_configs[0] is the TOP of the portal's list, and adding to the group in
-        # the same order puts it at the top here too. No reversal anywhere.
-        for cfg in configs:
-            layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
-            if layer_row is None:
-                missing.append(str(cfg.get("layer_id")))
-                continue
-            source = sources.describe(layer_row, prefer_attributes=self.attributes.isChecked())
-            if not source:
-                missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
-                continue
-            layer = self._build_layer(layer_row, source, layer_row.get("name") or "layer")
-            if layer is None:
-                missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
-                continue
-            project.addMapLayer(layer, False)      # False: placed into the group, not the root
-            node = group.addLayer(layer)
-            node.setItemVisibilityChecked(bool(cfg.get("visible", True)))
-            style = (cfg.get("style") or {}) if self.styled.isChecked() else {}
-            if style and cfg.get("layer_type") != "raster":
-                symbology.apply_to_qgis(layer, style)
-            added += 1
+        by_key = {(int(c.get("layer_id")), str(c.get("layer_type"))): c for c in configs
+                  if c.get("layer_id") is not None}
+
+        def place(node_list, parent):
+            """The portal's folder tree, as QGIS sub-groups. Folders are a real structure the
+            author built, so they come across as folders rather than being flattened."""
+            nonlocal added
+            for item in node_list:
+                if item.get("children") is not None:
+                    sub = parent.addGroup(item.get("name") or "Folder")
+                    sub.setCustomProperty(portal_sync.P_FOLDER_ID, str(item.get("id") or ""))
+                    sub.setExpanded(not item.get("collapsed"))
+                    place(item.get("children") or [], sub)
+                    continue
+                key = (int(item.get("layer_id")), str(item.get("layer_type") or "vector"))
+                cfg = by_key.get(key)
+                if cfg is None:
+                    continue
+                layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
+                if layer_row is None:
+                    missing.append(str(cfg.get("name") or cfg.get("layer_id")))
+                    continue
+                source = sources.describe(layer_row,
+                                          prefer_attributes=self.attributes.isChecked())
+                if not source:
+                    missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
+                    continue
+                layer = self._build_layer(layer_row, source, layer_row.get("name") or "layer")
+                if layer is None:
+                    missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
+                    continue
+                project.addMapLayer(layer, False)   # False: placed into the group, not the root
+                tree_node = parent.addLayer(layer)
+                tree_node.setItemVisibilityChecked(bool(cfg.get("visible", True)))
+                style = (cfg.get("style") or {}) if self.styled.isChecked() else {}
+                if style and cfg.get("layer_type") != "raster":
+                    symbology.apply_to_qgis(layer, style)
+                added += 1
+
+        # A portal with no folders is a flat list — the configs themselves, in order.
+        # layer_configs[0] is the TOP, and adding in the same order puts it at the top here too.
+        tree = doc.get("layer_groups") or [
+            {"layer_id": c.get("layer_id"), "layer_type": c.get("layer_type")} for c in configs]
+        place(tree, group)
 
         note = ""
         if missing:
@@ -582,7 +624,8 @@ class GeoDeployDock(QDockWidget):
             configs = final["configs"] + keep_removed
             # The rename was listed in the dialog and approved with everything else.
             new_title = (plan.get("rename") or (None, None))[1]
-            doc = portal_sync.push(client, group, configs, new_title=new_title)
+            doc = portal_sync.push(client, group, configs, new_title=new_title,
+                                   tree=final.get("tree"))
             return {"portal": doc, "uploaded": sent, "kept": len(keep_removed),
                     "skipped": [n for n, _l, _x in final["uploads"]]}
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -598,7 +598,10 @@ class GeoDeployDock(QDockWidget):
 
         def work():
             sent = []
-            for name, qgis_layer, _node in uploads:
+            for index, (name, qgis_layer, _node) in enumerate(uploads, start=1):
+                # Reported from the worker thread: publishing a group of five files is a long
+                # operation, and silence through it reads as a hang.
+                self._progress.emit("Uploading {0} ({1} of {2})…".format(name, index, len(uploads)))
                 # Upload, then TAG the QGIS layer with the id it was given. The tag is what makes
                 # the next push see it as an existing layer rather than a new one all over again.
                 path, temporary = export.prepare(qgis_layer)
@@ -620,6 +623,7 @@ class GeoDeployDock(QDockWidget):
 
             # Re-plan AFTER the uploads: the new layers are tagged now, so this puts them in their
             # place in the group's order rather than making the caller reconstruct it.
+            self._progress.emit("Publishing the portal…")
             final = portal_sync.plan_push(group, style_for, current)
             configs = final["configs"] + keep_removed
             # The rename was listed in the dialog and approved with everything else.

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -21,7 +21,7 @@ from qgis.PyQt.QtWidgets import (QAbstractItemView, QAction, QCheckBox, QComboBo
                                  QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar,
                                  QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
-from . import export, portals as portal_sync, sources, symbology
+from . import diffdialog, export, portals as portal_sync, sources, symbology
 from .connection import GeoDeployError, Instance, saved_instances
 
 PLUGIN_NAME = "GeoDeploy"
@@ -98,7 +98,7 @@ class GeoDeployDock(QDockWidget):
         self.styled.setChecked(True)
         outer.addWidget(self.styled)
 
-        self.attributes = QCheckBox("Prefer full attributes over drawing speed")
+        self.attributes = QCheckBox("Prefer the real data over the styled view")
         self.attributes.setToolTip(
             "Vector — off: one pre-generalized archive, downloaded once, carrying only the "
             "attributes the tiles hold. On: OGC API - Features, re-queried for the extent on "
@@ -112,7 +112,7 @@ class GeoDeployDock(QDockWidget):
         outer.addWidget(self.add_btn)
         self.tree.itemSelectionChanged.connect(self._on_selection_changed)
 
-    # -- upload -------------------------------------------------------------------------------
+        # -- portals ----------------------------------------------------------------------------
         self.open_group_btn = QPushButton("Open portal as a group")
         self.open_group_btn.setToolTip(
             "Every layer of the selected portal, in its order and with the portal's own styling, "
@@ -127,6 +127,7 @@ class GeoDeployDock(QDockWidget):
         self.push_group_btn.clicked.connect(self.push_group)
         outer.addWidget(self.push_group_btn)
 
+        # -- upload -----------------------------------------------------------------------------
         self.upload_btn = QPushButton("Upload selected layer(s)…")
         self.upload_btn.setToolTip(
             "Uploads every layer selected in the Layers panel, one after another — or the active "
@@ -493,7 +494,13 @@ class GeoDeployDock(QDockWidget):
                   Qgis.Warning if missing else Qgis.Info)
 
     def push_group(self):
-        """Push the selected QGIS group back as a portal, updating the one it came from."""
+        """Push the selected QGIS group back as a portal — after showing exactly what will change.
+
+        Republishing has several consequences that are not equally reversible: removing a layer
+        from a portal is one click to undo, uploading a 2 GB file is not, and publishing a layer
+        you were only inspecting is not either. So nothing happens until the plan has been read and
+        approved, and the two consequential parts are separate opt-ins rather than one blanket OK.
+        """
         if not self.instance or not self.instance.token:
             self._say("Pushing a portal needs a token with write access.", Qgis.Warning)
             return
@@ -505,6 +512,8 @@ class GeoDeployDock(QDockWidget):
                       "portal.", Qgis.Warning)
             return
         group = groups[0]
+        portal_id, title = portal_sync.group_portal(group)
+        client = self.instance.client
 
         def style_for(qgis_layer, layer_type):
             if not self.push_style.isChecked():
@@ -513,23 +522,73 @@ class GeoDeployDock(QDockWidget):
                 return symbology.raster_from_qgis(qgis_layer, self._colormaps())
             return symbology.from_qgis(qgis_layer)
 
+        # What the portal looks like NOW, so the plan is a real comparison rather than a guess.
+        current = []
+        if portal_id is not None:
+            try:
+                current = (client.portals.get(portal_id) or {}).get("layer_configs") or []
+            except GeoDeployError as exc:
+                self._say(f"Could not read the portal to compare against: {exc}", Qgis.Critical)
+                return
+
         try:
-            configs, skipped = portal_sync.configs_from_group(group, style_for)
+            plan = portal_sync.plan_push(group, style_for, current)
         except Exception as exc:            # noqa: BLE001 - never crash QGIS over a layer tree
-            self._say("Could not read that group: " + str(exc), Qgis.Critical)
+            self._say(f"Could not read that group: {exc}", Qgis.Critical)
             return
 
-        portal_id, title = portal_sync.group_portal(group)
-        verb = "Updating" if portal_id else "Creating"
-        client = self.instance.client
-        self._skipped = skipped
+        go, upload_new, drop_removed = diffdialog.confirm(
+            self, title or "Untitled portal",
+            {"unchanged": plan["unchanged"], "restyled": plan["restyled"], "added": plan["added"],
+             "uploads": [name for name, _layer, _node in plan["uploads"]],
+             "removed": plan["removed"], "rename": plan.get("rename")},
+            creating=portal_id is None)
+        if not go:
+            self._say("Nothing was pushed.", bar=False)
+            return
+
+        uploads = list(plan["uploads"]) if upload_new else []
+        keep_removed = [] if drop_removed else [
+            cfg for cfg in current
+            if (int(cfg.get("layer_id")), str(cfg.get("layer_type")))
+            not in {(c["layer_id"], c["layer_type"]) for c in plan["configs"]}]
+        instance_url = self.instance.url
 
         def work():
-            return portal_sync.push(client, group, configs)
+            sent = []
+            for name, qgis_layer, _node in uploads:
+                # Upload, then TAG the QGIS layer with the id it was given. The tag is what makes
+                # the next push see it as an existing layer rather than a new one all over again.
+                path, temporary = export.prepare(qgis_layer)
+                try:
+                    result = client.uploads.upload(path, wait=True)
+                finally:
+                    if temporary:
+                        shutil.rmtree(os.path.dirname(path), ignore_errors=True)
+                if not getattr(result, "layer_id", None):
+                    continue
+                kind = result.plan.layer_type
+                portal_sync.tag_layer(qgis_layer, instance_url, result.layer_id, kind)
+                style = style_for(qgis_layer, kind)
+                if style:
+                    body = (dict(style, opacity=1.0) if kind == "raster"
+                            else {"opacity": 1.0, "style": style, "popup_fields": []})
+                    client.layers.api(kind).set_default_style(result.layer_id, body)
+                sent.append(name)
+
+            # Re-plan AFTER the uploads: the new layers are tagged now, so this puts them in their
+            # place in the group's order rather than making the caller reconstruct it.
+            final = portal_sync.plan_push(group, style_for, current)
+            configs = final["configs"] + keep_removed
+            # The rename was listed in the dialog and approved with everything else.
+            new_title = (plan.get("rename") or (None, None))[1]
+            doc = portal_sync.push(client, group, configs, new_title=new_title)
+            return {"portal": doc, "uploaded": sent, "kept": len(keep_removed),
+                    "skipped": [n for n, _l, _x in final["uploads"]]}
 
         self._busy(True)
-        self._say(verb + " portal " + str(title) + " from " + str(len(configs)) + " layer(s)...",
-                  bar=False)
+        verb = "Updating" if portal_id else "Creating"
+        self._say(verb + " portal " + str(title) + "...", bar=False)
         self._run(_Job("GeoDeploy: pushing portal", work), self._group_pushed)
 
     def _group_pushed(self, job):
@@ -537,149 +596,20 @@ class GeoDeployDock(QDockWidget):
         if job.error:
             self._say(job.error, Qgis.Critical)
             return
-        doc = job.result or {}
-        skipped = getattr(self, "_skipped", [])
-        note = ""
-        if skipped:
-            note = (" Skipped " + str(len(skipped)) + ": " + ", ".join(skipped[:3]) +
-                    " - these are not on the instance yet, so upload them first.")
+        result = job.result or {}
+        doc = result.get("portal") or {}
+        bits = []
+        if result.get("uploaded"):
+            bits.append("uploaded " + str(len(result["uploaded"])))
+        if result.get("kept"):
+            bits.append("kept " + str(result["kept"]) + " you chose not to remove")
+        if result.get("skipped"):
+            bits.append("left out " + ", ".join(result["skipped"][:3]))
+        detail = (" (" + "; ".join(bits) + ")") if bits else ""
         base = self.instance.url.rstrip("/") if self.instance else ""
         self._say("Portal " + str(doc.get("title")) + " published: " +
-                  base + "/p/" + str(doc.get("slug")) + note,
-                  Qgis.Warning if skipped else Qgis.Info)
+                  base + "/p/" + str(doc.get("slug")) + detail)
         self.refresh_layers()
-
-    def _open_portal(self, row):
-        """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
-        base = (row.get("_base") or "").rstrip("/")
-        slug = row.get("slug") or ""
-        if not base or not slug:
-            self._say("That portal has no address yet — publish it first.", Qgis.Warning)
-            return
-        url = f"{base}/p/{slug}"
-        try:
-            from qgis.PyQt.QtCore import QUrl
-            from qgis.PyQt.QtGui import QDesktopServices
-            QDesktopServices.openUrl(QUrl(url))
-            self._say(f"Opened {url} in your browser.")
-        except Exception as exc:        # noqa: BLE001 - still give them the address
-            self._say(f"Open it at {url} ({exc}).", Qgis.Warning)
-
-    def upload_active(self):
-        if not self.instance:
-            self._say("Connect to an instance first.", Qgis.Warning)
-            return
-        if not self.instance.token:
-            self._say("Uploading needs a token with data:write. Public browsing does not.",
-                      Qgis.Warning)
-            return
-        # Whatever is SELECTED in the Layers panel, falling back to the active layer. Sending five
-        # layers is a normal thing to want, and doing it one at a time means five round trips
-        # through this dialog.
-        layers = list(self.iface.layerTreeView().selectedLayers() or [])
-        if not layers:
-            active = self.iface.activeLayer()
-            if active is None:
-                self._say("Select one or more layers in the Layers panel first.", Qgis.Warning)
-                return
-            layers = [active]
-
-        jobs = []           # (name, path, temporary, style)
-        refused = []
-        for layer in layers:
-            try:
-                # Not `layer.source()`: a filtered layer's file holds MORE than the layer does, and
-                # a memory or PostGIS layer has no file at all. `prepare` writes those out first.
-                path, temporary = export.prepare(
-                    layer, on_status=lambda t: self._say(t, bar=False))
-            except export.NotUploadable as exc:
-                refused.append("{0}: {1}".format(layer.name(), exc))
-                continue
-            # A raster's default style is a DIFFERENT shape — {colormap, rescale, bidx}, not
-            # classes — so it needs its own translation. Sending the vector shape is what made
-            # "Send its styling too" quietly do nothing for a GeoTIFF.
-            if not self.push_style.isChecked():
-                style = {}
-            elif isinstance(layer, QgsRasterLayer):
-                style = symbology.raster_from_qgis(layer, self._colormaps())
-            else:
-                style = symbology.from_qgis(layer)
-            jobs.append((layer.name(), path, temporary, style))
-
-        if not jobs:
-            # Everything was refused — say why, for each, rather than a generic failure.
-            self._say(" | ".join(refused) or "Nothing could be uploaded.", Qgis.Warning)
-            return
-
-        client = self.instance.client
-        total = len(jobs)
-
-        def work():
-            uploaded, styled, failed = [], [], list(refused)
-            for index, (name, path, temporary, style) in enumerate(jobs, start=1):
-                # Reported from the worker thread: a queue that looks frozen for four of five files
-                # is worse than no progress at all.
-                self._progress.emit("Uploading {0} ({1} of {2})…".format(name, index, total))
-                try:
-                    result = client.uploads.upload(path, wait=True)
-                    if style and getattr(result, "layer_id", None):
-                        # Styling travels with the upload: the portal then shows what the author
-                        # saw, instead of the next default colour in the palette.
-                        kind = result.plan.layer_type
-                        api = client.layers.api(kind)
-                        # The two kinds take different bodies. A raster's IS the style; a vector's
-                        # wraps it, alongside opacity and popup fields.
-                        body = (dict(style, opacity=1.0) if kind == "raster"
-                                else {"opacity": 1.0, "style": style, "popup_fields": []})
-                        api.set_default_style(result.layer_id, body)
-                        styled.append(name)
-                    uploaded.append(name)
-                except Exception as exc:            # noqa: BLE001 - one bad layer, not the batch
-                    # Four good layers must still arrive when the third one is broken.
-                    failed.append("{0}: {1}".format(name, exc))
-                finally:
-                    if temporary:
-                        # A multi-gigabyte export is not left behind in temp because upload failed.
-                        shutil.rmtree(os.path.dirname(path), ignore_errors=True)
-            return {"uploaded": uploaded, "styled": styled, "failed": failed}
-
-        self._busy(True)
-        self._say("Uploading {0} layer(s)… large files go straight to storage.".format(total),
-                  bar=False)
-        self._run(_Job("GeoDeploy: uploading", work), self._uploaded)
-
-    def _uploaded(self, job):
-        self._busy(False)
-        if job.error:
-            self._say(job.error, Qgis.Critical)
-            return
-        result = job.result or {}
-        uploaded = result.get("uploaded") or []
-        failed = result.get("failed") or []
-        styled = result.get("styled") or []
-        # Only claim what was actually sent. A renderer we cannot translate produces no style, and
-        # saying "styling sent" anyway is how a silent no-op passes for a feature.
-        if styled and len(styled) == len(uploaded):
-            styling = " Styling sent with " + ("it." if len(styled) == 1 else "them.")
-        elif styled:
-            styling = f" Styling sent for {len(styled)} of {len(uploaded)}."
-        elif uploaded and self.push_style.isChecked():
-            styling = " No styling was sent — this renderer has no GeoDeploy equivalent."
-        else:
-            styling = ""
-
-        if uploaded and not failed:
-            what = uploaded[0] if len(uploaded) == 1 else f"{len(uploaded)} layers"
-            self._say(f"Uploaded {what}.{styling}")
-        elif uploaded and failed:
-            # Partial success is its own outcome. Reporting it as failure hides work that landed;
-            # reporting it as success hides work that did not.
-            self._say(f"Uploaded {len(uploaded)}, but {len(failed)} did not: " + " | ".join(failed),
-                      Qgis.Warning)
-        else:
-            self._say(" | ".join(failed) or "Nothing was uploaded.", Qgis.Critical)
-        if uploaded:
-            self.refresh_layers()
 
     # -- task plumbing ------------------------------------------------------------------------------
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -21,7 +21,7 @@ from qgis.PyQt.QtWidgets import (QAbstractItemView, QAction, QCheckBox, QComboBo
                                  QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar,
                                  QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
-from . import export, sources, symbology
+from . import export, portals as portal_sync, sources, symbology
 from .connection import GeoDeployError, Instance, saved_instances
 
 PLUGIN_NAME = "GeoDeploy"
@@ -100,10 +100,11 @@ class GeoDeployDock(QDockWidget):
 
         self.attributes = QCheckBox("Prefer full attributes over drawing speed")
         self.attributes.setToolTip(
-            "Off: one pre-generalized archive, downloaded once — generalized geometry, and only "
-            "the attributes the tiles carry.\n"
-            "On: OGC API - Features, which QGIS re-queries for the extent on screen — exact "
-            "geometry and every attribute, at a server round-trip per pan.")
+            "Vector — off: one pre-generalized archive, downloaded once, carrying only the "
+            "attributes the tiles hold. On: OGC API - Features, re-queried for the extent on "
+            "screen, with exact geometry and every attribute.\n"
+            "Raster — off: server-rendered tiles, coloured exactly as GeoDeploy draws them. "
+            "On: the GeoTIFF itself, with real pixel values, drawn using QGIS's own defaults.")
         outer.addWidget(self.attributes)
 
         self.add_btn = QPushButton("Add to map")
@@ -112,6 +113,20 @@ class GeoDeployDock(QDockWidget):
         self.tree.itemSelectionChanged.connect(self._on_selection_changed)
 
     # -- upload -------------------------------------------------------------------------------
+        self.open_group_btn = QPushButton("Open portal as a group")
+        self.open_group_btn.setToolTip(
+            "Every layer of the selected portal, in its order and with the portal's own styling, "
+            "as one QGIS group. Restyle it and push it back.")
+        self.open_group_btn.clicked.connect(self.open_portal_as_group)
+        outer.addWidget(self.open_group_btn)
+
+        self.push_group_btn = QPushButton("Push group to portal")
+        self.push_group_btn.setToolTip(
+            "Turn the selected QGIS group into a portal. A group opened from a portal UPDATES that "
+            "portal; any other group creates a new one.")
+        self.push_group_btn.clicked.connect(self.push_group)
+        outer.addWidget(self.push_group_btn)
+
         self.upload_btn = QPushButton("Upload selected layer(s)…")
         self.upload_btn.setToolTip(
             "Uploads every layer selected in the Layers panel, one after another — or the active "
@@ -347,11 +362,8 @@ class GeoDeployDock(QDockWidget):
             return
 
         name = row.get("name") or "GeoDeploy layer"
-        if source["kind"] == "cog":
-            layer = QgsRasterLayer(source["uri"], name, "gdal")
-        else:
-            layer = QgsVectorLayer(source["uri"], name, source["provider"])
-        if not layer.isValid():
+        layer = self._build_layer(row, source, name)
+        if layer is None:
             self._say(f"QGIS could not open the {source['kind']} source for {name}.", Qgis.Critical)
             return
 
@@ -381,6 +393,161 @@ class GeoDeployDock(QDockWidget):
         self._say(f"Added {name} — {source['why']}{applied}.")
 
     # -- upload ------------------------------------------------------------------------------------
+
+    def _build_layer(self, row, source, name):
+        """One layer from a described source, tagged with its GeoDeploy identity.
+
+        The tag is what makes the portal round trip safe: a group pushed back has to know WHICH
+        layer each entry is, and matching by name would break the first time someone renames one.
+        """
+        if source["kind"] in ("cog", "xyz"):
+            layer = QgsRasterLayer(source["uri"], name, source["provider"])
+        else:
+            layer = QgsVectorLayer(source["uri"], name, source["provider"])
+        if not layer.isValid():
+            return None
+        if self.instance:
+            is_raster = (row.get("layer_type") == "raster"
+                         or row.get("storage_backend") == "raster")
+            portal_sync.tag_layer(layer, self.instance.url, row.get("id"),
+                                  "raster" if is_raster else "vector")
+        return layer
+
+    def _row_for(self, layer_id, layer_type):
+        """The listing row matching a portal layer_config entry."""
+        for row in self._rows:
+            kind = "raster" if (row.get("layer_type") == "raster"
+                                or row.get("storage_backend") == "raster") else "vector"
+            if str(row.get("id")) == str(layer_id) and kind == layer_type:
+                return row
+        return None
+
+    def open_portal_as_group(self):
+        """Every layer of a portal, in its order, styled as the portal styles it, in one group.
+
+        A portal IS an ordered styled list of layers, which is what a group is — so this is a
+        direct mapping rather than an interpretation. Styles come from the PORTAL's own
+        layer_config, not from the layer's default: a portal may deliberately draw a layer
+        differently from how it is stored, and that difference is the thing worth carrying across.
+        """
+        row = self._selected_row()
+        if not row or not row.get("_portal"):
+            self._say("Select a portal in the list first.", Qgis.Warning)
+            return
+        if not self.instance:
+            return
+        ref = row.get("id") or row.get("slug")
+
+        def work():
+            return self.instance.client.portals.get(ref)
+
+        self._busy(True)
+        self._say("Opening " + str(row.get("title") or "the portal") + "...", bar=False)
+        self._run(_Job("GeoDeploy: opening portal", work), self._portal_opened)
+
+    def _portal_opened(self, job):
+        self._busy(False)
+        if job.error:
+            self._say(job.error, Qgis.Critical)
+            return
+        doc = job.result or {}
+        configs = doc.get("layer_configs") or []
+        if not configs:
+            self._say("That portal has no layers yet.", Qgis.Warning)
+            return
+
+        project = QgsProject.instance()
+        group = project.layerTreeRoot().insertGroup(0, doc.get("title") or "GeoDeploy portal")
+        group.setCustomProperty(portal_sync.P_PORTAL_ID, str(doc.get("id")))
+        group.setCustomProperty(portal_sync.P_PORTAL_TITLE, doc.get("title") or "")
+
+        added, missing = 0, []
+        # In order: layer_configs[0] is the TOP of the portal's list, and adding to the group in
+        # the same order puts it at the top here too. No reversal anywhere.
+        for cfg in configs:
+            layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
+            if layer_row is None:
+                missing.append(str(cfg.get("layer_id")))
+                continue
+            source = sources.describe(layer_row, prefer_attributes=self.attributes.isChecked())
+            if not source:
+                missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
+                continue
+            layer = self._build_layer(layer_row, source, layer_row.get("name") or "layer")
+            if layer is None:
+                missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
+                continue
+            project.addMapLayer(layer, False)      # False: placed into the group, not the root
+            node = group.addLayer(layer)
+            node.setItemVisibilityChecked(bool(cfg.get("visible", True)))
+            style = (cfg.get("style") or {}) if self.styled.isChecked() else {}
+            if style and cfg.get("layer_type") != "raster":
+                symbology.apply_to_qgis(layer, style)
+            added += 1
+
+        note = ""
+        if missing:
+            note = " " + str(len(missing)) + " could not be opened (" + ", ".join(missing[:3]) + ")."
+        self._say("Opened " + str(doc.get("title")) + " as a group - " + str(added) +
+                  " layer(s)." + note + " Restyle it, then use Push group to portal.",
+                  Qgis.Warning if missing else Qgis.Info)
+
+    def push_group(self):
+        """Push the selected QGIS group back as a portal, updating the one it came from."""
+        if not self.instance or not self.instance.token:
+            self._say("Pushing a portal needs a token with write access.", Qgis.Warning)
+            return
+        view = self.iface.layerTreeView()
+        nodes = view.selectedNodes() if view else []
+        groups = [n for n in nodes if hasattr(n, "addLayer")]
+        if len(groups) != 1:
+            self._say("Select exactly one GROUP in the Layers panel - that group becomes the "
+                      "portal.", Qgis.Warning)
+            return
+        group = groups[0]
+
+        def style_for(qgis_layer, layer_type):
+            if not self.push_style.isChecked():
+                return {}
+            if layer_type == "raster":
+                return symbology.raster_from_qgis(qgis_layer, self._colormaps())
+            return symbology.from_qgis(qgis_layer)
+
+        try:
+            configs, skipped = portal_sync.configs_from_group(group, style_for)
+        except Exception as exc:            # noqa: BLE001 - never crash QGIS over a layer tree
+            self._say("Could not read that group: " + str(exc), Qgis.Critical)
+            return
+
+        portal_id, title = portal_sync.group_portal(group)
+        verb = "Updating" if portal_id else "Creating"
+        client = self.instance.client
+        self._skipped = skipped
+
+        def work():
+            return portal_sync.push(client, group, configs)
+
+        self._busy(True)
+        self._say(verb + " portal " + str(title) + " from " + str(len(configs)) + " layer(s)...",
+                  bar=False)
+        self._run(_Job("GeoDeploy: pushing portal", work), self._group_pushed)
+
+    def _group_pushed(self, job):
+        self._busy(False)
+        if job.error:
+            self._say(job.error, Qgis.Critical)
+            return
+        doc = job.result or {}
+        skipped = getattr(self, "_skipped", [])
+        note = ""
+        if skipped:
+            note = (" Skipped " + str(len(skipped)) + ": " + ", ".join(skipped[:3]) +
+                    " - these are not on the instance yet, so upload them first.")
+        base = self.instance.url.rstrip("/") if self.instance else ""
+        self._say("Portal " + str(doc.get("title")) + " published: " +
+                  base + "/p/" + str(doc.get("slug")) + note,
+                  Qgis.Warning if skipped else Qgis.Info)
+        self.refresh_layers()
 
     def _open_portal(self, row):
         """A portal is a published web map — QGIS cannot render one, so open it where it lives."""

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -63,6 +63,90 @@ def group_portal(group):
         return (None, title)
 
 
+def plan_push(group, style_for, current_configs) -> dict:
+    """What pushing this group would do, as five named lists plus the configs to send.
+
+    Compared by IDENTITY, never by name or position, so renaming a layer in QGIS or dragging it up
+    the list is not mistaken for removing one thing and adding another.
+
+    * `unchanged` — on the portal already, same style;
+    * `restyled`  — on the portal, style differs. This is the whole point of the round trip, so it
+                    is called out rather than folded into "unchanged";
+    * `added`     — in the group, already on the instance, not yet on the portal;
+    * `uploads`   — in the group but NOT on the instance: local files, with nothing to reference
+                    until they are uploaded. `(name, qgis_layer)` so the caller can send them;
+    * `removed`   — on the portal, no longer in the group.
+    """
+    before = {}
+    for cfg in (current_configs or []):
+        before[(int(cfg.get("layer_id")), str(cfg.get("layer_type")))] = cfg
+
+    configs, uploads, unchanged, restyled, added = [], [], [], [], []
+    seen = set()
+    for child in group.children():
+        qgis_layer = getattr(child, "layer", lambda: None)()
+        if qgis_layer is None:
+            continue                    # a nested group; reported by configs_from_group
+        identity = layer_identity(qgis_layer)
+        if identity is None:
+            uploads.append((qgis_layer.name(), qgis_layer, child))
+            continue
+        layer_id, layer_type = identity
+        seen.add((layer_id, layer_type))
+        style = style_for(qgis_layer, layer_type) or {}
+        entry = {"layer_id": layer_id, "layer_type": layer_type,
+                 "visible": bool(child.isVisible()), "opacity": _opacity_of(qgis_layer),
+                 "style": style, "popup_fields": []}
+        configs.append(entry)
+        was = before.get((layer_id, layer_type))
+        if was is None:
+            added.append(qgis_layer.name())
+        elif _style_differs(was, entry):
+            restyled.append(qgis_layer.name())
+        else:
+            unchanged.append(qgis_layer.name())
+
+    removed = [_config_label(cfg) for key, cfg in before.items() if key not in seen]
+
+    # Renaming the group is the obvious way to rename the portal, so it has to mean that — but it
+    # is a visible change to a published page, so it is proposed rather than applied. The stored
+    # title is what the portal was called when the group was opened; the group's CURRENT name is
+    # what the user has since typed.
+    portal_id, stored_title = group_portal(group)
+    current_name = group.name() if hasattr(group, "name") else stored_title
+    rename = None
+    if portal_id is not None and current_name and current_name != stored_title:
+        rename = (stored_title, current_name)
+
+    return {"configs": configs, "uploads": uploads, "unchanged": unchanged,
+            "restyled": restyled, "added": added, "removed": removed, "rename": rename}
+
+
+def _style_differs(before: dict, after: dict) -> bool:
+    """Whether anything a viewer would SEE has changed.
+
+    Visibility and opacity count: a layer switched off in QGIS is a real change to the portal, and
+    treating it as "unchanged" would publish something the user did not intend. Compared through
+    sorted JSON so that key order — which carries no meaning — never reads as a difference.
+    """
+    import json
+
+    def shape(cfg):
+        return json.dumps({"style": cfg.get("style") or {},
+                           "visible": bool(cfg.get("visible", True)),
+                           "opacity": round(float(cfg.get("opacity", 1.0) or 1.0), 3)},
+                          sort_keys=True)
+
+    return shape(before) != shape(after)
+
+
+def _config_label(cfg: dict) -> str:
+    name = cfg.get("name") or cfg.get("layer_name")
+    if name:
+        return str(name)
+    return "{0} layer {1}".format(cfg.get("layer_type") or "?", cfg.get("layer_id"))
+
+
 def configs_from_group(group, style_for) -> tuple[list[dict], list[str]]:
     """`(layer_configs, skipped)` from a QGIS group, top of the group first.
 
@@ -109,12 +193,12 @@ def _opacity_of(qgis_layer) -> float:
     return 1.0
 
 
-def push(client, group, configs, publish: bool = True) -> dict:
+def push(client, group, configs, publish: bool = True, new_title: str | None = None) -> dict:
     """Create or update the portal this group represents. Returns the portal document.
 
     Updating is a WHOLE-document write of `layer_configs`, not a series of add/remove calls: the
     group is the intended state, and applying it in pieces would leave the portal briefly showing
-    something nobody asked for if a call failed halfway.
+    something nobody asked for if one call failed halfway.
     """
     portal_id, title = group_portal(group)
     if not configs:
@@ -122,11 +206,23 @@ def push(client, group, configs, publish: bool = True) -> dict:
                           "or upload the ones you have, and try again.")
     try:
         if portal_id is None:
-            portal = client.portals.create(title=title or "Untitled portal")
+            portal = client.portals.create(title=new_title or title or "Untitled portal")
             portal_id = portal["id"]
+        elif new_title:
+            client.portals.update(portal_id, title=new_title)
         client.portals.update(portal_id, layer_configs=configs)
         if publish:
             client.portals.publish(portal_id)
-        return client.portals.get(portal_id)
+        doc = client.portals.get(portal_id)
     except GeoDeployError as exc:
         raise PortalError(str(exc)) from exc
+
+    # Re-tag, so the group knows which portal it is now and what it is called. Without this a
+    # renamed group would propose the SAME rename on every subsequent push, and a group that just
+    # created a portal would create a second one next time.
+    try:
+        group.setCustomProperty(P_PORTAL_ID, str(doc.get("id", portal_id)))
+        group.setCustomProperty(P_PORTAL_TITLE, doc.get("title") or new_title or title or "")
+    except Exception:                   # noqa: BLE001 - a tag is not worth failing a publish over
+        pass
+    return doc

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -28,6 +28,7 @@ P_LAYER_TYPE = "geodeploy/layer_type"
 P_INSTANCE = "geodeploy/instance"
 P_PORTAL_ID = "geodeploy/portal_id"
 P_PORTAL_TITLE = "geodeploy/portal_title"
+P_FOLDER_ID = "geodeploy/folder_id"
 
 
 class PortalError(Exception):
@@ -63,6 +64,110 @@ def group_portal(group):
         return (None, title)
 
 
+def _folder_id(node) -> str:
+    """A stable id for a folder, reused across pushes so the portal's own tree keeps its identity.
+
+    Stored on the QGIS group the first time it is needed: regenerating it on every push would make
+    the folder look new to anything downstream that tracks it.
+    """
+    existing = node.customProperty(P_FOLDER_ID) if hasattr(node, "customProperty") else None
+    if existing:
+        return str(existing)
+    import uuid
+    made = "g" + uuid.uuid4().hex[:8]
+    try:
+        node.setCustomProperty(P_FOLDER_ID, made)
+    except Exception:                   # noqa: BLE001 - an unstorable id is still usable once
+        pass
+    return made
+
+
+def _expanded(node) -> bool:
+    try:
+        return bool(node.isExpanded())
+    except Exception:                   # noqa: BLE001 - older API; assume open
+        return True
+
+
+def flatten_tree(tree) -> list:
+    """Every leaf of a folder tree, depth-first, in order — the portal's drawing order."""
+    out = []
+    for node in (tree or []):
+        if isinstance(node, dict) and node.get("children") is not None:
+            out.extend(flatten_tree(node.get("children")))
+        elif isinstance(node, dict) and node.get("layer_id") is not None:
+            out.append(node)
+    return out
+
+
+def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dict]:
+    """A published portal's layer_configs, rebuilt from its PUBLIC style.json.
+
+    Reading a portal through the API needs a token. Looking at one does not — a published portal is
+    public by definition — and being unable to open a public portal in QGIS without an account
+    would contradict the whole point of anonymous browsing. `/portals/<slug>/style.json` is served
+    to anyone and carries what the portal actually draws.
+
+    Two things this has to get right:
+
+    * **Order is REVERSED.** MapLibre draws later layers on top, so the style lists bottom-to-top,
+      while `layer_configs[0]` is the TOP of the portal's list. Measured on a live portal: configs
+      [18, 16, 11, 15] are baked as [15, 11, 16, 18]. Reconstructing without reversing would open
+      every anonymous portal upside down — and then push it back that way.
+    * **One layer can bake into SEVERAL MapLibre layers** (a fill plus its outline). Only the first
+      carries the full metadata, so entries are de-duplicated by layer id, keeping the first.
+    """
+    configs, seen = [], set()
+    for ml in (style_doc.get("layers") or []):
+        meta = ml.get("metadata") or {}
+        layer_id = meta.get("geodeploy:layer_id")
+        if layer_id is None or layer_id in seen:
+            continue
+        seen.add(layer_id)
+        legend = {"color_mode": _mode_of(meta), "field": meta.get("geodeploy:legendField"),
+                  "entries": meta.get("geodeploy:legend") or [],
+                  "size": _size_of(meta.get("geodeploy:sizeLegend"))}
+        configs.append({
+            "layer_id": layer_id,
+            "layer_type": meta.get("geodeploy:type") or "vector",
+            "name": meta.get("geodeploy:name"),
+            # MapLibre omits `visibility` when a layer is shown, so absent means visible.
+            "visible": ((ml.get("layout") or {}).get("visibility") or "visible") != "none",
+            "opacity": meta.get("geodeploy:opacity", 1.0),
+            "style": style_from_legend(legend) or {},
+            "popup_fields": [],
+        })
+    configs.reverse()
+    return configs
+
+
+def _mode_of(meta: dict) -> str:
+    """Which symbology kind the baked legend describes.
+
+    The style.json does not state the mode, but the legend's own shape does: entries carrying a
+    `value` are categories, entries carrying `min`/`max` are classes, and no entries at all is a
+    single symbol.
+    """
+    entries = meta.get("geodeploy:legend") or []
+    if not entries:
+        return "single"
+    first = entries[0] if isinstance(entries[0], dict) else {}
+    if "min" in first or "max" in first:
+        return "graduated"
+    if "value" in first:
+        return "categorized"
+    return "single"
+
+
+def _size_of(size_legend):
+    """The baked size legend in the shape `style_from_legend` reads."""
+    if not isinstance(size_legend, dict) or not size_legend.get("field"):
+        return None
+    return {"field": size_legend.get("field"),
+            "stops": [[size_legend.get("min_value"), size_legend.get("min_size")],
+                      [size_legend.get("max_value"), size_legend.get("max_size")]]}
+
+
 def plan_push(group, style_for, current_configs) -> dict:
     """What pushing this group would do, as five named lists plus the configs to send.
 
@@ -83,28 +188,46 @@ def plan_push(group, style_for, current_configs) -> dict:
 
     configs, uploads, unchanged, restyled, added = [], [], [], [], []
     seen = set()
-    for child in group.children():
-        qgis_layer = getattr(child, "layer", lambda: None)()
-        if qgis_layer is None:
-            continue                    # a nested group; reported by configs_from_group
-        identity = layer_identity(qgis_layer)
-        if identity is None:
-            uploads.append((qgis_layer.name(), qgis_layer, child))
-            continue
-        layer_id, layer_type = identity
-        seen.add((layer_id, layer_type))
-        style = style_for(qgis_layer, layer_type) or {}
-        entry = {"layer_id": layer_id, "layer_type": layer_type,
-                 "visible": bool(child.isVisible()), "opacity": _opacity_of(qgis_layer),
-                 "style": style, "popup_fields": []}
-        configs.append(entry)
-        was = before.get((layer_id, layer_type))
-        if was is None:
-            added.append(qgis_layer.name())
-        elif _style_differs(was, entry):
-            restyled.append(qgis_layer.name())
-        else:
-            unchanged.append(qgis_layer.name())
+
+    def walk(node):
+        """Depth-first, in panel order, building the folder TREE as it goes.
+
+        A portal's folders are a real structure, not decoration, so a QGIS sub-group has to become
+        a GeoDeploy folder rather than being flattened away — the reader loses the grouping the
+        author built, and the next pull would come back without it.
+        """
+        tree = []
+        for child in node.children():
+            qgis_layer = getattr(child, "layer", lambda: None)()
+            if qgis_layer is None:
+                # A sub-group: a folder, with whatever is inside it.
+                folder = {"id": _folder_id(child), "name": child.name(),
+                          "collapsed": not _expanded(child), "exclusive": False,
+                          "description": "", "children": walk(child)}
+                tree.append(folder)
+                continue
+            identity = layer_identity(qgis_layer)
+            if identity is None:
+                uploads.append((qgis_layer.name(), qgis_layer, child))
+                continue
+            layer_id, layer_type = identity
+            seen.add((layer_id, layer_type))
+            style = style_for(qgis_layer, layer_type) or {}
+            entry = {"layer_id": layer_id, "layer_type": layer_type,
+                     "visible": bool(child.isVisible()), "opacity": _opacity_of(qgis_layer),
+                     "style": style, "popup_fields": []}
+            configs.append(entry)
+            tree.append({"layer_id": layer_id, "layer_type": layer_type})
+            was = before.get((layer_id, layer_type))
+            if was is None:
+                added.append(qgis_layer.name())
+            elif _style_differs(was, entry):
+                restyled.append(qgis_layer.name())
+            else:
+                unchanged.append(qgis_layer.name())
+        return tree
+
+    tree = walk(group)
 
     removed = [_config_label(cfg) for key, cfg in before.items() if key not in seen]
 
@@ -119,7 +242,8 @@ def plan_push(group, style_for, current_configs) -> dict:
         rename = (stored_title, current_name)
 
     return {"configs": configs, "uploads": uploads, "unchanged": unchanged,
-            "restyled": restyled, "added": added, "removed": removed, "rename": rename}
+            "restyled": restyled, "added": added, "removed": removed, "rename": rename,
+            "tree": tree}
 
 
 def _style_differs(before: dict, after: dict) -> bool:
@@ -147,41 +271,6 @@ def _config_label(cfg: dict) -> str:
     return "{0} layer {1}".format(cfg.get("layer_type") or "?", cfg.get("layer_id"))
 
 
-def configs_from_group(group, style_for) -> tuple[list[dict], list[str]]:
-    """`(layer_configs, skipped)` from a QGIS group, top of the group first.
-
-    `style_for(qgis_layer, layer_type)` returns the GeoDeploy style dict — passed in so this module
-    does not have to know about renderers, and so the caller can decide whether styles travel.
-
-    A layer with no GeoDeploy identity is SKIPPED and named. It is almost always a local file the
-    user has not uploaded yet, and quietly dropping it would produce a portal missing a layer with
-    no explanation, while quietly uploading it would be a surprise write.
-    """
-    configs, skipped = [], []
-    for child in group.children():
-        qgis_layer = getattr(child, "layer", lambda: None)()
-        if qgis_layer is None:
-            # A nested group. Portals have one flat ordered list, so there is nothing to map a
-            # sub-group onto; say so rather than silently flattening it.
-            skipped.append("{0} (a nested group)".format(child.name()))
-            continue
-        identity = layer_identity(qgis_layer)
-        if identity is None:
-            skipped.append(qgis_layer.name())
-            continue
-        layer_id, layer_type = identity
-        configs.append({
-            "layer_id": layer_id,
-            "layer_type": layer_type,
-            # `isVisible` is the CHECKBOX in the layer tree, which is what the user manipulated.
-            "visible": bool(child.isVisible()),
-            "opacity": _opacity_of(qgis_layer),
-            "style": style_for(qgis_layer, layer_type) or {},
-            "popup_fields": [],
-        })
-    return configs, skipped
-
-
 def _opacity_of(qgis_layer) -> float:
     """Layer opacity as 0–1. QGIS keeps it on the renderer for vectors and the layer for rasters."""
     try:
@@ -193,7 +282,8 @@ def _opacity_of(qgis_layer) -> float:
     return 1.0
 
 
-def push(client, group, configs, publish: bool = True, new_title: str | None = None) -> dict:
+def push(client, group, configs, publish: bool = True, new_title: str | None = None,
+         tree=None) -> dict:
     """Create or update the portal this group represents. Returns the portal document.
 
     Updating is a WHOLE-document write of `layer_configs`, not a series of add/remove calls: the
@@ -211,6 +301,10 @@ def push(client, group, configs, publish: bool = True, new_title: str | None = N
         elif new_title:
             client.portals.update(portal_id, title=new_title)
         client.portals.update(portal_id, layer_configs=configs)
+        if tree is not None:
+            # Sent separately because `layer_groups` is "leave as-is" when omitted, and a portal
+            # with no folders must be able to STAY without folders rather than keep an old tree.
+            client.portals.set_groups(portal_id, tree)
         if publish:
             client.portals.publish(portal_id)
         doc = client.portals.get(portal_id)

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -1,0 +1,132 @@
+"""A portal as a QGIS layer group, and back again.
+
+A portal IS an ordered, styled list of layers — which is exactly what a QGIS group is. So the two
+map onto each other directly, and the useful workflow falls out: open a portal, restyle it with
+QGIS's tools, push it back. No web editor in the middle.
+
+Three things make the round trip trustworthy rather than approximate:
+
+* **Identity is carried, not guessed.** Every layer added from a portal remembers which GeoDeploy
+  layer it is, in a custom property. Matching by NAME would break the moment someone renames a
+  layer in QGIS — which is the first thing anyone does — and would silently push the wrong style
+  onto the wrong layer. A layer without that property was not added from the instance, and is
+  refused by name rather than uploaded behind the user's back.
+* **The group remembers its portal.** Pushing again UPDATES the portal it came from instead of
+  creating a duplicate. A group built from scratch has no portal, so it makes one.
+* **Order is preserved in both directions.** `layer_configs[0]` is the top of the portal's list and
+  draws on top; QGIS's group index 0 is likewise the top. They correspond exactly, and the
+  conversion is a straight pass rather than a reversal — the kind of detail that is invisible until
+  a published map comes out upside down.
+"""
+from __future__ import annotations
+
+from .connection import GeoDeployError
+
+# Namespaced so nothing else in a QGIS project collides with them.
+P_LAYER_ID = "geodeploy/layer_id"
+P_LAYER_TYPE = "geodeploy/layer_type"
+P_INSTANCE = "geodeploy/instance"
+P_PORTAL_ID = "geodeploy/portal_id"
+P_PORTAL_TITLE = "geodeploy/portal_title"
+
+
+class PortalError(Exception):
+    """Explains, in words a user can act on, why a portal cannot be opened or pushed."""
+
+
+def tag_layer(qgis_layer, instance_url: str, layer_id, layer_type: str) -> None:
+    """Record which GeoDeploy layer this is, so a later push knows what it is looking at."""
+    qgis_layer.setCustomProperty(P_LAYER_ID, str(layer_id))
+    qgis_layer.setCustomProperty(P_LAYER_TYPE, layer_type)
+    qgis_layer.setCustomProperty(P_INSTANCE, instance_url)
+
+
+def layer_identity(qgis_layer):
+    """`(layer_id, layer_type)` for a layer added from an instance, or None."""
+    lid = qgis_layer.customProperty(P_LAYER_ID)
+    ltype = qgis_layer.customProperty(P_LAYER_TYPE)
+    if lid in (None, "") or ltype in (None, ""):
+        return None
+    try:
+        return (int(lid), str(ltype))
+    except (TypeError, ValueError):
+        return None
+
+
+def group_portal(group):
+    """`(portal_id, title)` when this group came from a portal, else `(None, title)`."""
+    pid = group.customProperty(P_PORTAL_ID)
+    title = group.customProperty(P_PORTAL_TITLE) or group.name()
+    try:
+        return (int(pid), title) if pid not in (None, "") else (None, title)
+    except (TypeError, ValueError):
+        return (None, title)
+
+
+def configs_from_group(group, style_for) -> tuple[list[dict], list[str]]:
+    """`(layer_configs, skipped)` from a QGIS group, top of the group first.
+
+    `style_for(qgis_layer, layer_type)` returns the GeoDeploy style dict — passed in so this module
+    does not have to know about renderers, and so the caller can decide whether styles travel.
+
+    A layer with no GeoDeploy identity is SKIPPED and named. It is almost always a local file the
+    user has not uploaded yet, and quietly dropping it would produce a portal missing a layer with
+    no explanation, while quietly uploading it would be a surprise write.
+    """
+    configs, skipped = [], []
+    for child in group.children():
+        qgis_layer = getattr(child, "layer", lambda: None)()
+        if qgis_layer is None:
+            # A nested group. Portals have one flat ordered list, so there is nothing to map a
+            # sub-group onto; say so rather than silently flattening it.
+            skipped.append("{0} (a nested group)".format(child.name()))
+            continue
+        identity = layer_identity(qgis_layer)
+        if identity is None:
+            skipped.append(qgis_layer.name())
+            continue
+        layer_id, layer_type = identity
+        configs.append({
+            "layer_id": layer_id,
+            "layer_type": layer_type,
+            # `isVisible` is the CHECKBOX in the layer tree, which is what the user manipulated.
+            "visible": bool(child.isVisible()),
+            "opacity": _opacity_of(qgis_layer),
+            "style": style_for(qgis_layer, layer_type) or {},
+            "popup_fields": [],
+        })
+    return configs, skipped
+
+
+def _opacity_of(qgis_layer) -> float:
+    """Layer opacity as 0–1. QGIS keeps it on the renderer for vectors and the layer for rasters."""
+    try:
+        value = qgis_layer.opacity()          # QgsRasterLayer, and QgsVectorLayer since 3.18
+        if value is not None:
+            return round(float(value), 3)
+    except Exception:                         # noqa: BLE001 - older API, fall through
+        pass
+    return 1.0
+
+
+def push(client, group, configs, publish: bool = True) -> dict:
+    """Create or update the portal this group represents. Returns the portal document.
+
+    Updating is a WHOLE-document write of `layer_configs`, not a series of add/remove calls: the
+    group is the intended state, and applying it in pieces would leave the portal briefly showing
+    something nobody asked for if a call failed halfway.
+    """
+    portal_id, title = group_portal(group)
+    if not configs:
+        raise PortalError("This group has no GeoDeploy layers in it. Add layers from an instance, "
+                          "or upload the ones you have, and try again.")
+    try:
+        if portal_id is None:
+            portal = client.portals.create(title=title or "Untitled portal")
+            portal_id = portal["id"]
+        client.portals.update(portal_id, layer_configs=configs)
+        if publish:
+            client.portals.publish(portal_id)
+        return client.portals.get(portal_id)
+    except GeoDeployError as exc:
+        raise PortalError(str(exc)) from exc

--- a/integrations/qgis-plugin/geodeploy_qgis/sources.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/sources.py
@@ -7,7 +7,10 @@ A GeoDeploy layer is published through several surfaces at once, and they are no
   to tile boundaries, and attributes are only what the tiles carry.
 * **OGC API - Features** is the DATA: full attributes, exact geometry. QGIS has read it natively
   since 3.16, and its provider is VIEWPORT-DRIVEN — it asks the server for the extent on screen.
-* **COG** is a raster, read by range request through `/vsicurl/`.
+* **COG** is a raster's real pixel values, read by range request through `/vsicurl/` — and
+  rendered by QGIS's own defaults, NOT by GeoDeploy's styling.
+* **Raster tiles** are the same raster as the portal draws it: colormap, stretch and band choice
+  baked in by the server. A picture, not measurements.
 
 A correction worth stating plainly, because the first version of this file got it wrong and the
 error is easy to repeat: **PMTiles being fast in MapLibre does not make it fast in QGIS.** A web map
@@ -20,6 +23,8 @@ on how the user moves around it, and neither is universally right.
 So the rule below is a default, not a verdict, and the caller can override it.
 """
 from __future__ import annotations
+
+from urllib.parse import quote
 
 # GDAL gained its PMTiles driver in 3.8. Below that the archive cannot be opened at all, so the
 # choice is not a preference — it is availability. Checked at runtime rather than assumed from the
@@ -52,11 +57,33 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
         return None
 
     if layer.get("layer_type") == "raster" or layer.get("kind") == "raster":
+        # THE COG IS THE DATA; THE TILES ARE THE PICTURE.
+        #
+        # Opening the COG gives real pixel values — what analysis needs — but QGIS then renders it
+        # with ITS defaults, so a raster carefully coloured in GeoDeploy arrives as a grey stretch
+        # and looks unstyled. The tile URL is the opposite: the server bakes the colormap, rescale,
+        # band selection and hillshade into the image, so it looks exactly like the portal, but the
+        # pixels are display colours and the values are gone.
+        #
+        # Neither is "correct", so the same switch that chooses attributes over speed for a vector
+        # chooses values over appearance here.
+        tiles = (layer.get("tile_url") or "").strip()
+        if tiles and not prefer_attributes:
+            # Relative to the instance (that is how the API returns it), and QGIS's XYZ provider
+            # wants the template URL-encoded inside the connection string.
+            url = tiles if tiles.startswith("http") else f"{base}{tiles}"
+            return {
+                "kind": "xyz",
+                "uri": f"type=xyz&url={quote(url, safe='')}&zmin=0&zmax=22",
+                "provider": "wms",          # QGIS serves XYZ through the WMS provider
+                "why": "server-rendered tiles, coloured exactly as GeoDeploy draws it",
+            }
         return {
             "kind": "cog",
             "uri": f"/vsicurl/{base}/api/data/raster/{ref}/cog",
             "provider": "gdal",
-            "why": "the Cloud-Optimized GeoTIFF itself, read by range request",
+            "why": ("the Cloud-Optimized GeoTIFF itself — real pixel values, drawn with QGIS's own "
+                    "defaults rather than GeoDeploy's styling"),
         }
 
     tiled = bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready"

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -27,7 +27,8 @@ try:                                    # pragma: no cover - only present inside
                            QgsSimpleLineSymbolLayer, QgsSimpleMarkerSymbolLayer, QgsSymbol,
                            QgsSingleSymbolRenderer, QgsClassificationRange,
                            QgsMultiBandColorRenderer, QgsSingleBandGrayRenderer,
-                           QgsSingleBandPseudoColorRenderer)
+                           QgsSingleBandPseudoColorRenderer, QgsHillshadeRenderer,
+                           QgsPalettedRasterRenderer)
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtGui import QColor
     QGIS = True
@@ -332,7 +333,47 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
                      "stretch without it.".format(name))
             return style
 
-        # Anything else — paletted, hillshade, a renderer from a plugin. The band selection and the
+        if isinstance(renderer, QgsHillshadeRenderer):
+            # Exactly representable: GeoDeploy asks TiTiler for a hillshade of the same band, and
+            # `zfactor` is the same vertical exaggeration QGIS calls Z factor. Azimuth and altitude
+            # have no equivalent in the raster style, so a non-default sun position is announced
+            # rather than dropped in silence.
+            band = renderer.band()
+            if isinstance(band, int) and band > 0:
+                style["bidx"] = [band]
+            style["algorithm"] = "hillshade"
+            try:
+                z = float(renderer.zFactor())
+                if _finite(z) and z > 0:
+                    style["zfactor"] = z
+            except (TypeError, ValueError):
+                pass
+            try:
+                az, alt = float(renderer.azimuth()), float(renderer.altitude())
+                if abs(az - 315.0) > 0.5 or abs(alt - 45.0) > 0.5:
+                    _log("This hillshade uses azimuth {0:g}/altitude {1:g}; GeoDeploy renders the "
+                         "standard 315/45, so the shading will differ.".format(az, alt))
+            except (TypeError, ValueError, AttributeError):
+                pass
+            return style
+
+        if isinstance(renderer, QgsPalettedRasterRenderer):
+            # NOT representable. A paletted raster gives each value its own colour, while a
+            # GeoDeploy raster style carries a NAMED continuous colormap — there is nowhere to put
+            # a per-value palette. Send the band so the right one is displayed, and say plainly
+            # what did not travel instead of implying the colours came across.
+            try:
+                band = renderer.band()
+                if isinstance(band, int) and band > 0:
+                    style["bidx"] = [band]
+            except (TypeError, AttributeError):
+                pass
+            _log("Paletted rasters keep per-value colours, which a GeoDeploy raster style cannot "
+                 "express (it carries a named colormap). The band was sent; choose a colormap on "
+                 "the layer instead.")
+            return style
+
+        # Anything else — a renderer from a plugin, or a QGIS class we have not met. The band and the
         # stretch are still worth having even when the colouring cannot travel: the stretch is what
         # keeps non-8-bit data from rendering as a black rectangle, and it is the part users notice.
         bands = renderer.usesBands() if hasattr(renderer, "usesBands") else []
@@ -346,7 +387,7 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
             style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
         # Name the class. "No GeoDeploy equivalent" without saying what it saw is the kind of
         # message that costs a round trip to diagnose.
-        _log("Raster renderer {0} is not fully translatable{1}.".format(
+        _log("Raster renderer {0} is not translatable{1}.".format(
             type(renderer).__name__,
             " — sent its bands and stretch" if style else ", and exposed no bands or stretch"))
         return style

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -45,6 +45,51 @@ _MARKERS = {
 }
 
 
+def _size_stops(style: dict):
+    """`(field, in_min, in_max, out_min, out_max)` for a proportional size, or None."""
+    if (style.get("size_mode") or "fixed") != "proportional":
+        return None
+    field = (style.get("size_field") or "").strip()
+    stops = [s for s in (style.get("size_stops") or [])
+             if isinstance(s, (list, tuple)) and len(s) == 2]
+    if not field or len(stops) < 2:
+        return None
+    ordered = sorted(stops, key=lambda s: s[0])
+    lo, hi = ordered[0], ordered[-1]
+    if hi[0] == lo[0]:
+        return None                     # a zero-width input range divides by zero in scale_linear
+    return (field, lo[0], hi[0], lo[1], hi[1])
+
+
+def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
+    """Drive marker size / line width from a field, the way the portal does.
+
+    GeoDeploy interpolates linearly between two stops, so `scale_linear` is the exact equivalent —
+    not an approximation. The unit conversions are the same ones the fixed sizes use: a marker's
+    QGIS size is a DIAMETER against GeoDeploy's radius, and a line's width is in mm against pixels.
+    """
+    spec = _size_stops(style)
+    if spec is None:
+        return
+    field, in_lo, in_hi, out_lo, out_hi = spec
+    try:
+        from qgis.core import QgsProperty, QgsSymbolLayer
+    except ImportError:                 # pragma: no cover
+        return
+    try:
+        if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
+            expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
+                field, in_lo, in_hi, out_lo * 2, out_hi * 2)
+            symbol.setDataDefinedSize(QgsProperty.fromExpression(expr))
+        elif isinstance(layer0, QgsSimpleLineSymbolLayer):
+            expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
+                field, in_lo, in_hi, out_lo / 4.0, out_hi / 4.0)
+            layer0.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeWidth,
+                                          QgsProperty.fromExpression(expr))
+    except Exception as exc:            # noqa: BLE001 - a size must never stop a layer drawing
+        _log("Could not apply size-by-field ({0}): {1}".format(field, exc))
+
+
 def _symbol_for(qgis_layer, color: str | None, style: dict):
     """A single symbol of the right geometry kind, coloured and sized from `style`."""
     symbol = QgsSymbol.defaultSymbol(qgis_layer.geometryType())
@@ -55,6 +100,11 @@ def _symbol_for(qgis_layer, color: str | None, style: dict):
     layer0 = symbol.symbolLayer(0) if symbol.symbolLayerCount() else None
     if layer0 is None:
         return symbol
+
+    # Size FROM A FIELD, which is independent of colour: a layer can be graduated by one column
+    # and sized by another, and applying only the colours dropped half the symbology on the floor.
+    # A fixed size is set below; this overrides it with an expression when the style has one.
+    _apply_data_defined_size(symbol, layer0, style)
 
     if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
         shape = _MARKERS.get((style.get("marker") or "circle").lower())
@@ -281,8 +331,28 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
                 _log("QGIS ramp {0!r} has no colormap of that name on the instance — sending the "
                      "stretch without it.".format(name))
             return style
+
+        # Anything else — paletted, hillshade, a renderer from a plugin. The band selection and the
+        # stretch are still worth having even when the colouring cannot travel: the stretch is what
+        # keeps non-8-bit data from rendering as a black rectangle, and it is the part users notice.
+        bands = renderer.usesBands() if hasattr(renderer, "usesBands") else []
+        bands = [b for b in (bands or []) if isinstance(b, int) and b > 0]
+        if bands:
+            style["bidx"] = bands[:3] if len(bands) >= 3 else bands[:1]
+        lo, hi = (None, None)
+        if hasattr(renderer, "contrastEnhancement"):
+            lo, hi = _enhancement_range(renderer.contrastEnhancement())
+        if lo is not None:
+            style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
+        # Name the class. "No GeoDeploy equivalent" without saying what it saw is the kind of
+        # message that costs a round trip to diagnose.
+        _log("Raster renderer {0} is not fully translatable{1}.".format(
+            type(renderer).__name__,
+            " — sent its bands and stretch" if style else ", and exposed no bands or stretch"))
+        return style
     except Exception as exc:            # noqa: BLE001 - never block an upload over styling
-        _log("Could not read this raster's symbology: {0}: {1}".format(type(exc).__name__, exc))
+        _log("Could not read this raster's symbology ({0}): {1}: {2}".format(
+            type(renderer).__name__, type(exc).__name__, exc))
         return {}
     return style
 

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -272,6 +272,12 @@ def _hex(color) -> str:
     return color.name() if hasattr(color, "name") else str(color)
 
 
+#: Must match `services/titiler.MAX_COLOR_CLASSES`. The mapping rides in the URL of every tile
+#: request, so the ceiling is set by what a proxy accepts, not by taste — 128 classes is ~5 kB,
+#: against nginx's default 8 kB request line.
+MAX_COLOR_CLASSES = 128
+
+
 def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
     """A GeoDeploy RASTER default style from a QGIS raster renderer.
 
@@ -358,19 +364,41 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
             return style
 
         if isinstance(renderer, QgsPalettedRasterRenderer):
-            # NOT representable. A paletted raster gives each value its own colour, while a
-            # GeoDeploy raster style carries a NAMED continuous colormap — there is nowhere to put
-            # a per-value palette. Send the band so the right one is displayed, and say plainly
-            # what did not travel instead of implying the colours came across.
+            # A colour per pixel VALUE — land cover, soil types, any classification. A named
+            # colormap cannot express this (interpolating between class 3 and class 4 is
+            # meaningless), so GeoDeploy carries the mapping itself and TiTiler renders from it.
             try:
                 band = renderer.band()
                 if isinstance(band, int) and band > 0:
                     style["bidx"] = [band]
             except (TypeError, AttributeError):
                 pass
-            _log("Paletted rasters keep per-value colours, which a GeoDeploy raster style cannot "
-                 "express (it carries a named colormap). The band was sent; choose a colormap on "
-                 "the layer instead.")
+            classes = []
+            for cls in (renderer.classes() or []):
+                try:
+                    value = int(cls.value)
+                except (TypeError, ValueError, AttributeError):
+                    continue
+                colour = getattr(cls, "color", None)
+                if colour is None:
+                    continue
+                # Alpha travels: "no data" in a classification is usually a transparent class, and
+                # dropping that would paint it over everything underneath.
+                classes.append({"value": value,
+                                "color": "#{0:02x}{1:02x}{2:02x}{3:02x}".format(
+                                    colour.red(), colour.green(), colour.blue(), colour.alpha())})
+            if len(classes) > MAX_COLOR_CLASSES:
+                # Truncating a classification would silently mis-colour part of the map, so refuse
+                # the colours and keep the band: a grey raster is obviously unstyled, where a
+                # half-coloured one looks finished and is wrong.
+                _log("This raster has {0} classes; GeoDeploy carries at most {1} because the "
+                     "mapping travels in every tile request. The colours were not sent — the band "
+                     "was.".format(len(classes), MAX_COLOR_CLASSES))
+                return style
+            if classes:
+                style["color_classes"] = classes
+            else:
+                _log("This paletted raster exposed no readable classes; only its band was sent.")
             return style
 
         # Anything else — a renderer from a plugin, or a QGIS class we have not met. The band and the

--- a/ui/src/components/data/RasterRow.vue
+++ b/ui/src/components/data/RasterRow.vue
@@ -7,7 +7,9 @@
           @keyup.enter="saveName" @keyup.esc="cancelEdit" @blur="saveName"
           class="text-sm font-medium bg-transparent border border-primary/60 rounded px-1 py-0.5 flex-1 min-w-0 focus:outline-none" />
         <template v-else>
-          <span class="text-sm font-medium truncate">{{ layer.name }}</span>
+          <RouterLink :to="`/data/raster/${layer.id}`"
+            class="text-sm font-medium truncate hover:text-primary hover:underline"
+            title="Open this layer's page">{{ layer.name }}</RouterLink>
           <button v-if="auth.canEdit" @click="startEdit" title="Rename layer"
             class="opacity-0 group-hover:opacity-100 text-muted-foreground/60 hover:text-foreground flex-shrink-0 transition-opacity">
             <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>
@@ -62,6 +64,7 @@
 </template>
 
 <script setup>
+import { RouterLink } from 'vue-router'
 import { computed, ref, nextTick } from 'vue'
 import { TrashIcon, LinkIcon } from '@/views/icons'
 import { useAuthStore } from '@/stores/auth'

--- a/ui/src/components/data/VectorRow.vue
+++ b/ui/src/components/data/VectorRow.vue
@@ -7,7 +7,9 @@
           @keyup.enter="saveName" @keyup.esc="cancelEdit" @blur="saveName"
           class="text-sm font-medium bg-transparent border border-primary/60 rounded px-1 py-0.5 flex-1 min-w-0 focus:outline-none" />
         <template v-else>
-          <span class="text-sm font-medium truncate">{{ layer.name }}</span>
+          <RouterLink :to="`/data/vector/${layer.id}`"
+            class="text-sm font-medium truncate hover:text-primary hover:underline"
+            title="Open this layer's page">{{ layer.name }}</RouterLink>
           <button v-if="auth.canEdit" @click="startEdit" title="Rename layer"
             class="opacity-0 group-hover:opacity-100 text-muted-foreground/60 hover:text-foreground flex-shrink-0 transition-opacity">
             <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>
@@ -102,6 +104,7 @@
 </template>
 
 <script setup>
+import { RouterLink } from 'vue-router'
 import { computed, ref, nextTick } from 'vue'
 import { TrashIcon, RefreshIcon, LinkIcon } from '@/views/icons'
 import { useAuthStore } from '@/stores/auth'

--- a/ui/src/components/portal/CreatePortalModal.vue
+++ b/ui/src/components/portal/CreatePortalModal.vue
@@ -47,6 +47,9 @@ import { usePortalsStore } from '@/stores/portals'
 import { useRouter } from 'vue-router'
 
 const emit = defineEmits(['close', 'created'])
+// Optional layer_configs to start the portal with — how "create a portal from THIS layer" works
+// without a second create path. Empty by default, which is the plain "New portal" behaviour.
+const props = defineProps({ seedLayers: { type: Array, default: () => [] } })
 const portalsStore = usePortalsStore()
 const router = useRouter()
 const busy = ref(false)
@@ -58,7 +61,7 @@ const form = reactive({
   template_id: 'minimal',
   access_type: 'public',
   access_password: '',
-  layer_configs: [],
+  layer_configs: [...props.seedLayers],
 })
 
 async function submit() {

--- a/ui/src/lib/basemaps.js
+++ b/ui/src/lib/basemaps.js
@@ -1,0 +1,44 @@
+/**
+ * The basemaps every map in GeoDeploy can sit on.
+ *
+ * Here rather than in a view because more than one place needs them now, and a second copy of a
+ * tile-URL list is a second place to fix when a provider changes a path — which they do.
+ */
+export const BASEMAPS = [
+  { id: 'positron', name: 'Positron',
+    tiles: ['https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'],
+    attribution: '© OpenStreetMap © CARTO',
+    thumb: 'https://a.basemaps.cartocdn.com/light_all/4/8/5.png' },
+  { id: 'voyager', name: 'Voyager',
+    tiles: ['https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png'],
+    attribution: '© OpenStreetMap © CARTO',
+    thumb: 'https://a.basemaps.cartocdn.com/rastertiles/voyager/4/8/5.png' },
+  { id: 'dark', name: 'Dark Matter',
+    tiles: ['https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png'],
+    attribution: '© OpenStreetMap © CARTO',
+    thumb: 'https://a.basemaps.cartocdn.com/dark_all/4/8/5.png' },
+  { id: 'osm', name: 'OpenStreetMap',
+    tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+    attribution: '© OpenStreetMap contributors',
+    thumb: 'https://a.tile.openstreetmap.org/4/8/5.png' },
+  { id: 'topo', name: 'OpenTopoMap',
+    tiles: ['https://a.tile.opentopomap.org/{z}/{x}/{y}.png', 'https://b.tile.opentopomap.org/{z}/{x}/{y}.png'],
+    attribution: '© OpenStreetMap, SRTM | © OpenTopoMap (CC-BY-SA)',
+    thumb: 'https://a.tile.opentopomap.org/4/8/5.png' },
+  { id: 'satellite', name: 'Satellite',
+    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+    attribution: 'Imagery © Esri, Maxar, Earthstar Geographics',
+    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/4/5/8' },
+  { id: 'esri-topo', name: 'Esri Topographic',
+    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}'],
+    attribution: '© Esri',
+    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/4/5/8' },
+]
+
+/** What a map uses when nobody has chosen: the first entry, by definition of "default". */
+export const DEFAULT_BASEMAP = BASEMAPS[0]
+
+/** The catalog entry for an id, falling back to the default rather than returning nothing. */
+export function basemapById(id) {
+  return BASEMAPS.find(b => b.id === id) || DEFAULT_BASEMAP
+}

--- a/ui/src/lib/mapStyle.js
+++ b/ui/src/lib/mapStyle.js
@@ -1,0 +1,285 @@
+/**
+ * The MapLibre style for a set of GeoDeploy layers — the ONE implementation.
+ *
+ * Lifted out of PortalEditor so the portal preview and any other view that has to draw layers use
+ * the same code. This function is the browser twin of `services/portal_generator.generate_style`,
+ * and nearly every line of it encodes a parity decision that took a bug to learn: which source a
+ * GeoParquet layer draws from, why an omitted `fill-outline-color` still draws an outline, why a
+ * hillshade must not be rescaled, why points become pillars in 3D. A second copy would drift from
+ * the published portal, and the drift would show up as a map that does not match its own legend.
+ *
+ * Everything it used to reach for in the editor's scope is now an argument, so the caller decides
+ * what to draw and nothing here knows about editor state.
+ */
+import {
+  colorExpression as symColorExpression,
+  sizeExpression as symSizeExpression,
+  extrusionPaint as symExtrusionPaint,
+  isExtruded as symIsExtruded,
+  iconImageExpression as symIconImageExpression,
+  iconSizeExpression as symIconSizeExpression,
+  markerImages as symMarkerImages,
+  NO_OUTLINE,
+} from '@/lib/symbology'
+
+export function buildMapStyle({ configs = [], layers = [], rasters = [], sources = [],
+                               basemap }) {
+  /**
+   * `configs` are layer_configs in PORTAL order (index 0 = top of the list). Draw order is the
+   * reverse, because MapLibre paints later layers on top — the same reversal the generator does.
+   */
+  const bm = basemap
+  const style = {
+    version: 8,
+    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+    sources: {
+      basemap: {
+        type: 'raster',
+        tiles: bm.tiles,
+        tileSize: 256,
+        attribution: bm.attribution,
+      },
+    },
+    layers: [{ id: 'basemap', type: 'raster', source: 'basemap' }],
+  }
+
+  // Merge every visible layer's bbox (skipping non-lon/lat bboxes, e.g. an old
+  // projected raster) so "fit"/zoom-to-all covers all layers, not just the last one.
+  let bounds = null
+  const expandBounds = (b) => {
+    if (!lonLatBbox(b)) return
+    bounds = bounds
+      ? [Math.min(bounds[0], b[0]), Math.min(bounds[1], b[1]), Math.max(bounds[2], b[2]), Math.max(bounds[3], b[3])]
+      : b.slice()
+  }
+
+  // Draw order follows the folder tree (flattened, top→bottom); top of the list draws on top → reverse.
+  // Parity with portal_generator.generate_style. Falls back to config order if a node lacks a config.
+  for (const cfg of [...configs].reverse()) {
+    if (cfg.visible === false) continue
+    if (cfg.layer_type === 'elevation') { expandBounds(cfg.bbox); continue }  // deck-only (see refreshDeck)
+    if (cfg.layer_type === 'vector') {
+      const layer = layers.find(l => l.id === cfg.layer_id)
+      if (!layer || layer.status !== 'ready') continue
+
+      const srcId = `vector_${layer.id}`
+      let sourceLayer
+      if (layer.storage_backend === 'geoparquet') {
+        // File-backed (GeoParquet). PRIMARY display = a deck.gl overlay fed by the viewport query
+        // (rendered outside this MapLibre style — see refreshDeck), so EXCLUDE the layer here and
+        // just keep its bbox for zoom-to-all. FALLBACK: a layer explicitly tiled (ready PMTiles)
+        // renders via the pmtiles:// vector source instead.
+        if (!(layer.tile_status === 'ready' && layer.pmtiles_key)) { expandBounds(layer.bbox); continue }
+        style.sources[srcId] = { type: 'vector', url: `pmtiles://${location.origin}/api/data/vector/${layer.id}/pmtiles` }
+        sourceLayer = 'geodeploy'
+      } else {
+        style.sources[srcId] = {
+          type: 'vector',
+          tiles: [`${location.origin}/tiles/${layer.schema_name}.${layer.table_name}/{z}/{x}/{y}`],
+          minzoom: 0, maxzoom: 22,
+        }
+        sourceLayer = `${layer.schema_name}.${layer.table_name}`
+      }
+      // Raw-paint passthrough (GeoLibre-imported layers): emit one MapLibre layer per entry, wired to
+      // this layer's tile source/source-layer. Mirrors portal_generator._vector_layers so the editor
+      // preview matches the published portal. Distinct ids let fill + outline coexist.
+      const rawLayers = cfg.style?.maplibre?.layers
+      if (Array.isArray(rawLayers) && rawLayers.length) {
+        rawLayers.forEach((entry, i) => {
+          const ml = { id: `${srcId}-${entry.suffix || entry.type || i}`, type: entry.type,
+                       source: srcId, 'source-layer': sourceLayer }
+          if (entry.filter != null) ml.filter = entry.filter
+          if (entry.paint) ml.paint = entry.paint
+          if (entry.layout) ml.layout = { ...entry.layout }
+          style.layers.push(ml)
+        })
+        expandBounds(layer.bbox)
+        continue
+      }
+      const st = cfg.style || {}
+      const opacity = cfg.opacity ?? 1.0
+      const geom = (layer.geometry_type || '').toLowerCase()
+      // Colour may be a data-driven EXPRESSION (graduated / categorized). `lib/symbology` is the
+      // twin of services/symbology.py, so the preview and the published portal classify features
+      // identically — see the parity note in that file.
+      const color = symColorExpression(st)
+
+      if (geom.includes('polygon')) {
+        if (symIsExtruded(st)) {
+          // 3D: a different layer TYPE, not a paint variation. Needs pitch to be visible at all —
+          // `ensurePitchFor3D` below tilts the preview the first time an extrusion appears.
+          style.layers.push({
+            id: srcId, type: 'fill-extrusion', source: srcId, 'source-layer': sourceLayer,
+            paint: symExtrusionPaint(st, opacity),
+          })
+        } else {
+          // MapLibre has no transparent-outline keyword: you get no outline by omitting the
+          // property. Mirrors portal_generator._vector_layer.
+          const fillPaint = {
+            'fill-color': color,
+            'fill-opacity': opacity * (st.fill_opacity ?? 0.45),
+          }
+          // `fill-antialias: false`, not an omission: an omitted fill-outline-color MATCHES the
+          // fill colour (the spec default), which is why "None" drew a visible edge. Mirrors
+          // portal_generator._vector_layer.
+          if (st.outline_color === NO_OUTLINE) fillPaint['fill-antialias'] = false
+          else fillPaint['fill-outline-color'] = st.outline_color || '#1d4ed8'
+          style.layers.push({
+            id: srcId, type: 'fill', source: srcId, 'source-layer': sourceLayer, paint: fillPaint,
+          })
+        }
+      } else if (geom.includes('line')) {
+        const linePaint = {
+          'line-color': color,
+          'line-width': symSizeExpression(st, st.line_width ?? 2),
+          'line-opacity': opacity,
+        }
+        if (st.lineType === 'dashed') linePaint['line-dasharray'] = [2, 1.5]
+        else if (st.lineType === 'dotted') linePaint['line-dasharray'] = [0.4, 1.8]
+        style.layers.push({
+          id: srcId, type: 'line', source: srcId, 'source-layer': sourceLayer, paint: linePaint,
+        })
+      } else if (symIsExtruded(st) && layer.storage_backend !== 'geoparquet') {
+        // POINTS IN 3D: pillars. MapLibre extrudes fills only, so the geometry has to become a
+        // polygon — the shared Martin function buffers the points by a radius in metres and serves
+        // them as one. A SECOND source beside the normal one, so toggling 3D off changes nothing
+        // else. Mirrors portal_generator._vector_layer / the pillar source it adds.
+        const pillarSrc = `${srcId}-pillars`
+        const r = Math.min(Math.max(Number(st.extrusion?.radius) || 30, 0.5), 100000)
+        const qs = new URLSearchParams({
+          schema: layer.schema_name, table: layer.table_name,
+          geom: layer.geometry_column || 'geom', radius: String(Math.round(r * 100) / 100),
+        })
+        style.sources[pillarSrc] = {
+          type: 'vector',
+          tiles: [`${location.origin}/tiles/point_pillars/{z}/{x}/{y}?${qs}`],
+          minzoom: 0, maxzoom: 22,
+        }
+        style.layers.push({
+          id: srcId, type: 'fill-extrusion', source: pillarSrc, 'source-layer': 'pillars',
+          paint: symExtrusionPaint(st, opacity),
+        })
+      } else {
+        // Points render as a symbol layer with generated canvas icons, so marker SHAPES work on any
+        // basemap. A classified layer keeps its shape: `icon-image` is data-driven, so we register
+        // one image per class and let MapLibre pick. Mirrors portal_generator._vector_layer — if
+        // these disagree, the preview shows a style the portal will not render.
+        symMarkerImages(st).forEach((im) => { markerSpecs[im.id] = im })
+        style.layers.push({
+          id: srcId, type: 'symbol', source: srcId, 'source-layer': sourceLayer,
+          layout: {
+            'icon-image': symIconImageExpression(st),
+            'icon-size': symIconSizeExpression(st),
+            'icon-allow-overlap': true,
+            'icon-ignore-placement': true,
+          },
+          paint: { 'icon-opacity': opacity },
+        })
+      }
+
+      expandBounds(layer.bbox)
+
+    } else if (cfg.layer_type === 'raster') {
+      const layer = rasters.find(l => l.id === cfg.layer_id)
+      if (!layer || layer.status !== 'ready' || !layer.tile_url) continue
+
+      const srcId = `raster_${layer.id}`
+      const absTileUrl = rasterTilesUrl(layer.tile_url, cfg.style, layer.band_count)
+      style.sources[srcId] = { type: 'raster', tiles: [absTileUrl], tileSize: 256 }
+      // Where the data actually IS — the published style has carried this for a while, this map
+      // never did. Without it MapLibre asks for tiles across the whole viewport at every zoom and
+      // the tile server 404s every one that misses the raster. For a drone orthomosaic a few
+      // hundred metres wide that is nearly every tile on screen, which is what filled the console.
+      const rbounds = lonLatBbox(layer.bbox)
+      if (rbounds) {
+        style.sources[srcId].bounds = rbounds
+        // And how far OUT to bother asking. Mirrors portal_generator._min_zoom_for: `bounds` stops
+        // tiles that MISS the raster, not a tile that hits it and spans a continent — and a z3 tile
+        // of a drone orthomosaic took long enough that nginx returned 504, which hangs the map.
+        const mz = minZoomFor(rbounds)
+        if (mz) style.sources[srcId].minzoom = mz
+      }
+      style.layers.push({
+        id: srcId, type: 'raster', source: srcId,
+        paint: { 'raster-opacity': cfg.opacity ?? 1.0, ...(cfg.style?.paint || {}) },
+      })
+      expandBounds(layer.bbox)
+
+    } else if (cfg.layer_type === 'external') {
+      const src = sources.find(s => s.id === cfg.layer_id)
+      if (!src) continue
+      const srcId = `ext_${src.id}`
+      const abs = (u) => (u && u.startsWith('/')) ? location.origin + u : u
+      const op = cfg.opacity ?? 1.0
+      if (src.kind === 'raster') {
+        if (!src.tile_url) continue
+        style.sources[srcId] = { type: 'raster', tiles: [abs(src.tile_url)], tileSize: 256 }
+        if (src.attribution) style.sources[srcId].attribution = src.attribution
+        style.layers.push({ id: `external-${src.id}`, type: 'raster', source: srcId, paint: { 'raster-opacity': op } })
+      } else {
+        if (!src.data_url) continue
+        style.sources[srcId] = { type: 'geojson', data: abs(src.data_url) }
+        if (src.attribution) style.sources[srcId].attribution = src.attribution
+        const geom = src.geometry_type || 'polygon'
+        const color = cfg.style?.color || '#3b82f6'
+        if (geom === 'polygon') {
+          style.layers.push({ id: `external-${src.id}`, type: 'fill', source: srcId,
+            paint: { 'fill-color': color, 'fill-opacity': op * (cfg.style?.fill_opacity ?? 0.45), 'fill-outline-color': cfg.style?.outline_color || '#1d4ed8' } })
+        } else if (geom === 'line') {
+          style.layers.push({ id: `external-${src.id}`, type: 'line', source: srcId,
+            paint: { 'line-color': color, 'line-width': cfg.style?.line_width ?? 2, 'line-opacity': op } })
+        } else {
+          style.layers.push({ id: `external-${src.id}`, type: 'circle', source: srcId,
+            paint: { 'circle-color': color, 'circle-radius': cfg.style?.radius ?? 5, 'circle-opacity': op, 'circle-stroke-color': '#fff', 'circle-stroke-width': 1 } })
+        }
+      }
+      expandBounds(src.bbox)
+    }
+  }
+
+  return { style, bounds }
+}
+
+
+export function lonLatBbox(b) {
+  return (Array.isArray(b) && b.length === 4 &&
+    b[0] >= -180 && b[2] <= 180 && b[0] < b[2] &&
+    b[1] >= -90 && b[3] <= 90 && b[1] < b[3]) ? b.slice(0, 4) : null
+}
+
+// The lowest zoom worth requesting tiles at, from the layer's extent. Mirrors
+// services/portal_generator.py::_min_zoom_for — a tile spans 360/2^z degrees, so the layer first
+// fits in one tile at log2(360/width); four levels of slack keeps it visible as a speck before we
+// stop asking. 0 (falsy) = continent-sized, leave unrestricted.
+const MINZOOM_SLACK = 4
+function minZoomFor(b) {
+  const width = Math.max(b[2] - b[0], b[3] - b[1])
+  if (!(width > 0)) return 0
+  const fitsAt = width < 360 ? Math.log2(360 / width) : 0
+  return Math.max(0, Math.min(Math.trunc(fitsAt) - MINZOOM_SLACK, 18))
+}
+
+// Build a raster tile URL from the layer's base URL + the configured raster style.
+export function rasterTilesUrl(baseTileUrl, style, bandCount) {
+  const base = (baseTileUrl || '').split('&')[0]  // s3 key has no '&', so this keeps ?url=...
+  const params = []
+  let bands = Array.isArray(style?.bidx) ? style.bidx.filter(b => b != null) : []
+  // Mirrors services/titiler.py::get_tile_url. A PNG holds at most four channels and TiTiler adds
+  // the mask as alpha, so a 4-band multispectral raster asks the driver for five and every tile
+  // 500s. With no band selection TiTiler reads them all — hence an explicit default.
+  if (!bands.length && bandCount > 3) bands = [1, 2, 3]
+  bands.forEach(b => params.push(`bidx=${b}`))
+  // Mirrors services/titiler.py::get_tile_url — a hillshade is already a finished 0-255 relief
+  // image, and TiTiler applies rescale AFTER the algorithm, so a data-range stretch flattens it.
+  if (style?.rescale && style?.algorithm !== 'hillshade') params.push(`rescale=${style.rescale}`)
+  if (style?.algorithm) {
+    params.push(`algorithm=${style.algorithm}`)
+    if (style.algorithm === 'hillshade' && style.zfactor && Number(style.zfactor) !== 1) {
+      params.push(`expression=b1*${style.zfactor}`)
+    }
+  } else if (style?.colormap && bands.length !== 3) {
+    params.push(`colormap_name=${style.colormap}`)
+  }
+  const url = base + (params.length ? '&' + params.join('&') : '')
+  return url.startsWith('/') ? location.origin + url : url
+}

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -16,6 +16,9 @@ const routes = [
     children: [
       { path: '', redirect: '/data' },
       { path: 'data', component: () => import('@/views/DataManager.vue') },
+      // One layer, on its own page. `kind` is vector|raster because the two are separate
+      // id sequences — layer 1 exists twice, and the URL has to say which one.
+      { path: 'data/:kind(vector|raster)/:id', component: () => import('@/views/LayerPage.vue') },
       { path: 'portals', component: () => import('@/views/PortalBuilder.vue') },
       { path: 'portals/:id/edit', component: () => import('@/views/PortalEditor.vue'), meta: { requiresEditor: true } },
       { path: 'templates', component: () => import('@/views/TemplateGallery.vue') },

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -1,0 +1,388 @@
+<!--
+  One layer, on its own page.
+
+  My Data lists layers but never shows you one — to actually LOOK at a layer you had to build a
+  portal around it, which is a strange price for answering "what is in this file?". This is that
+  page: the layer on a map exactly as a portal would draw it, what it is, how it is served, and
+  every action the list row offers.
+
+  Nothing here re-implements anything. The map comes from `lib/mapStyle.buildMapStyle` — the same
+  function the portal editor uses and the twin of `portal_generator.generate_style` — so what you
+  see here IS what a portal shows. The actions are the same modals and the same store calls the row
+  uses. A second implementation of either would drift, and the drift would be a page that lies
+  about the layer it describes.
+-->
+<template>
+  <div v-if="!layer" class="p-8 text-center text-muted-foreground">
+    <p v-if="dataStore.loading">Loading…</p>
+    <template v-else>
+      <p class="text-sm">That layer is not here any more.</p>
+      <RouterLink to="/data" class="btn-secondary mt-4 inline-flex">Back to My Data</RouterLink>
+    </template>
+  </div>
+
+  <div v-else class="space-y-5">
+    <!-- Header ------------------------------------------------------------------------------ -->
+    <div class="flex items-start justify-between gap-4 flex-wrap">
+      <div class="min-w-0">
+        <RouterLink to="/data"
+          class="text-xs text-muted-foreground/70 hover:text-foreground inline-flex items-center gap-1">
+          <span aria-hidden="true">←</span> My Data
+        </RouterLink>
+        <div class="flex items-center gap-2 mt-1">
+          <span class="w-3 h-3 rounded-sm flex-shrink-0 ring-1 ring-black/20"
+            :style="{ background: swatch }" :title="`Drawn in ${swatch}`" />
+          <h1 v-if="!renaming" class="text-2xl font-semibold truncate">{{ layer.name }}</h1>
+          <input v-else ref="nameInput" v-model="draftName" @keyup.enter="commitRename"
+            @keyup.esc="renaming = false" @blur="commitRename"
+            class="input text-2xl font-semibold py-0.5" />
+          <button v-if="auth.canEdit && !renaming" @click="startRename"
+            class="text-muted-foreground/60 hover:text-foreground text-sm" title="Rename layer">✎</button>
+        </div>
+        <p class="text-xs text-muted-foreground/70 mt-1">
+          {{ kindLabel }}<span v-if="layer.created_by"> · added by {{ layer.created_by }}</span>
+          <span v-if="layer.created_at"> · {{ new Date(layer.created_at).toLocaleDateString() }}</span>
+        </p>
+      </div>
+
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="badge" :class="statusClass">{{ layer.status }}</span>
+        <span v-if="layer.tile_status === 'ready'" class="badge badge-muted"
+          title="Tiled to PMTiles — renders as fast static vector tiles">Tiled</span>
+        <span class="badge badge-muted">{{ visibilityLabel }}</span>
+      </div>
+    </div>
+
+    <!-- Map + facts ------------------------------------------------------------------------- -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
+      <div class="lg:col-span-2 card overflow-hidden">
+        <div ref="mapEl" class="w-full h-[460px] bg-muted/40" />
+        <p v-if="mapNote" class="text-xs text-amber-300/90 px-4 py-2 border-t border-border/60">
+          {{ mapNote }}
+        </p>
+      </div>
+
+      <div class="space-y-5">
+        <section class="card p-4">
+          <h2 class="text-sm font-semibold mb-3">What it is</h2>
+          <dl class="space-y-1.5 text-sm">
+            <Fact label="Geometry" :value="layer.geometry_type" />
+            <Fact label="Features" :value="layer.feature_count?.toLocaleString()" />
+            <Fact label="Bands" :value="layer.band_count" />
+            <Fact label="CRS" :value="layer.crs" mono />
+            <Fact label="Size" :value="prettySize" />
+            <Fact label="Extent" :value="prettyExtent" mono
+              hint="West, south, east, north in EPSG:4326" />
+          </dl>
+        </section>
+
+        <section class="card p-4">
+          <h2 class="text-sm font-semibold mb-3">How it is served</h2>
+          <dl class="space-y-1.5 text-sm">
+            <Fact label="Storage" :value="storageLabel" />
+            <Fact label="Tiles" :value="tilesLabel" />
+            <Fact v-if="isRaster" label="Zoom floor"
+              :value="layer.low_zoom_ok === false ? 'High zoom only' : 'Draws when zoomed out'"
+              hint="Measured from the file's overview pyramid at ingest" />
+            <Fact v-if="isRaster && rasterStyle.colormap" label="Colormap" :value="rasterStyle.colormap" />
+            <Fact v-if="isRaster && rasterStyle.rescale" label="Stretch" :value="rasterStyle.rescale" mono />
+          </dl>
+        </section>
+
+        <section v-if="hasDescription" class="card p-4">
+          <h2 class="text-sm font-semibold mb-3">Metadata</h2>
+          <dl class="space-y-1.5 text-sm">
+            <Fact label="Licence" :value="layer.license" />
+            <Fact label="Attribution" :value="layer.attribution" />
+            <Fact label="Keywords" :value="layer.keywords" />
+          </dl>
+          <p v-if="layer.abstract" class="text-xs text-muted-foreground mt-2 whitespace-pre-line">
+            {{ layer.abstract }}
+          </p>
+          <p class="text-[11px] text-muted-foreground/60 mt-2">
+            Edited under Sharing — it travels with the layer into STAC, OGC API and the catalog.
+          </p>
+        </section>
+
+        <section v-if="legend.length" class="card p-4">
+          <h2 class="text-sm font-semibold mb-1">Legend</h2>
+          <p v-if="colorField" class="text-[11px] text-muted-foreground/70 mb-2">
+            Colour by <span class="font-medium text-muted-foreground">{{ colorField }}</span>
+          </p>
+          <div class="space-y-1 max-h-52 overflow-y-auto pr-1">
+            <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-2">
+              <span class="w-3.5 h-3.5 rounded-sm flex-shrink-0 ring-1 ring-black/25"
+                :style="{ background: e.color }" />
+              <span class="text-xs text-muted-foreground truncate">{{ e.label }}</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <!-- Actions ------------------------------------------------------------------------------ -->
+    <section class="card p-4">
+      <h2 class="text-sm font-semibold mb-3">Do something with it</h2>
+      <div class="flex flex-wrap gap-2">
+        <button v-if="auth.canEdit && ready" @click="showStyle = true" class="btn-secondary text-sm">
+          Style
+        </button>
+        <button v-if="ready" @click="showLinks = true" class="btn-secondary text-sm">
+          Share links
+        </button>
+        <button v-if="auth.canEdit && ready" @click="showSharing = true" class="btn-secondary text-sm">
+          {{ visibilityLabel === 'Public' ? 'Sharing — public' : 'Sharing' }}
+        </button>
+        <button v-if="auth.canEdit && ready" @click="showPortal = true" class="btn-primary text-sm">
+          Create a portal from this layer
+        </button>
+        <button v-if="auth.canEdit && isVector && ready" @click="onTile" :disabled="tiling"
+          class="btn-secondary text-sm disabled:opacity-60"
+          :title="layer.tile_status === 'ready' ? 'Regenerate the PMTiles archive' : 'Tile for fast display'">
+          {{ tiling ? 'Tiling…' : (layer.tile_status === 'ready' ? 'Re-tile' : 'Tile for fast display') }}
+        </button>
+        <button v-if="auth.canEdit && isVector" @click="onReprocess" :disabled="restarting"
+          class="btn-secondary text-sm disabled:opacity-60"
+          title="Re-convert from the uploaded file — no re-upload needed">
+          {{ restarting ? 'Restarting…' : 'Reprocess' }}
+        </button>
+        <button v-if="auth.canEdit" @click="confirmDelete = true"
+          class="btn-secondary text-sm text-red-400 hover:text-red-300 ml-auto">
+          Delete
+        </button>
+      </div>
+    </section>
+
+    <!-- Fields -------------------------------------------------------------------------------- -->
+    <section v-if="fields.length" class="card p-4">
+      <h2 class="text-sm font-semibold mb-3">Fields <span class="text-muted-foreground/60 font-normal">({{ fields.length }})</span></h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-left text-xs text-muted-foreground/70 border-b border-border/60">
+              <th class="py-1.5 pr-4 font-medium">Name</th>
+              <th class="py-1.5 font-medium">Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="f in fields" :key="f.name" class="border-b border-border/30 last:border-0">
+              <td class="py-1.5 pr-4 font-mono text-xs">{{ f.name }}</td>
+              <td class="py-1.5 text-muted-foreground text-xs">{{ f.type }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <StyleModal v-if="showStyle" :layer="layer" :layer-type="kind" @close="onStyleClosed" />
+    <SharingModal v-if="showSharing" :layer="layer" :layer-type="kind" @close="showSharing = false" />
+    <ShareLinksModal v-if="showLinks" :layer="layer" :layer-type="kind" @close="showLinks = false" />
+    <CreatePortalModal v-if="showPortal" :seed-layers="[portalSeed]" @close="showPortal = false" />
+    <ConfirmDeleteModal v-if="confirmDelete" :name="layer.name"
+      @cancel="confirmDelete = false" @confirm="onDelete" />
+  </div>
+</template>
+
+<script setup>
+import { computed, h, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
+import maplibregl from 'maplibre-gl'
+
+import { useDataStore } from '@/stores/data'
+import { useAuthStore } from '@/stores/auth'
+import { buildMapStyle, lonLatBbox } from '@/lib/mapStyle'
+import { DEFAULT_BASEMAP } from '@/lib/basemaps'
+import { legendEntries, representativeColor } from '@/lib/symbology'
+import StyleModal from '@/components/data/StyleModal.vue'
+import SharingModal from '@/components/data/SharingModal.vue'
+import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
+import ConfirmDeleteModal from '@/components/data/ConfirmDeleteModal.vue'
+import CreatePortalModal from '@/components/portal/CreatePortalModal.vue'
+
+// A label/value row. Rendered rather than templated because it must vanish entirely when the value
+// is absent — a "Bands: —" line on a vector layer is noise pretending to be information.
+const Fact = (props) => (props.value === undefined || props.value === null || props.value === '')
+  ? null
+  : h('div', { class: 'flex items-baseline justify-between gap-3' }, [
+      h('dt', { class: 'text-xs text-muted-foreground/70 flex-shrink-0', title: props.hint || '' },
+        props.label),
+      h('dd', { class: props.mono ? 'text-xs font-mono text-right break-all' : 'text-sm text-right' },
+        String(props.value)),
+    ])
+Fact.props = ['label', 'value', 'mono', 'hint']
+
+const route = useRoute()
+const router = useRouter()
+const dataStore = useDataStore()
+const auth = useAuthStore()
+
+const kind = computed(() => (route.params.kind === 'raster' ? 'raster' : 'vector'))
+const isRaster = computed(() => kind.value === 'raster')
+const isVector = computed(() => kind.value === 'vector')
+
+const layer = computed(() => {
+  const id = Number(route.params.id)
+  const list = isRaster.value ? dataStore.rasterLayers : dataStore.vectorLayers
+  return list.find(l => l.id === id) || null
+})
+const ready = computed(() => layer.value?.status === 'ready')
+
+// A vector's default style nests the visual part under `style`; a raster's is flat. Same split the
+// API stores, so this is where it is unpacked rather than in three places downstream.
+const vectorStyle = computed(() => (layer.value?.default_style?.style) || {})
+const rasterStyle = computed(() => layer.value?.default_style || {})
+const styleForMap = computed(() => (isRaster.value ? rasterStyle.value : vectorStyle.value))
+
+const legend = computed(() => (isVector.value ? legendEntries(vectorStyle.value) : []))
+const colorField = computed(() =>
+  (vectorStyle.value.color_mode && vectorStyle.value.color_mode !== 'single')
+    ? vectorStyle.value.color_field : null)
+const swatch = computed(() => (isRaster.value ? '#64748b' : representativeColor(vectorStyle.value)))
+
+const fields = computed(() => (layer.value?.columns || []).filter(c => c?.name))
+const hasDescription = computed(() => Boolean(
+  layer.value?.abstract || layer.value?.keywords || layer.value?.license || layer.value?.attribution))
+
+/** This layer as a portal's first layer_config — the same shape the editor writes. */
+const portalSeed = computed(() => ({
+  layer_id: layer.value.id, layer_type: kind.value, visible: true,
+  opacity: layer.value.default_style?.opacity ?? 1.0,
+  style: styleForMap.value, popup_fields: [],
+}))
+
+const kindLabel = computed(() => isRaster.value
+  ? 'Raster'
+  : (layer.value?.storage_backend === 'geoparquet' ? 'Vector · GeoParquet' : 'Vector · PostGIS'))
+const storageLabel = computed(() => isRaster.value
+  ? 'Cloud-Optimized GeoTIFF'
+  : (layer.value?.storage_backend === 'geoparquet' ? 'GeoParquet in object storage' : 'PostGIS table'))
+const tilesLabel = computed(() => {
+  if (isRaster.value) return 'TiTiler, rendered on demand'
+  if (layer.value?.storage_backend === 'geoparquet') {
+    return layer.value?.tile_status === 'ready' ? 'PMTiles archive' : 'Not tiled'
+  }
+  return 'Martin vector tiles'
+})
+const visibilityLabel = computed(() =>
+  layer.value?.is_public ? 'Public' : (layer.value?.visibility === 'private' ? 'Private' : 'Organization'))
+const statusClass = computed(() => ({
+  ready: 'badge-success', error: 'badge-error',
+}[layer.value?.status] || 'badge-muted'))
+
+const prettySize = computed(() => {
+  const b = layer.value?.file_size
+  if (!b) return null
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let n = b, i = 0
+  while (n >= 1024 && i < units.length - 1) { n /= 1024; i += 1 }
+  return `${n < 10 && i > 0 ? n.toFixed(1) : Math.round(n)} ${units[i]}`
+})
+const prettyExtent = computed(() => {
+  const b = lonLatBbox(layer.value?.bbox)
+  return b ? b.map(v => Number(v).toFixed(4)).join(', ') : null
+})
+
+// -- the map ---------------------------------------------------------------------------------
+const mapEl = ref(null)
+const mapNote = ref('')
+let map = null
+
+/** The layer as a portal would configure it — one entry, drawn by the shared builder. */
+function configFor(l) {
+  return {
+    layer_id: l.id,
+    layer_type: kind.value,
+    visible: true,
+    opacity: l.default_style?.opacity ?? 1.0,
+    style: styleForMap.value,
+  }
+}
+
+function renderMap() {
+  const l = layer.value
+  if (!l || !mapEl.value) return
+
+  // An untiled GeoParquet layer draws through the portal's data view (deck.gl over a viewport
+  // query), which this page does not run. Saying so beats an empty basemap that looks broken.
+  mapNote.value = (isVector.value && l.storage_backend === 'geoparquet'
+                   && l.tile_status !== 'ready')
+    ? 'This GeoParquet layer is not tiled, so there is nothing to draw here yet. Tile it for a preview.'
+    : ''
+
+  const { style, bounds } = buildMapStyle({
+    configs: [configFor(l)],
+    layers: isVector.value ? [l] : [],
+    rasters: isRaster.value ? [l] : [],
+    sources: [],
+    basemap: DEFAULT_BASEMAP,
+  })
+
+  if (map) { map.setStyle(style); fit(bounds); return }
+  map = new maplibregl.Map({ container: mapEl.value, style, center: [0, 20], zoom: 1.4,
+                             attributionControl: { compact: true } })
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right')
+  map.on('load', () => fit(bounds))
+}
+
+function fit(bounds) {
+  const b = lonLatBbox(bounds) || lonLatBbox(layer.value?.bbox)
+  if (b && map) map.fitBounds([[b[0], b[1]], [b[2], b[3]]], { padding: 36, duration: 0, maxZoom: 16 })
+}
+
+onMounted(async () => {
+  if (!dataStore.vectorLayers.length && !dataStore.rasterLayers.length) await dataStore.refresh()
+  await nextTick()
+  renderMap()
+})
+onBeforeUnmount(() => { if (map) { map.remove(); map = null } })
+// Re-render when the layer arrives, when its style changes, or when the route moves to another one.
+watch([layer, styleForMap], () => renderMap(), { deep: true })
+
+// -- actions ---------------------------------------------------------------------------------
+const showStyle = ref(false)
+const showSharing = ref(false)
+const showLinks = ref(false)
+const showPortal = ref(false)
+const confirmDelete = ref(false)
+const tiling = ref(false)
+const restarting = ref(false)
+
+const renaming = ref(false)
+const draftName = ref('')
+const nameInput = ref(null)
+
+async function startRename() {
+  draftName.value = layer.value.name
+  renaming.value = true
+  await nextTick()
+  nameInput.value?.focus()
+}
+async function commitRename() {
+  if (!renaming.value) return
+  renaming.value = false
+  const name = draftName.value.trim()
+  if (!name || name === layer.value.name) return
+  if (isRaster.value) await dataStore.renameRaster(layer.value.id, name)
+  else await dataStore.renameVector(layer.value.id, name)
+}
+
+function onStyleClosed() {
+  showStyle.value = false
+  renderMap()            // the map is the preview of what was just saved
+}
+
+async function onTile() {
+  tiling.value = true
+  try { await dataStore.tileVector(layer.value.id) } finally { tiling.value = false }
+}
+async function onReprocess() {
+  restarting.value = true
+  try { await dataStore.reprocessVector(layer.value.id) } finally { restarting.value = false }
+}
+async function onDelete() {
+  confirmDelete.value = false
+  if (isRaster.value) await dataStore.removeRaster(layer.value.id)
+  else await dataStore.removeVector(layer.value.id)
+  router.push('/data')
+}
+</script>

--- a/ui/src/views/PortalEditor.vue
+++ b/ui/src/views/PortalEditor.vue
@@ -557,6 +557,7 @@ import {
   iconSizeExpression as symIconSizeExpression,
   markerImages as symMarkerImages,
 } from '@/lib/symbology'
+import { buildMapStyle, lonLatBbox, rasterTilesUrl } from '@/lib/mapStyle'
 import { capturePortalThumbnail } from '@/composables/portalThumbnail'
 import maplibregl from 'maplibre-gl'
 import { MapboxOverlay } from '@deck.gl/mapbox'
@@ -1784,217 +1785,16 @@ class BasemapControl {
 }
 
 function buildPreviewStyle() {
-  const bm = currentBasemap()
-  const style = {
-    version: 8,
-    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
-    sources: {
-      basemap: {
-        type: 'raster',
-        tiles: bm.tiles,
-        tileSize: 256,
-        attribution: bm.attribution,
-      },
-    },
-    layers: [{ id: 'basemap', type: 'raster', source: 'basemap' }],
-  }
-
-  // Merge every visible layer's bbox (skipping non-lon/lat bboxes, e.g. an old
-  // projected raster) so "fit"/zoom-to-all covers all layers, not just the last one.
-  let bounds = null
-  const expandBounds = (b) => {
-    if (!lonLatBbox(b)) return
-    bounds = bounds
-      ? [Math.min(bounds[0], b[0]), Math.min(bounds[1], b[1]), Math.max(bounds[2], b[2]), Math.max(bounds[3], b[3])]
-      : b.slice()
-  }
-
-  // Draw order follows the folder tree (flattened, top→bottom); top of the list draws on top → reverse.
-  // Parity with portal_generator.generate_style. Falls back to config order if a node lacks a config.
+  // The editor's own inputs, handed to the shared builder. Draw order comes from the folder tree
+  // (flattened, top-first); falls back to the config order when a node has no config.
   const orderedForDraw = flattenTreeRefs(layerTree.value).map(configForNode).filter(Boolean)
-  for (const cfg of [...(orderedForDraw.length ? orderedForDraw : layerConfigs.value)].reverse()) {
-    if (cfg.visible === false) continue
-    if (cfg.layer_type === 'elevation') { expandBounds(cfg.bbox); continue }  // deck-only (see refreshDeck)
-    if (cfg.layer_type === 'vector') {
-      const layer = dataStore.vectorLayers.find(l => l.id === cfg.layer_id)
-      if (!layer || layer.status !== 'ready') continue
-
-      const srcId = `vector_${layer.id}`
-      let sourceLayer
-      if (layer.storage_backend === 'geoparquet') {
-        // File-backed (GeoParquet). PRIMARY display = a deck.gl overlay fed by the viewport query
-        // (rendered outside this MapLibre style — see refreshDeck), so EXCLUDE the layer here and
-        // just keep its bbox for zoom-to-all. FALLBACK: a layer explicitly tiled (ready PMTiles)
-        // renders via the pmtiles:// vector source instead.
-        if (!(layer.tile_status === 'ready' && layer.pmtiles_key)) { expandBounds(layer.bbox); continue }
-        style.sources[srcId] = { type: 'vector', url: `pmtiles://${location.origin}/api/data/vector/${layer.id}/pmtiles` }
-        sourceLayer = 'geodeploy'
-      } else {
-        style.sources[srcId] = {
-          type: 'vector',
-          tiles: [`${location.origin}/tiles/${layer.schema_name}.${layer.table_name}/{z}/{x}/{y}`],
-          minzoom: 0, maxzoom: 22,
-        }
-        sourceLayer = `${layer.schema_name}.${layer.table_name}`
-      }
-      // Raw-paint passthrough (GeoLibre-imported layers): emit one MapLibre layer per entry, wired to
-      // this layer's tile source/source-layer. Mirrors portal_generator._vector_layers so the editor
-      // preview matches the published portal. Distinct ids let fill + outline coexist.
-      const rawLayers = cfg.style?.maplibre?.layers
-      if (Array.isArray(rawLayers) && rawLayers.length) {
-        rawLayers.forEach((entry, i) => {
-          const ml = { id: `${srcId}-${entry.suffix || entry.type || i}`, type: entry.type,
-                       source: srcId, 'source-layer': sourceLayer }
-          if (entry.filter != null) ml.filter = entry.filter
-          if (entry.paint) ml.paint = entry.paint
-          if (entry.layout) ml.layout = { ...entry.layout }
-          style.layers.push(ml)
-        })
-        expandBounds(layer.bbox)
-        continue
-      }
-      const st = cfg.style || {}
-      const opacity = cfg.opacity ?? 1.0
-      const geom = (layer.geometry_type || '').toLowerCase()
-      // Colour may be a data-driven EXPRESSION (graduated / categorized). `lib/symbology` is the
-      // twin of services/symbology.py, so the preview and the published portal classify features
-      // identically — see the parity note in that file.
-      const color = symColorExpression(st)
-
-      if (geom.includes('polygon')) {
-        if (symIsExtruded(st)) {
-          // 3D: a different layer TYPE, not a paint variation. Needs pitch to be visible at all —
-          // `ensurePitchFor3D` below tilts the preview the first time an extrusion appears.
-          style.layers.push({
-            id: srcId, type: 'fill-extrusion', source: srcId, 'source-layer': sourceLayer,
-            paint: symExtrusionPaint(st, opacity),
-          })
-        } else {
-          // MapLibre has no transparent-outline keyword: you get no outline by omitting the
-          // property. Mirrors portal_generator._vector_layer.
-          const fillPaint = {
-            'fill-color': color,
-            'fill-opacity': opacity * (st.fill_opacity ?? 0.45),
-          }
-          // `fill-antialias: false`, not an omission: an omitted fill-outline-color MATCHES the
-          // fill colour (the spec default), which is why "None" drew a visible edge. Mirrors
-          // portal_generator._vector_layer.
-          if (st.outline_color === NO_OUTLINE) fillPaint['fill-antialias'] = false
-          else fillPaint['fill-outline-color'] = st.outline_color || '#1d4ed8'
-          style.layers.push({
-            id: srcId, type: 'fill', source: srcId, 'source-layer': sourceLayer, paint: fillPaint,
-          })
-        }
-      } else if (geom.includes('line')) {
-        const linePaint = {
-          'line-color': color,
-          'line-width': symSizeExpression(st, st.line_width ?? 2),
-          'line-opacity': opacity,
-        }
-        if (st.lineType === 'dashed') linePaint['line-dasharray'] = [2, 1.5]
-        else if (st.lineType === 'dotted') linePaint['line-dasharray'] = [0.4, 1.8]
-        style.layers.push({
-          id: srcId, type: 'line', source: srcId, 'source-layer': sourceLayer, paint: linePaint,
-        })
-      } else if (symIsExtruded(st) && layer.storage_backend !== 'geoparquet') {
-        // POINTS IN 3D: pillars. MapLibre extrudes fills only, so the geometry has to become a
-        // polygon — the shared Martin function buffers the points by a radius in metres and serves
-        // them as one. A SECOND source beside the normal one, so toggling 3D off changes nothing
-        // else. Mirrors portal_generator._vector_layer / the pillar source it adds.
-        const pillarSrc = `${srcId}-pillars`
-        const r = Math.min(Math.max(Number(st.extrusion?.radius) || 30, 0.5), 100000)
-        const qs = new URLSearchParams({
-          schema: layer.schema_name, table: layer.table_name,
-          geom: layer.geometry_column || 'geom', radius: String(Math.round(r * 100) / 100),
-        })
-        style.sources[pillarSrc] = {
-          type: 'vector',
-          tiles: [`${location.origin}/tiles/point_pillars/{z}/{x}/{y}?${qs}`],
-          minzoom: 0, maxzoom: 22,
-        }
-        style.layers.push({
-          id: srcId, type: 'fill-extrusion', source: pillarSrc, 'source-layer': 'pillars',
-          paint: symExtrusionPaint(st, opacity),
-        })
-      } else {
-        // Points render as a symbol layer with generated canvas icons, so marker SHAPES work on any
-        // basemap. A classified layer keeps its shape: `icon-image` is data-driven, so we register
-        // one image per class and let MapLibre pick. Mirrors portal_generator._vector_layer — if
-        // these disagree, the preview shows a style the portal will not render.
-        symMarkerImages(st).forEach((im) => { markerSpecs[im.id] = im })
-        style.layers.push({
-          id: srcId, type: 'symbol', source: srcId, 'source-layer': sourceLayer,
-          layout: {
-            'icon-image': symIconImageExpression(st),
-            'icon-size': symIconSizeExpression(st),
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-          },
-          paint: { 'icon-opacity': opacity },
-        })
-      }
-
-      expandBounds(layer.bbox)
-
-    } else if (cfg.layer_type === 'raster') {
-      const layer = dataStore.rasterLayers.find(l => l.id === cfg.layer_id)
-      if (!layer || layer.status !== 'ready' || !layer.tile_url) continue
-
-      const srcId = `raster_${layer.id}`
-      const absTileUrl = rasterTilesUrl(layer.tile_url, cfg.style, layer.band_count)
-      style.sources[srcId] = { type: 'raster', tiles: [absTileUrl], tileSize: 256 }
-      // Where the data actually IS — the published style has carried this for a while, this map
-      // never did. Without it MapLibre asks for tiles across the whole viewport at every zoom and
-      // the tile server 404s every one that misses the raster. For a drone orthomosaic a few
-      // hundred metres wide that is nearly every tile on screen, which is what filled the console.
-      const rbounds = lonLatBbox(layer.bbox)
-      if (rbounds) {
-        style.sources[srcId].bounds = rbounds
-        // And how far OUT to bother asking. Mirrors portal_generator._min_zoom_for: `bounds` stops
-        // tiles that MISS the raster, not a tile that hits it and spans a continent — and a z3 tile
-        // of a drone orthomosaic took long enough that nginx returned 504, which hangs the map.
-        const mz = minZoomFor(rbounds)
-        if (mz) style.sources[srcId].minzoom = mz
-      }
-      style.layers.push({
-        id: srcId, type: 'raster', source: srcId,
-        paint: { 'raster-opacity': cfg.opacity ?? 1.0, ...(cfg.style?.paint || {}) },
-      })
-      expandBounds(layer.bbox)
-
-    } else if (cfg.layer_type === 'external') {
-      const src = dataStore.externalSources.find(s => s.id === cfg.layer_id)
-      if (!src) continue
-      const srcId = `ext_${src.id}`
-      const abs = (u) => (u && u.startsWith('/')) ? location.origin + u : u
-      const op = cfg.opacity ?? 1.0
-      if (src.kind === 'raster') {
-        if (!src.tile_url) continue
-        style.sources[srcId] = { type: 'raster', tiles: [abs(src.tile_url)], tileSize: 256 }
-        if (src.attribution) style.sources[srcId].attribution = src.attribution
-        style.layers.push({ id: `external-${src.id}`, type: 'raster', source: srcId, paint: { 'raster-opacity': op } })
-      } else {
-        if (!src.data_url) continue
-        style.sources[srcId] = { type: 'geojson', data: abs(src.data_url) }
-        if (src.attribution) style.sources[srcId].attribution = src.attribution
-        const geom = src.geometry_type || 'polygon'
-        const color = cfg.style?.color || '#3b82f6'
-        if (geom === 'polygon') {
-          style.layers.push({ id: `external-${src.id}`, type: 'fill', source: srcId,
-            paint: { 'fill-color': color, 'fill-opacity': op * (cfg.style?.fill_opacity ?? 0.45), 'fill-outline-color': cfg.style?.outline_color || '#1d4ed8' } })
-        } else if (geom === 'line') {
-          style.layers.push({ id: `external-${src.id}`, type: 'line', source: srcId,
-            paint: { 'line-color': color, 'line-width': cfg.style?.line_width ?? 2, 'line-opacity': op } })
-        } else {
-          style.layers.push({ id: `external-${src.id}`, type: 'circle', source: srcId,
-            paint: { 'circle-color': color, 'circle-radius': cfg.style?.radius ?? 5, 'circle-opacity': op, 'circle-stroke-color': '#fff', 'circle-stroke-width': 1 } })
-        }
-      }
-      expandBounds(src.bbox)
-    }
-  }
-
-  return { style, bounds }
+  return buildMapStyle({
+    configs: orderedForDraw.length ? orderedForDraw : layerConfigs.value,
+    layers: dataStore.vectorLayers,
+    rasters: dataStore.rasterLayers,
+    sources: dataStore.externalSources,
+    basemap: currentBasemap(),
+  })
 }
 
 /**
@@ -2004,48 +1804,8 @@ function buildPreviewStyle() {
  * fails. Projected metres used as MapLibre `bounds` would hide the layer completely, which is far
  * worse than the 404s being fixed, so anything not plausibly lon/lat is dropped.
  */
-function lonLatBbox(b) {
-  return (Array.isArray(b) && b.length === 4 &&
-    b[0] >= -180 && b[2] <= 180 && b[0] < b[2] &&
-    b[1] >= -90 && b[3] <= 90 && b[1] < b[3]) ? b.slice(0, 4) : null
-}
 
-// The lowest zoom worth requesting tiles at, from the layer's extent. Mirrors
-// services/portal_generator.py::_min_zoom_for — a tile spans 360/2^z degrees, so the layer first
-// fits in one tile at log2(360/width); four levels of slack keeps it visible as a speck before we
-// stop asking. 0 (falsy) = continent-sized, leave unrestricted.
-const MINZOOM_SLACK = 4
-function minZoomFor(b) {
-  const width = Math.max(b[2] - b[0], b[3] - b[1])
-  if (!(width > 0)) return 0
-  const fitsAt = width < 360 ? Math.log2(360 / width) : 0
-  return Math.max(0, Math.min(Math.trunc(fitsAt) - MINZOOM_SLACK, 18))
-}
 
-// Build a raster tile URL from the layer's base URL + the configured raster style.
-function rasterTilesUrl(baseTileUrl, style, bandCount) {
-  const base = (baseTileUrl || '').split('&')[0]  // s3 key has no '&', so this keeps ?url=...
-  const params = []
-  let bands = Array.isArray(style?.bidx) ? style.bidx.filter(b => b != null) : []
-  // Mirrors services/titiler.py::get_tile_url. A PNG holds at most four channels and TiTiler adds
-  // the mask as alpha, so a 4-band multispectral raster asks the driver for five and every tile
-  // 500s. With no band selection TiTiler reads them all — hence an explicit default.
-  if (!bands.length && bandCount > 3) bands = [1, 2, 3]
-  bands.forEach(b => params.push(`bidx=${b}`))
-  // Mirrors services/titiler.py::get_tile_url — a hillshade is already a finished 0-255 relief
-  // image, and TiTiler applies rescale AFTER the algorithm, so a data-range stretch flattens it.
-  if (style?.rescale && style?.algorithm !== 'hillshade') params.push(`rescale=${style.rescale}`)
-  if (style?.algorithm) {
-    params.push(`algorithm=${style.algorithm}`)
-    if (style.algorithm === 'hillshade' && style.zfactor && Number(style.zfactor) !== 1) {
-      params.push(`expression=b1*${style.zfactor}`)
-    }
-  } else if (style?.colormap && bands.length !== 3) {
-    params.push(`colormap_name=${style.colormap}`)
-  }
-  const url = base + (params.length ? '&' + params.join('&') : '')
-  return url.startsWith('/') ? location.origin + url : url
-}
 
 const availableLayers = computed(() => [
   ...dataStore.vectorLayers.filter(l => l.status === 'ready').map(l => ({ ...l, type: 'vector' })),

--- a/ui/src/views/PortalEditor.vue
+++ b/ui/src/views/PortalEditor.vue
@@ -558,6 +558,7 @@ import {
   markerImages as symMarkerImages,
 } from '@/lib/symbology'
 import { buildMapStyle, lonLatBbox, rasterTilesUrl } from '@/lib/mapStyle'
+import { BASEMAPS } from '@/lib/basemaps'
 import { capturePortalThumbnail } from '@/composables/portalThumbnail'
 import maplibregl from 'maplibre-gl'
 import { MapboxOverlay } from '@deck.gl/mapbox'
@@ -900,36 +901,7 @@ const basemap = ref(null)  // chosen basemap catalog id; null → first catalog 
 // one-place change on the server. The inline list is only an instant bootstrap/offline fallback so
 // the preview never flashes blank before the fetch resolves. (Declared here — above the watches
 // that reference it at setup time — to avoid a temporal-dead-zone error.)
-const basemapCatalog = ref([
-  { id: 'positron', name: 'Positron',
-    tiles: ['https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/light_all/4/8/5.png' },
-  { id: 'voyager', name: 'Voyager',
-    tiles: ['https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/rastertiles/voyager/4/8/5.png' },
-  { id: 'dark', name: 'Dark Matter',
-    tiles: ['https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/dark_all/4/8/5.png' },
-  { id: 'osm', name: 'OpenStreetMap',
-    tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png'],
-    attribution: '© OpenStreetMap contributors',
-    thumb: 'https://a.tile.openstreetmap.org/4/8/5.png' },
-  { id: 'topo', name: 'OpenTopoMap',
-    tiles: ['https://a.tile.opentopomap.org/{z}/{x}/{y}.png', 'https://b.tile.opentopomap.org/{z}/{x}/{y}.png'],
-    attribution: '© OpenStreetMap, SRTM | © OpenTopoMap (CC-BY-SA)',
-    thumb: 'https://a.tile.opentopomap.org/4/8/5.png' },
-  { id: 'satellite', name: 'Satellite',
-    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
-    attribution: 'Imagery © Esri, Maxar, Earthstar Geographics',
-    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/4/5/8' },
-  { id: 'esri-topo', name: 'Esri Topographic',
-    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}'],
-    attribution: '© Esri',
-    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/4/5/8' },
-])
+const basemapCatalog = ref(BASEMAPS)
 
 // Drag-to-reorder layers (top of list = top of map)
 const dragIndex = ref(null)


### PR DESCRIPTION
Five findings from testing against a live instance.

## A 3D shapefile could not be imported at all

```
Geometry has Z dimension but column does not
```

`geometry(Geometry, srid)` is a **two-dimensional** type. The untyped staging table accepted the
features happily, so nothing looked wrong until the INSERT into the real table — and that is most
shapefiles digitised from a DEM, and every GPS track.

The column is created 3D when the data has Z, with `ST_Force3D` so a file **mixing** 2D and 3D
features still loads. Padding a missing Z with 0 keeps the layer usable; flattening everything to
match the 2D features would discard real measurements.

Reproduced and verified against PostGIS 16/3.4 — the old type raises that exact message, the new one
loads a mixed file with srid 4326 and `coord_dimension=3` in `geometry_columns` (which Martin reads).

## OGC API - Features ignored your token

Measured on the instance: **the token could see 14 layers; OAPIF offered 8, with or without it.**
Since OAPIF is how QGIS adds a layer with full attributes, "add my own layer to QGIS" only worked if
the layer had been published to the world first.

Collections and features now answer according to the credential — and `Vary: Authorization` comes
with it, which is not optional: a CDN sits in front of these instances, and without it the first
authenticated response would be cached and then handed to anonymous callers. Correct filtering,
undone by the cache. Anything non-public is `private, no-store`.

## QGIS never sent the token

Which means the above would have changed nothing on its own — an OAPIF layer is fetched by QGIS, not
by the plugin. The plugin now installs a **request preprocessor**, the supported plugin API for
this, scoped to the exact host of the connected instance: a preprocessor sees every request QGIS
makes, and a bearer token must never leave the host it belongs to.

## Size-by-field never reached QGIS

Only colour was translated, so a layer graduated by one column and sized by another arrived with
half its symbology. Sizes are now data-defined through `scale_linear` — the exact equivalent of
GeoDeploy's linear interpolation, not an approximation — using the same unit conversions as the
fixed sizes (marker diameter vs radius, mm vs px).

## Portals were listed nowhere

They now appear as their own section and open in a browser. QGIS cannot render a portal, and
pretending otherwise would be worse than being clear; the button relabels itself for a portal row.
Verified against the live API: `published`/`title`/`slug`, and `/p/<slug>` → 200.

## Also

Raster symbology degrades better: an untranslatable renderer still sends its bands and stretch, and
**names its class** in the log — "no GeoDeploy equivalent" without saying what it saw costs a round
trip to diagnose.

## Tests

36 pass in `test_ogcapi.py` (5 new, covering the widened list, the private collection, an unready
layer staying 404, and both cache headers), 5 for the Z decision, plus the size-stop logic checked
against the reported colour+size combination and four degenerate inputs.

**Deploy note:** `api/geodeploy/tasks/` changed, so the worker needs recreating alongside the API.