### PR TITLE
fix(ui): the layer page, fixed — plus reversible palettes and external sources

### DIFF
--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -54,6 +54,7 @@ async def list_layers(user: User = Depends(require_scope("data:read")), db: Asyn
                 zfactor=ds.get("zfactor"),
                 bidx=ds.get("bidx"),
                 color_classes=ds.get("color_classes"),
+                colormap_reverse=bool(ds.get("colormap_reverse")),
                 band_count=l.band_count,
             )
         out.append(obj)
@@ -435,6 +436,8 @@ async def raster_legend(layer_ref: str, request: Request, db: AsyncSession = Dep
                     for c in (style.get("color_classes") or [])],
         "color_classes": style.get("color_classes") or None,
         "colormap": style.get("colormap"),
+        # Without this a client draws the ramp forwards and its legend contradicts the map.
+        "colormap_reverse": bool(style.get("colormap_reverse")),
         "rescale": rescale,
         "algorithm": style.get("algorithm"),
         "bidx": style.get("bidx"),
@@ -474,6 +477,7 @@ async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
             layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
             algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
             color_classes=ds.get("color_classes"),
+            colormap_reverse=bool(ds.get("colormap_reverse")),
             band_count=layer.band_count)],
         "minzoom": 0,
         "maxzoom": 22,
@@ -558,6 +562,7 @@ async def raster_wmts(layer_ref: str, request: Request, db: AsyncSession = Depen
         layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
         algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
         color_classes=ds.get("color_classes"),
+        colormap_reverse=bool(ds.get("colormap_reverse")),
         band_count=layer.band_count)
     tmpl = (tmpl.replace("{z}", "{TileMatrix}").replace("{x}", "{TileCol}")
                 .replace("{y}", "{TileRow}"))

--- a/api/geodeploy/routers/stac.py
+++ b/api/geodeploy/routers/stac.py
@@ -226,6 +226,7 @@ def _raster_assets(layer, base: str) -> dict:
         colormap=default.get("colormap"), rescale=default.get("rescale"),
         algorithm=default.get("algorithm"), zfactor=default.get("zfactor"),
         bidx=default.get("bidx"), color_classes=default.get("color_classes"),
+        colormap_reverse=bool(default.get("colormap_reverse")),
         band_count=layer.band_count,
     )
     return {

--- a/api/geodeploy/schemas.py
+++ b/api/geodeploy/schemas.py
@@ -474,6 +474,10 @@ class RasterDefaultStyle(BaseModel):
     # like the vector `categories` list on purpose, so both kinds of "this value is that colour"
     # read the same way.
     color_classes: list[dict] | None = None
+    # Flip whichever palette is in use — the named ramp, or the explicit classes. Stored as a fact
+    # about the style rather than baked into the name, so the palette a person picked is still the
+    # palette the UI shows selected.
+    colormap_reverse: bool = False
 
 
 class RasterLayerOut(BaseModel):

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -260,6 +260,7 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
                     zfactor=rstyle.get("zfactor"),
                     bidx=rstyle.get("bidx"),
                     color_classes=rstyle.get("color_classes"),
+                    colormap_reverse=bool(rstyle.get("colormap_reverse")),
                     band_count=layer.band_count,
                 )],
                 "tileSize": 256,

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -156,6 +156,7 @@ def raster_links(layer, base: str, default_style: dict | None = None) -> list[di
         layer.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
         algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
         color_classes=ds.get("color_classes"),
+        colormap_reverse=bool(ds.get("colormap_reverse")),
         band_count=getattr(layer, "band_count", None))
     return [
         _link("tilejson", "TileJSON — raster tiles", f"{api}/tilejson",

--- a/api/geodeploy/services/titiler.py
+++ b/api/geodeploy/services/titiler.py
@@ -19,6 +19,7 @@ def get_tile_url(
     bidx: list | None = None,
     band_count: int | None = None,
     color_classes: list | None = None,
+    colormap_reverse: bool = False,
     settings=None,
 ) -> str:
     """
@@ -28,6 +29,9 @@ def get_tile_url(
       output (a colormap may apply); three bands → an RGB composite (colormap ignored).
       Empty/None lets TiTiler pick its default bands.
     - colormap: a TiTiler colormap name (single-band data only).
+    - colormap_reverse: flip the ramp. Low values take the colour high values had — which is what
+      you want whenever the convention runs the other way (depth, deprivation, error), and it is
+      not a cosmetic preference: a reversed ramp read as forward inverts the map's meaning.
     - color_classes: [{"value": n, "color": "#rrggbb"}] — an EXPLICIT colour per pixel value, for
       data that is classified rather than continuous (land cover, soil types, a QGIS paletted
       raster). Takes precedence over `colormap`, which can only describe a gradient.
@@ -71,14 +75,18 @@ def get_tile_url(
     # colormap only makes sense for single-band output (one selected band, or a
     # single-band raster). It is ignored when an algorithm or an RGB composite is active.
     elif len(bands) != 3:
-        explicit = _explicit_colormap(color_classes)
+        explicit = _explicit_colormap(color_classes, colormap_reverse)
         if explicit:
             # A CLASSIFIED raster — land cover, soil types, a QGIS paletted layer — has a colour
             # per VALUE, which no named gradient can express: interpolating between class 3 and
             # class 4 is meaningless. TiTiler takes the mapping itself as JSON.
             url += f"&colormap={quote(explicit, safe='')}"
         elif colormap:
-            url += f"&colormap_name={colormap}"
+            # matplotlib — and so rio-tiler, and so TiTiler — spells a reversed ramp with an `_r`
+            # suffix. Appended rather than stored that way, so the stored style still names the
+            # palette a person chose and "reversed" stays a separate, toggleable fact.
+            name = colormap[:-2] if colormap.endswith("_r") else colormap
+            url += f"&colormap_name={name}_r" if colormap_reverse else f"&colormap_name={name}"
     return url
 
 
@@ -94,7 +102,7 @@ def get_tile_url(
 MAX_COLOR_CLASSES = 128
 
 
-def _explicit_colormap(color_classes) -> str | None:
+def _explicit_colormap(color_classes, reverse: bool = False) -> str | None:
     """`{"3": [r,g,b,a], …}` as compact JSON, or None when there is nothing usable.
 
     Silently skips entries that are not a number-plus-colour rather than failing the whole tile
@@ -102,6 +110,13 @@ def _explicit_colormap(color_classes) -> str | None:
     """
     if not color_classes:
         return None
+    if reverse:
+        # No name to suffix, so the colours themselves are re-paired with the values in the
+        # opposite order — the values keep their places, the ramp runs the other way.
+        entries = list(color_classes[:MAX_COLOR_CLASSES])
+        colours = [e.get("color") if isinstance(e, dict) else None for e in entries][::-1]
+        color_classes = [dict(e, color=c) if isinstance(e, dict) else e
+                         for e, c in zip(entries, colours)]
     mapping = {}
     for entry in color_classes[:MAX_COLOR_CLASSES]:
         if not isinstance(entry, dict):

--- a/api/tests/test_paletted_raster.py
+++ b/api/tests/test_paletted_raster.py
@@ -188,3 +188,41 @@ async def test_a_continuous_raster_is_still_a_ramp(client, db, auth):
     assert body["ramp"] is True
     assert body["entries"] == []
     assert body["colormap"] == "viridis"
+
+
+# ── Reversing a palette ───────────────────────────────────────────────────────────────────────
+# Not cosmetic: a ramp read the wrong way inverts the map's meaning. Depth, deprivation and error
+# all conventionally run dark-for-high, which is the opposite of most sequential ramps.
+
+def test_a_named_ramp_reverses_with_the_matplotlib_suffix():
+    url = get_tile_url("r/x.tif", colormap="viridis", colormap_reverse=True, settings=_S())
+    assert _params(url)["colormap_name"] == ["viridis_r"]
+
+
+def test_reversing_is_idempotent_on_an_already_suffixed_name():
+    """A stored `viridis_r` must not become `viridis_r_r`, which names no colormap at all."""
+    url = get_tile_url("r/x.tif", colormap="viridis_r", colormap_reverse=True, settings=_S())
+    assert _params(url)["colormap_name"] == ["viridis_r"]
+
+
+def test_not_reversing_a_suffixed_name_unwinds_it():
+    """The flag is the single source of truth, so `viridis_r` + reverse=False is forward."""
+    url = get_tile_url("r/x.tif", colormap="viridis_r", colormap_reverse=False, settings=_S())
+    assert _params(url)["colormap_name"] == ["viridis"]
+
+
+def test_explicit_classes_reverse_by_re_pairing_the_colours():
+    """There is no name to suffix, so the COLOURS move and the values stay put."""
+    url = get_tile_url("r/x.tif", colormap_reverse=True, settings=_S(), color_classes=[
+        {"value": 1, "color": "#ff0000"},
+        {"value": 2, "color": "#00ff00"},
+        {"value": 3, "color": "#0000ff"}])
+    cm = json.loads(_params(url)["colormap"][0])
+    assert cm["1"] == [0, 0, 255, 255]      # was blue at the top, now at the bottom
+    assert cm["2"] == [0, 255, 0, 255]      # the middle is its own mirror
+    assert cm["3"] == [255, 0, 0, 255]
+
+
+def test_reverse_is_inert_without_a_palette():
+    url = get_tile_url("r/x.tif", colormap_reverse=True, settings=_S())
+    assert "colormap_name" not in _params(url) and "colormap" not in _params(url)

--- a/cli/geodeploy/cli/commands/_common.py
+++ b/cli/geodeploy/cli/commands/_common.py
@@ -77,6 +77,11 @@ def add_style_args(parser, raster: bool = True) -> None:
     if raster:
         rast = parser.add_argument_group("raster")
         rast.add_argument("--colormap", help="TiTiler colormap, e.g. viridis (see `layers colormaps`)")
+        rast.add_argument("--reverse-colormap", dest="colormap_reverse", action="store_true",
+                          default=None,
+                          help="flip the palette (low values take the colour high values had)")
+        rast.add_argument("--no-reverse-colormap", dest="colormap_reverse", action="store_false",
+                          help="undo --reverse-colormap")
         rast.add_argument("--rescale", help="stretch as 'min,max' (see `layers stats` for a suggestion)")
         rast.add_argument("--algorithm", help="e.g. hillshade (single-band)")
         rast.add_argument("--zfactor", type=float, help="hillshade vertical exaggeration")
@@ -112,7 +117,8 @@ def style_from_args(args, client=None, layer_ref: Optional[Any] = None,
 
     kwargs = {}  # type: Dict[str, Any]
     for name in ("color", "fill_opacity", "outline_color", "outline_width", "line_width",
-                 "radius", "marker", "line_type", "colormap", "rescale", "algorithm", "zfactor",
+                 "radius", "marker", "line_type", "colormap", "colormap_reverse",
+                 "rescale", "algorithm", "zfactor",
                  "color_field", "color_mode", "size_field", "other_color", "size_stops",
                  "extrude_field", "extrude_scale", "extrude_base", "extrude_color",
                  "extrude_opacity", "extrude_radius"):

--- a/cli/geodeploy/cli/commands/layers.py
+++ b/cli/geodeploy/cli/commands/layers.py
@@ -58,6 +58,7 @@ examples:
   geodeploy layers style sites --marker star --radius 6 --outline-color none
   geodeploy layers style parcels --color-field pop --classify jenks --classes 6 --ramp magma
   geodeploy layers style dem --colormap terrain --rescale 0,2400
+  geodeploy layers style depth --colormap blues --reverse-colormap
 """)
     layer_ref_arg(style)
     style.add_argument("--popup-fields", help="comma-separated attribute names for popups")
@@ -190,7 +191,8 @@ def cmd_legend(ctx, args) -> int:
         ctx.out.json(legend)
         return EXIT_OK
     if legend.get("ramp"):
-        ctx.out.record(legend, ["layer", "colormap", "rescale", "algorithm", "bidx", "band_count"])
+        ctx.out.record(legend, ["layer", "colormap", "colormap_reverse", "rescale", "algorithm",
+                                "bidx", "band_count"])
         ctx.out.info("A raster legend is a continuous ramp, so there are no swatches to list.")
         return EXIT_OK
     ctx.out.out(ctx.out.bold(legend.get("layer") or ""))
@@ -467,7 +469,7 @@ def cmd_style(ctx, args) -> int:
     else:
         # The raster default-style body is flat: colormap/rescale/algorithm live at the top level.
         body = {"opacity": body["opacity"]}
-        for key in ("colormap", "rescale", "algorithm", "zfactor", "bidx"):
+        for key in ("colormap", "colormap_reverse", "rescale", "algorithm", "zfactor", "bidx"):
             if style.get(key) is not None:
                 body[key] = style[key]
 

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -331,9 +331,14 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
             lo, hi = renderer.classificationMin(), renderer.classificationMax()
             if _finite(lo) and _finite(hi) and hi > lo:
                 style["rescale"] = "{0},{1}".format(_trim(lo), _trim(hi))
-            name = _ramp_name(renderer)
+            name, inverted = _ramp_name(renderer)
             if name and colormaps and name in colormaps:
                 style["colormap"] = name
+                if inverted:
+                    # QGIS inverts a ramp in place; GeoDeploy keeps the palette's name and a
+                    # separate flag, so the two agree about WHICH ramp while disagreeing about
+                    # its direction only where that is recorded.
+                    style["colormap_reverse"] = True
             elif name:
                 _log("QGIS ramp {0!r} has no colormap of that name on the instance — sending the "
                      "stretch without it.".format(name))
@@ -450,8 +455,13 @@ def _enhancement_range(enhancement):
     return (None, None)
 
 
-def _ramp_name(renderer) -> str | None:
-    """The lower-cased name of the renderer's colour ramp, if it has a named one."""
+def _ramp_name(renderer):
+    """`(name, inverted)` for the renderer's colour ramp — lower-cased, or `(None, False)`.
+
+    QGIS reverses a ramp by INVERTING it in place, so the direction is a property of the ramp
+    object rather than part of its name. GeoDeploy keeps the two apart, which is what lets the
+    palette a user chose stay recognisable in the UI after they flip it.
+    """
     try:
         shader = renderer.shader()
         fn = shader.rasterShaderFunction() if shader else None
@@ -459,9 +469,15 @@ def _ramp_name(renderer) -> str | None:
         # `type()` is the ramp KIND ("gradient", "cpt-city", …); cpt-city ramps carry a real name.
         name = getattr(ramp, "schemeName", None)
         name = name() if callable(name) else None
-        return (name or "").strip().lower() or None
+        inverted = False
+        for attr in ("isInverted", "inverted"):
+            probe = getattr(ramp, attr, None)
+            if callable(probe):
+                inverted = bool(probe())
+                break
+        return ((name or "").strip().lower() or None, inverted)
     except Exception:                   # noqa: BLE001 - a missing ramp is not an error
-        return None
+        return (None, False)
 
 
 def from_qgis(qgis_layer) -> dict:

--- a/ui/src/components/data/RasterRow.vue
+++ b/ui/src/components/data/RasterRow.vue
@@ -7,7 +7,7 @@
           @keyup.enter="saveName" @keyup.esc="cancelEdit" @blur="saveName"
           class="text-sm font-medium bg-transparent border border-primary/60 rounded px-1 py-0.5 flex-1 min-w-0 focus:outline-none" />
         <template v-else>
-          <RouterLink :to="`/data/raster/${layer.id}`"
+          <RouterLink :to="`/data/raster/${layer.uid || layer.id}`"
             class="text-sm font-medium truncate hover:text-primary hover:underline"
             title="Open this layer's page">{{ layer.name }}</RouterLink>
           <button v-if="auth.canEdit" @click="startEdit" title="Rename layer"

--- a/ui/src/components/data/SourceRow.vue
+++ b/ui/src/components/data/SourceRow.vue
@@ -3,7 +3,9 @@
     <div class="w-8 h-8 rounded-md flex items-center justify-center text-[10px] font-bold flex-shrink-0"
       :class="badgeClass">{{ source.source_type.toUpperCase() }}</div>
     <div class="flex-1 min-w-0">
-      <div class="text-sm font-medium truncate">{{ source.name }}</div>
+      <RouterLink :to="`/data/external/${source.id}`"
+        class="text-sm font-medium truncate block hover:text-primary hover:underline"
+        title="Open this source's page">{{ source.name }}</RouterLink>
       <div class="text-xs text-muted-foreground flex gap-3 mt-0.5">
         <span class="uppercase">{{ source.kind }}</span>
         <span v-if="source.geometry_type">{{ source.geometry_type }}</span>
@@ -27,6 +29,7 @@
 </template>
 
 <script setup>
+import { RouterLink } from 'vue-router'
 import { computed, ref } from 'vue'
 import { TrashIcon } from '@/views/icons'
 import { useAuthStore } from '@/stores/auth'

--- a/ui/src/components/data/StyleModal.vue
+++ b/ui/src/components/data/StyleModal.vue
@@ -70,6 +70,7 @@ const config = ref({
     ? { ...(ds.style || {}) }
     : {
         colormap: ds.colormap || null,
+        colormap_reverse: !!ds.colormap_reverse,
         rescale: ds.rescale || null,
         algorithm: ds.algorithm || null,
         zfactor: ds.zfactor ?? null,
@@ -92,6 +93,7 @@ async function save() {
       : {
           opacity: c.opacity,
           colormap: c.style?.colormap || null,
+          colormap_reverse: !!c.style?.colormap_reverse,
           rescale: c.style?.rescale || null,
           algorithm: c.style?.algorithm || null,
           zfactor: c.style?.zfactor ?? null,

--- a/ui/src/components/data/VectorRow.vue
+++ b/ui/src/components/data/VectorRow.vue
@@ -7,7 +7,7 @@
           @keyup.enter="saveName" @keyup.esc="cancelEdit" @blur="saveName"
           class="text-sm font-medium bg-transparent border border-primary/60 rounded px-1 py-0.5 flex-1 min-w-0 focus:outline-none" />
         <template v-else>
-          <RouterLink :to="`/data/vector/${layer.id}`"
+          <RouterLink :to="`/data/vector/${layer.uid || layer.id}`"
             class="text-sm font-medium truncate hover:text-primary hover:underline"
             title="Open this layer's page">{{ layer.name }}</RouterLink>
           <button v-if="auth.canEdit" @click="startEdit" title="Rename layer"

--- a/ui/src/components/portal/LayerPanel.vue
+++ b/ui/src/components/portal/LayerPanel.vue
@@ -410,6 +410,15 @@
                   <option value="">None (grayscale)</option>
                   <option v-for="cm in colormaps" :key="cm" :value="cm">{{ cm }}</option>
                 </select>
+                <!-- Reversing is not a preference: depth, deprivation and error all read
+                     dark-for-high, which is the opposite of most sequential ramps. -->
+                <label v-if="config.style?.colormap"
+                  class="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer mt-1.5">
+                  <input type="checkbox" :checked="!!config.style?.colormap_reverse"
+                    @change="emitStyle({ colormap_reverse: $event.target.checked })"
+                    class="accent-primary" />
+                  Reverse the palette
+                </label>
               </div>
               <div class="flex items-center gap-3">
                 <label class="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">

--- a/ui/src/lib/mapStyle.js
+++ b/ui/src/lib/mapStyle.js
@@ -281,7 +281,10 @@ export function rasterTilesUrl(baseTileUrl, style, bandCount) {
       params.push(`expression=b1*${style.zfactor}`)
     }
   } else if (style?.colormap && bands.length !== 3) {
-    params.push(`colormap_name=${style.colormap}`)
+    // Mirrors services/titiler.py: matplotlib spells a reversed ramp with an `_r` suffix, and the
+    // flag is the single source of truth — a stored `viridis_r` with reverse off is forward.
+    const base_ = style.colormap.endsWith('_r') ? style.colormap.slice(0, -2) : style.colormap
+    params.push(`colormap_name=${style.colormap_reverse ? base_ + '_r' : base_}`)
   }
   const url = base + (params.length ? '&' + params.join('&') : '')
   return url.startsWith('/') ? location.origin + url : url

--- a/ui/src/lib/mapStyle.js
+++ b/ui/src/lib/mapStyle.js
@@ -29,6 +29,9 @@ export function buildMapStyle({ configs = [], layers = [], rasters = [], sources
    * reverse, because MapLibre paints later layers on top — the same reversal the generator does.
    */
   const bm = basemap
+  // Icon id -> spec, for the caller to register on its map. Returned rather than written to an
+  // outer variable: this function is pure, and a closure write is exactly what broke when it moved.
+  const markerSpecs = {}
   const style = {
     version: 8,
     glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
@@ -237,7 +240,7 @@ export function buildMapStyle({ configs = [], layers = [], rasters = [], sources
     }
   }
 
-  return { style, bounds }
+  return { style, bounds, markerSpecs }
 }
 
 

--- a/ui/src/lib/markerImage.js
+++ b/ui/src/lib/markerImage.js
@@ -1,0 +1,73 @@
+/**
+ * Point markers, drawn as canvas images — the browser twin of the same code in
+ * `templates/shared/portal.js`.
+ *
+ * MapLibre cannot draw a star or a cross from paint properties, so a point layer with a SHAPE is a
+ * symbol layer whose icon is generated here and registered on demand (`styleimagemissing`). Every
+ * map that shows GeoDeploy points therefore needs this, which is why it is a library rather than
+ * something the portal editor happens to own.
+ */
+function starPts(cx, cy, r) {
+  const p = []
+  for (let i = 0; i < 10; i++) { const a = -Math.PI / 2 + i * Math.PI / 5, rr = (i % 2) ? r * 0.45 : r; p.push([cx + Math.cos(a) * rr, cy + Math.sin(a) * rr]) }
+  return p
+}
+
+function crossPts(cx, cy, r) {
+  const t = r * 0.38
+  return [[-t, -r], [t, -r], [t, -t], [r, -t], [r, t], [t, t], [t, r], [-t, r], [-t, t], [-r, t], [-r, -t], [-t, -t]].map(d => [cx + d[0], cy + d[1]])
+}
+
+export function markerImage(shape, color, size, outline, outlineWidth) {
+  const dpr = 2, r = Math.max(3, Number(size) || 5)
+  // Outline width is a RATIO of the radius (see portal.js) so it stays proportional when a layer is
+  // resized; 0.28 reproduces the old hard-coded stroke exactly.
+  const ow = outlineWidth == null ? 0.28 : Number(outlineWidth)
+  const stroke = Math.max(0, r * (isFinite(ow) ? ow : 0.28))
+  const dim = 80  // fixed canvas (see portal.js): constant dims let updateImage handle size changes
+  const cv = document.createElement('canvas')
+  cv.width = dim * dpr; cv.height = dim * dpr
+  const ctx = cv.getContext('2d')
+  ctx.scale(dpr, dpr); ctx.lineJoin = 'round'
+  const cx = dim / 2, cy = dim / 2
+  ctx.beginPath()
+  if (shape === 'square') ctx.rect(cx - r, cy - r, r * 2, r * 2)
+  else if (shape === 'triangle') { ctx.moveTo(cx, cy - r); ctx.lineTo(cx + r * 0.92, cy + r * 0.72); ctx.lineTo(cx - r * 0.92, cy + r * 0.72); ctx.closePath() }
+  else if (shape === 'diamond') { ctx.moveTo(cx, cy - r); ctx.lineTo(cx + r, cy); ctx.lineTo(cx, cy + r); ctx.lineTo(cx - r, cy); ctx.closePath() }
+  else if (shape === 'star') { starPts(cx, cy, r).forEach((p, i) => i ? ctx.lineTo(p[0], p[1]) : ctx.moveTo(p[0], p[1])); ctx.closePath() }
+  else if (shape === 'cross') { crossPts(cx, cy, r).forEach((p, i) => i ? ctx.lineTo(p[0], p[1]) : ctx.moveTo(p[0], p[1])); ctx.closePath() }
+  else ctx.arc(cx, cy, r, 0, Math.PI * 2)
+  ctx.fillStyle = color || '#3b82f6'; ctx.fill()
+  // null = draw no outline; undefined = unspecified, i.e. the white default markers always had.
+  const oc = outline === undefined ? '#ffffff' : outline
+  if (oc && stroke > 0) { ctx.strokeStyle = oc; ctx.lineWidth = stroke; ctx.stroke() }
+  const d = ctx.getImageData(0, 0, dim * dpr, dim * dpr)
+  return { width: dim * dpr, height: dim * dpr, data: d.data, pixelRatio: dpr }
+}
+
+
+/**
+ * Wire a map up to draw the markers a style asks for.
+ *
+ * `specs` is what `buildMapStyle` returns: icon id -> {shape, color, size, outline}. MapLibre asks
+ * for an image the first time a symbol layer references one it does not have, which is the only
+ * moment we can know which are actually needed.
+ */
+export function registerMarkerImages(map, specs) {
+  if (!map || map.__gdMarkerHook) return
+  map.__gdMarkerHook = true
+  map.on('styleimagemissing', (e) => {
+    if (!e.id || !e.id.startsWith('gd-pt-') || map.hasImage(e.id)) return
+    const spec = (map.__gdMarkerSpecs || {})[e.id]
+    if (!spec) return
+    const im = markerImage(spec.shape, spec.color, spec.size, spec.outline, spec.outline_width)
+    try { map.addImage(e.id, im, { pixelRatio: im.pixelRatio }) } catch { /* already added */ }
+  })
+  setMarkerSpecs(map, specs)
+}
+
+/** Replace the specs a map draws from — call whenever the style is rebuilt. */
+export function setMarkerSpecs(map, specs) {
+  if (!map) return
+  map.__gdMarkerSpecs = { ...(map.__gdMarkerSpecs || {}), ...(specs || {}) }
+}

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -18,7 +18,7 @@ const routes = [
       { path: 'data', component: () => import('@/views/DataManager.vue') },
       // One layer, on its own page. `kind` is vector|raster because the two are separate
       // id sequences — layer 1 exists twice, and the URL has to say which one.
-      { path: 'data/:kind(vector|raster)/:id', component: () => import('@/views/LayerPage.vue') },
+      { path: 'data/:kind(vector|raster|external)/:id', component: () => import('@/views/LayerPage.vue') },
       { path: 'portals', component: () => import('@/views/PortalBuilder.vue') },
       { path: 'portals/:id/edit', component: () => import('@/views/PortalEditor.vue'), meta: { requiresEditor: true } },
       { path: 'templates', component: () => import('@/views/TemplateGallery.vue') },

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -21,7 +21,7 @@
     </template>
   </div>
 
-  <div v-else class="space-y-5">
+  <div v-else class="space-y-5 p-4 sm:p-6 max-w-[1600px] mx-auto">
     <!-- Header ------------------------------------------------------------------------------ -->
     <div class="flex items-start justify-between gap-4 flex-wrap">
       <div class="min-w-0">
@@ -56,7 +56,7 @@
     <!-- Map + facts ------------------------------------------------------------------------- -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
       <div class="lg:col-span-2 card overflow-hidden">
-        <div ref="mapEl" class="w-full h-[460px] bg-muted/40" />
+        <div id="gd-layer-map" class="w-full h-[460px] bg-muted/40" />
         <p v-if="mapNote" class="text-xs text-amber-300/90 px-4 py-2 border-t border-border/60">
           {{ mapNote }}
         </p>
@@ -122,7 +122,7 @@
 
     <!-- Actions ------------------------------------------------------------------------------ -->
     <section class="card p-4">
-      <h2 class="text-sm font-semibold mb-3">Do something with it</h2>
+      <h2 class="text-sm font-semibold mb-3">Actions</h2>
       <div class="flex flex-wrap gap-2">
         <button v-if="auth.canEdit && ready" @click="showStyle = true" class="btn-secondary text-sm">
           Style
@@ -155,22 +155,21 @@
 
     <!-- Fields -------------------------------------------------------------------------------- -->
     <section v-if="fields.length" class="card p-4">
-      <h2 class="text-sm font-semibold mb-3">Fields <span class="text-muted-foreground/60 font-normal">({{ fields.length }})</span></h2>
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="text-left text-xs text-muted-foreground/70 border-b border-border/60">
-              <th class="py-1.5 pr-4 font-medium">Name</th>
-              <th class="py-1.5 font-medium">Type</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="f in fields" :key="f.name" class="border-b border-border/30 last:border-0">
-              <td class="py-1.5 pr-4 font-mono text-xs">{{ f.name }}</td>
-              <td class="py-1.5 text-muted-foreground text-xs">{{ f.type }}</td>
-            </tr>
-          </tbody>
-        </table>
+      <button class="flex items-center gap-2 w-full text-left" @click="fieldsOpen = !fieldsOpen">
+        <span class="text-xs text-muted-foreground/60">{{ fieldsOpen ? '▾' : '▸' }}</span>
+        <h2 class="text-sm font-semibold">
+          Fields <span class="text-muted-foreground/60 font-normal">({{ fields.length }})</span>
+        </h2>
+      </button>
+      <!-- Two or three columns, not one row per field: a table of 8 fields took more of the page
+           than the map, and a layer with 40 would have been unusable. -->
+      <div v-if="fieldsOpen"
+        class="mt-3 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-x-6 gap-y-1 max-h-64 overflow-y-auto pr-1">
+        <div v-for="f in fields" :key="f.name"
+          class="flex items-baseline justify-between gap-3 border-b border-border/25 py-1">
+          <span class="font-mono text-xs truncate" :title="f.name">{{ f.name }}</span>
+          <span class="text-[11px] text-muted-foreground/70 flex-shrink-0">{{ f.type }}</span>
+        </div>
       </div>
     </section>
 
@@ -184,13 +183,14 @@
 </template>
 
 <script setup>
-import { computed, h, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, h, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import maplibregl from 'maplibre-gl'
 
 import { useDataStore } from '@/stores/data'
 import { useAuthStore } from '@/stores/auth'
+import { useMaplibre } from '@/composables/useMaplibre'
 import { buildMapStyle, lonLatBbox } from '@/lib/mapStyle'
+import { registerMarkerImages, setMarkerSpecs } from '@/lib/markerImage'
 import { DEFAULT_BASEMAP } from '@/lib/basemaps'
 import { legendEntries, representativeColor } from '@/lib/symbology'
 import StyleModal from '@/components/data/StyleModal.vue'
@@ -221,9 +221,12 @@ const isRaster = computed(() => kind.value === 'raster')
 const isVector = computed(() => kind.value === 'vector')
 
 const layer = computed(() => {
-  const id = Number(route.params.id)
+  // The URL carries the UID: integer ids are per-kind sequences that renumber on a restore, so a
+  // bookmarked /data/vector/12 could come back pointing at a different layer. An integer is still
+  // accepted, for links made before this and for anyone typing one by hand.
+  const ref_ = String(route.params.id || '')
   const list = isRaster.value ? dataStore.rasterLayers : dataStore.vectorLayers
-  return list.find(l => l.id === id) || null
+  return list.find(l => l.uid === ref_) || list.find(l => String(l.id) === ref_) || null
 })
 const ready = computed(() => layer.value?.status === 'ready')
 
@@ -283,9 +286,12 @@ const prettyExtent = computed(() => {
 })
 
 // -- the map ---------------------------------------------------------------------------------
-const mapEl = ref(null)
+// Through the shared composable, not a hand-rolled maplibregl.Map: it is what registers the
+// `pmtiles://` protocol (a tiled GeoParquet layer fails with 'URL scheme "pmtiles" is not
+// supported' without it), and it owns the map's lifecycle and the globe/zoom controls.
+const { map, loaded, applyStyle, fitToBbox } = useMaplibre('gd-layer-map',
+  { version: 8, sources: {}, layers: [] })
 const mapNote = ref('')
-let map = null
 
 /** The layer as a portal would configure it — one entry, drawn by the shared builder. */
 function configFor(l) {
@@ -300,7 +306,7 @@ function configFor(l) {
 
 function renderMap() {
   const l = layer.value
-  if (!l || !mapEl.value) return
+  if (!l || !map.value || !loaded.value) return
 
   // An untiled GeoParquet layer draws through the portal's data view (deck.gl over a viewport
   // query), which this page does not run. Saying so beats an empty basemap that looks broken.
@@ -309,34 +315,25 @@ function renderMap() {
     ? 'This GeoParquet layer is not tiled, so there is nothing to draw here yet. Tile it for a preview.'
     : ''
 
-  const { style, bounds } = buildMapStyle({
+  const { style, bounds, markerSpecs } = buildMapStyle({
     configs: [configFor(l)],
     layers: isVector.value ? [l] : [],
     rasters: isRaster.value ? [l] : [],
     sources: [],
     basemap: DEFAULT_BASEMAP,
   })
-
-  if (map) { map.setStyle(style); fit(bounds); return }
-  map = new maplibregl.Map({ container: mapEl.value, style, center: [0, 20], zoom: 1.4,
-                             attributionControl: { compact: true } })
-  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right')
-  map.on('load', () => fit(bounds))
-}
-
-function fit(bounds) {
-  const b = lonLatBbox(bounds) || lonLatBbox(layer.value?.bbox)
-  if (b && map) map.fitBounds([[b[0], b[1]], [b[2], b[3]]], { padding: 36, duration: 0, maxZoom: 16 })
+  // Points are symbol layers whose icons are generated on demand — without this they draw nothing.
+  registerMarkerImages(map.value, markerSpecs)
+  setMarkerSpecs(map.value, markerSpecs)
+  applyStyle(style)
+  fitToBbox(lonLatBbox(bounds) || lonLatBbox(l.bbox))
 }
 
 onMounted(async () => {
   if (!dataStore.vectorLayers.length && !dataStore.rasterLayers.length) await dataStore.refresh()
-  await nextTick()
-  renderMap()
 })
-onBeforeUnmount(() => { if (map) { map.remove(); map = null } })
-// Re-render when the layer arrives, when its style changes, or when the route moves to another one.
-watch([layer, styleForMap], () => renderMap(), { deep: true })
+// The map is created on mount by the composable, so wait for it AND for the layer to arrive.
+watch([loaded, layer, styleForMap], () => renderMap(), { deep: true, immediate: true })
 
 // -- actions ---------------------------------------------------------------------------------
 const showStyle = ref(false)
@@ -344,6 +341,7 @@ const showSharing = ref(false)
 const showLinks = ref(false)
 const showPortal = ref(false)
 const confirmDelete = ref(false)
+const fieldsOpen = ref(true)
 const tiling = ref(false)
 const restarting = ref(false)
 

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -36,7 +36,7 @@
           <input v-else ref="nameInput" v-model="draftName" @keyup.enter="commitRename"
             @keyup.esc="renaming = false" @blur="commitRename"
             class="input text-2xl font-semibold py-0.5" />
-          <button v-if="auth.canEdit && !renaming" @click="startRename"
+          <button v-if="auth.canEdit && !renaming && !isExternal" @click="startRename"
             class="text-muted-foreground/60 hover:text-foreground text-sm" title="Rename layer">✎</button>
         </div>
         <p class="text-xs text-muted-foreground/70 mt-1">
@@ -53,84 +53,85 @@
       </div>
     </div>
 
-    <!-- Map + facts ------------------------------------------------------------------------- -->
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
-      <div class="lg:col-span-2 card overflow-hidden">
-        <div id="gd-layer-map" class="w-full h-[460px] bg-muted/40" />
-        <p v-if="mapNote" class="text-xs text-amber-300/90 px-4 py-2 border-t border-border/60">
-          {{ mapNote }}
-        </p>
-      </div>
+    <!-- The map, full width. A fixed side column left a tall void next to it whenever a layer had
+         no legend and no metadata, which is most of them — the facts read better as a row of cards
+         under the map, and they reflow instead of stacking into one narrow strip. -->
+    <div class="card overflow-hidden">
+      <div id="gd-layer-map" class="w-full h-[52vh] min-h-[340px] bg-muted/40" />
+      <p v-if="mapNote" class="text-xs text-amber-300/90 px-4 py-2 border-t border-border/60">
+        {{ mapNote }}
+      </p>
+    </div>
 
-      <div class="space-y-5">
-        <section class="card p-4">
-          <h2 class="text-sm font-semibold mb-3">What it is</h2>
-          <dl class="space-y-1.5 text-sm">
-            <Fact label="Geometry" :value="layer.geometry_type" />
-            <Fact label="Features" :value="layer.feature_count?.toLocaleString()" />
-            <Fact label="Bands" :value="layer.band_count" />
-            <Fact label="CRS" :value="layer.crs" mono />
-            <Fact label="Size" :value="prettySize" />
-            <Fact label="Extent" :value="prettyExtent" mono
-              hint="West, south, east, north in EPSG:4326" />
-          </dl>
+    <!-- Facts ---------------------------------------------------------------------------------- -->
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 items-start">
+      <section class="card p-4">
+        <h2 class="text-sm font-semibold mb-3">What it is</h2>
+        <dl class="space-y-1.5 text-sm">
+          <Fact label="Geometry" :value="layer.geometry_type" />
+          <Fact label="Features" :value="layer.feature_count?.toLocaleString()" />
+          <Fact label="Bands" :value="layer.band_count" />
+          <Fact label="CRS" :value="layer.crs" mono />
+          <Fact label="Size" :value="prettySize" />
+          <Fact label="Extent" :value="prettyExtent" mono
+            hint="West, south, east, north in EPSG:4326" />
+        </dl>
         </section>
 
         <section class="card p-4">
-          <h2 class="text-sm font-semibold mb-3">How it is served</h2>
-          <dl class="space-y-1.5 text-sm">
-            <Fact label="Storage" :value="storageLabel" />
-            <Fact label="Tiles" :value="tilesLabel" />
-            <Fact v-if="isRaster" label="Zoom floor"
-              :value="layer.low_zoom_ok === false ? 'High zoom only' : 'Draws when zoomed out'"
-              hint="Measured from the file's overview pyramid at ingest" />
-            <Fact v-if="isRaster && rasterStyle.colormap" label="Colormap" :value="rasterStyle.colormap" />
-            <Fact v-if="isRaster && rasterStyle.rescale" label="Stretch" :value="rasterStyle.rescale" mono />
-          </dl>
+        <h2 class="text-sm font-semibold mb-3">How it is served</h2>
+        <dl class="space-y-1.5 text-sm">
+          <Fact label="Storage" :value="storageLabel" />
+          <Fact label="Tiles" :value="tilesLabel" />
+          <Fact v-if="isRaster" label="Zoom floor"
+            :value="layer.low_zoom_ok === false ? 'High zoom only' : 'Draws when zoomed out'"
+            hint="Measured from the file's overview pyramid at ingest" />
+          <Fact v-if="isRaster && rasterStyle.colormap" label="Colormap" :value="rasterStyle.colormap" />
+          <Fact v-if="isRaster && rasterStyle.rescale" label="Stretch" :value="rasterStyle.rescale" mono />
+        </dl>
         </section>
 
         <section v-if="hasDescription" class="card p-4">
-          <h2 class="text-sm font-semibold mb-3">Metadata</h2>
-          <dl class="space-y-1.5 text-sm">
-            <Fact label="Licence" :value="layer.license" />
-            <Fact label="Attribution" :value="layer.attribution" />
-            <Fact label="Keywords" :value="layer.keywords" />
-          </dl>
-          <p v-if="layer.abstract" class="text-xs text-muted-foreground mt-2 whitespace-pre-line">
-            {{ layer.abstract }}
-          </p>
-          <p class="text-[11px] text-muted-foreground/60 mt-2">
-            Edited under Sharing — it travels with the layer into STAC, OGC API and the catalog.
-          </p>
+        <h2 class="text-sm font-semibold mb-3">Metadata</h2>
+        <dl class="space-y-1.5 text-sm">
+          <Fact label="Licence" :value="layer.license" />
+          <Fact label="Attribution" :value="layer.attribution" />
+          <Fact label="Keywords" :value="layer.keywords" />
+        </dl>
+        <p v-if="layer.abstract" class="text-xs text-muted-foreground mt-2 whitespace-pre-line">
+          {{ layer.abstract }}
+        </p>
+        <p class="text-[11px] text-muted-foreground/60 mt-2">
+          Edited under Sharing — it travels with the layer into STAC, OGC API and the catalog.
+        </p>
         </section>
 
         <section v-if="legend.length" class="card p-4">
-          <h2 class="text-sm font-semibold mb-1">Legend</h2>
-          <p v-if="colorField" class="text-[11px] text-muted-foreground/70 mb-2">
-            Colour by <span class="font-medium text-muted-foreground">{{ colorField }}</span>
-          </p>
-          <div class="space-y-1 max-h-52 overflow-y-auto pr-1">
-            <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-2">
-              <span class="w-3.5 h-3.5 rounded-sm flex-shrink-0 ring-1 ring-black/25"
-                :style="{ background: e.color }" />
-              <span class="text-xs text-muted-foreground truncate">{{ e.label }}</span>
-            </div>
+        <h2 class="text-sm font-semibold mb-1">Legend</h2>
+        <p v-if="colorField" class="text-[11px] text-muted-foreground/70 mb-2">
+          Colour by <span class="font-medium text-muted-foreground">{{ colorField }}</span>
+        </p>
+        <div class="space-y-1 max-h-52 overflow-y-auto pr-1">
+          <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-2">
+            <span class="w-3.5 h-3.5 rounded-sm flex-shrink-0 ring-1 ring-black/25"
+              :style="{ background: e.color }" />
+            <span class="text-xs text-muted-foreground truncate">{{ e.label }}</span>
           </div>
-        </section>
-      </div>
+        </div>
+      </section>
     </div>
 
     <!-- Actions ------------------------------------------------------------------------------ -->
     <section class="card p-4">
       <h2 class="text-sm font-semibold mb-3">Actions</h2>
       <div class="flex flex-wrap gap-2">
-        <button v-if="auth.canEdit && ready" @click="showStyle = true" class="btn-secondary text-sm">
+        <button v-if="auth.canEdit && ready && !isExternal" @click="showStyle = true" class="btn-secondary text-sm">
           Style
         </button>
-        <button v-if="ready" @click="showLinks = true" class="btn-secondary text-sm">
+        <button v-if="ready && !isExternal" @click="showLinks = true" class="btn-secondary text-sm">
           Share links
         </button>
-        <button v-if="auth.canEdit && ready" @click="showSharing = true" class="btn-secondary text-sm">
+        <button v-if="auth.canEdit && ready && !isExternal" @click="showSharing = true" class="btn-secondary text-sm">
           {{ visibilityLabel === 'Public' ? 'Sharing — public' : 'Sharing' }}
         </button>
         <button v-if="auth.canEdit && ready" @click="showPortal = true" class="btn-primary text-sm">
@@ -216,25 +217,34 @@ const router = useRouter()
 const dataStore = useDataStore()
 const auth = useAuthStore()
 
-const kind = computed(() => (route.params.kind === 'raster' ? 'raster' : 'vector'))
-const isRaster = computed(() => kind.value === 'raster')
-const isVector = computed(() => kind.value === 'vector')
+const kind = computed(() => ['raster', 'external'].includes(route.params.kind)
+  ? route.params.kind : 'vector')
+const isExternal = computed(() => kind.value === 'external')
+// An external RASTER source draws through the raster path; a vector one through the vector path.
+// `kind` is what the layer_config calls it, which is 'external' for both.
+const isRaster = computed(() => kind.value === 'raster'
+  || (isExternal.value && layer.value?.kind === 'raster'))
+const isVector = computed(() => !isRaster.value && !isExternal.value)
 
 const layer = computed(() => {
   // The URL carries the UID: integer ids are per-kind sequences that renumber on a restore, so a
   // bookmarked /data/vector/12 could come back pointing at a different layer. An integer is still
   // accepted, for links made before this and for anyone typing one by hand.
   const ref_ = String(route.params.id || '')
-  const list = isRaster.value ? dataStore.rasterLayers : dataStore.vectorLayers
+  const list = kind.value === 'external' ? dataStore.externalSources
+    : (kind.value === 'raster' ? dataStore.rasterLayers : dataStore.vectorLayers)
   return list.find(l => l.uid === ref_) || list.find(l => String(l.id) === ref_) || null
 })
-const ready = computed(() => layer.value?.status === 'ready')
+const ready = computed(() => isExternal.value || layer.value?.status === 'ready')
 
 // A vector's default style nests the visual part under `style`; a raster's is flat. Same split the
 // API stores, so this is where it is unpacked rather than in three places downstream.
 const vectorStyle = computed(() => (layer.value?.default_style?.style) || {})
 const rasterStyle = computed(() => layer.value?.default_style || {})
-const styleForMap = computed(() => (isRaster.value ? rasterStyle.value : vectorStyle.value))
+const styleForMap = computed(() => {
+  if (isExternal.value) return {}      // the remote service decides how it draws
+  return isRaster.value ? rasterStyle.value : vectorStyle.value
+})
 
 const legend = computed(() => (isVector.value ? legendEntries(vectorStyle.value) : []))
 const colorField = computed(() =>
@@ -253,13 +263,18 @@ const portalSeed = computed(() => ({
   style: styleForMap.value, popup_fields: [],
 }))
 
-const kindLabel = computed(() => isRaster.value
+const kindLabel = computed(() => isExternal.value
+  ? `External ${layer.value?.kind || ''} · ${(layer.value?.source_type || '').toUpperCase()}`
+  : isRaster.value
   ? 'Raster'
   : (layer.value?.storage_backend === 'geoparquet' ? 'Vector · GeoParquet' : 'Vector · PostGIS'))
-const storageLabel = computed(() => isRaster.value
+const storageLabel = computed(() => isExternal.value
+  ? 'Served by another organisation'
+  : isRaster.value
   ? 'Cloud-Optimized GeoTIFF'
   : (layer.value?.storage_backend === 'geoparquet' ? 'GeoParquet in object storage' : 'PostGIS table'))
 const tilesLabel = computed(() => {
+  if (isExternal.value) return 'From the remote service'
   if (isRaster.value) return 'TiTiler, rendered on demand'
   if (layer.value?.storage_backend === 'geoparquet') {
     return layer.value?.tile_status === 'ready' ? 'PMTiles archive' : 'Not tiled'
@@ -317,9 +332,9 @@ function renderMap() {
 
   const { style, bounds, markerSpecs } = buildMapStyle({
     configs: [configFor(l)],
-    layers: isVector.value ? [l] : [],
-    rasters: isRaster.value ? [l] : [],
-    sources: [],
+    layers: (isVector.value && !isExternal.value) ? [l] : [],
+    rasters: (isRaster.value && !isExternal.value) ? [l] : [],
+    sources: isExternal.value ? [l] : [],
     basemap: DEFAULT_BASEMAP,
   })
   // Points are symbol layers whose icons are generated on demand — without this they draw nothing.
@@ -364,9 +379,13 @@ async function commitRename() {
   else await dataStore.renameVector(layer.value.id, name)
 }
 
-function onStyleClosed() {
+async function onStyleClosed() {
   showStyle.value = false
-  renderMap()            // the map is the preview of what was just saved
+  // Pull the saved style back before redrawing. Without this the map rebuilt from the layer the
+  // store still held, so a just-saved raster could come back looking unchanged — or briefly not
+  // at all — until the page was reloaded by hand.
+  await dataStore.refresh()
+  renderMap()
 }
 
 async function onTile() {
@@ -379,7 +398,8 @@ async function onReprocess() {
 }
 async function onDelete() {
   confirmDelete.value = false
-  if (isRaster.value) await dataStore.removeRaster(layer.value.id)
+  if (isExternal.value) await dataStore.removeExternal(layer.value.id)
+  else if (isRaster.value) await dataStore.removeRaster(layer.value.id)
   else await dataStore.removeVector(layer.value.id)
   router.push('/data')
 }

--- a/ui/src/views/PortalEditor.vue
+++ b/ui/src/views/PortalEditor.vue
@@ -559,6 +559,7 @@ import {
 } from '@/lib/symbology'
 import { buildMapStyle, lonLatBbox, rasterTilesUrl } from '@/lib/mapStyle'
 import { BASEMAPS } from '@/lib/basemaps'
+import { registerMarkerImages, setMarkerSpecs } from '@/lib/markerImage'
 import { capturePortalThumbnail } from '@/composables/portalThumbnail'
 import maplibregl from 'maplibre-gl'
 import { MapboxOverlay } from '@deck.gl/mapbox'
@@ -1607,18 +1608,11 @@ watch([layerConfigs, layerTree, loaded, basemap, basemapCatalog, ready], () => {
   }
 }, { deep: true })
 
-// Point marker icons — mirror of templates/shared/portal.js. Generated on demand
-// when a symbol layer references a missing icon image (styleimagemissing).
-const markerSpecs = {}
+// Point marker icons — mirror of templates/shared/portal.js. Generated on demand when a symbol
+// layer references a missing icon image; the specs come back from `buildMapStyle`.
 watch(loaded, (v) => {
   if (!v || !map.value) return
-  map.value.on('styleimagemissing', (e) => {
-    if (!e.id || !e.id.startsWith('gd-pt-') || map.value.hasImage(e.id)) return
-    const spec = markerSpecs[e.id]
-    if (!spec) return
-    const im = markerImage(spec.shape, spec.color, spec.size, spec.outline, spec.outline_width)
-    try { map.value.addImage(e.id, im, { pixelRatio: im.pixelRatio }) } catch { /* ignore */ }
-  })
+  registerMarkerImages(map.value, {})
   // deck.gl overlay (once): a control so it survives setStyle; refetch the viewport on pan/zoom.
   if (!deckOverlay) {
     // Basemap picker control — top-right, above the globe/zoom controls, mirroring the published
@@ -1661,41 +1655,6 @@ watch(loaded, (v) => {
     refreshDeck(true)
   }
 })
-function starPts(cx, cy, r) {
-  const p = []
-  for (let i = 0; i < 10; i++) { const a = -Math.PI / 2 + i * Math.PI / 5, rr = (i % 2) ? r * 0.45 : r; p.push([cx + Math.cos(a) * rr, cy + Math.sin(a) * rr]) }
-  return p
-}
-function crossPts(cx, cy, r) {
-  const t = r * 0.38
-  return [[-t, -r], [t, -r], [t, -t], [r, -t], [r, t], [t, t], [t, r], [-t, r], [-t, t], [-r, t], [-r, -t], [-t, -t]].map(d => [cx + d[0], cy + d[1]])
-}
-function markerImage(shape, color, size, outline, outlineWidth) {
-  const dpr = 2, r = Math.max(3, Number(size) || 5)
-  // Outline width is a RATIO of the radius (see portal.js) so it stays proportional when a layer is
-  // resized; 0.28 reproduces the old hard-coded stroke exactly.
-  const ow = outlineWidth == null ? 0.28 : Number(outlineWidth)
-  const stroke = Math.max(0, r * (isFinite(ow) ? ow : 0.28))
-  const dim = 80  // fixed canvas (see portal.js): constant dims let updateImage handle size changes
-  const cv = document.createElement('canvas')
-  cv.width = dim * dpr; cv.height = dim * dpr
-  const ctx = cv.getContext('2d')
-  ctx.scale(dpr, dpr); ctx.lineJoin = 'round'
-  const cx = dim / 2, cy = dim / 2
-  ctx.beginPath()
-  if (shape === 'square') ctx.rect(cx - r, cy - r, r * 2, r * 2)
-  else if (shape === 'triangle') { ctx.moveTo(cx, cy - r); ctx.lineTo(cx + r * 0.92, cy + r * 0.72); ctx.lineTo(cx - r * 0.92, cy + r * 0.72); ctx.closePath() }
-  else if (shape === 'diamond') { ctx.moveTo(cx, cy - r); ctx.lineTo(cx + r, cy); ctx.lineTo(cx, cy + r); ctx.lineTo(cx - r, cy); ctx.closePath() }
-  else if (shape === 'star') { starPts(cx, cy, r).forEach((p, i) => i ? ctx.lineTo(p[0], p[1]) : ctx.moveTo(p[0], p[1])); ctx.closePath() }
-  else if (shape === 'cross') { crossPts(cx, cy, r).forEach((p, i) => i ? ctx.lineTo(p[0], p[1]) : ctx.moveTo(p[0], p[1])); ctx.closePath() }
-  else ctx.arc(cx, cy, r, 0, Math.PI * 2)
-  ctx.fillStyle = color || '#3b82f6'; ctx.fill()
-  // null = draw no outline; undefined = unspecified, i.e. the white default markers always had.
-  const oc = outline === undefined ? '#ffffff' : outline
-  if (oc && stroke > 0) { ctx.strokeStyle = oc; ctx.lineWidth = stroke; ctx.stroke() }
-  const d = ctx.getImageData(0, 0, dim * dpr, dim * dpr)
-  return { width: dim * dpr, height: dim * dpr, data: d.data, pixelRatio: dpr }
-}
 
 // (basemapCatalog ref is declared up top with the other state — it's referenced by watches that
 // run at setup time, so it must exist before them.)
@@ -1760,13 +1719,17 @@ function buildPreviewStyle() {
   // The editor's own inputs, handed to the shared builder. Draw order comes from the folder tree
   // (flattened, top-first); falls back to the config order when a node has no config.
   const orderedForDraw = flattenTreeRefs(layerTree.value).map(configForNode).filter(Boolean)
-  return buildMapStyle({
+  const built = buildMapStyle({
     configs: orderedForDraw.length ? orderedForDraw : layerConfigs.value,
     layers: dataStore.vectorLayers,
     rasters: dataStore.rasterLayers,
     sources: dataStore.externalSources,
     basemap: currentBasemap(),
   })
+  // The icons the new style will ask for. Registered against the map rather than a module global,
+  // so two maps in one session cannot overwrite each other's markers.
+  setMarkerSpecs(map.value, built.markerSpecs)
+  return built
 }
 
 /**


### PR DESCRIPTION
Everything found by actually using the layer page, plus two features.

## Two real breakages from the extraction

**`ReferenceError: markerSpecs is not defined`** — `buildPreviewStyle` didn't only build a style, it
also filled a dictionary in the component's scope that the `styleimagemissing` handler read back.
Moving the function left that write pointing at nothing. Point layers are symbol layers whose icons
are generated on demand, so **no point layer drew anywhere** — in the portal editor as much as on the
new page.

Fixed by making the function honest: `buildMapStyle` **returns** its marker specs and the caller
registers them against its own map, so two maps can't overwrite each other's icons either.
`markerImage` moved to `lib/markerImage.js` with it.

**`URL scheme "pmtiles" is not supported`** — the protocol is registered as an import side effect of
`composables/useMaplibre`, which the page never imported because it built its own map. It now uses
that composable, so tiled GeoParquet layers load.

## Layout, from the screenshots

- The page had **no margins** and sat flush against the window.
- **"Do something with it" → "Actions"**.
- **Fields** no longer take more room than the map: columns, capped height, collapsible. 29 fields
  as one row each was longer than everything else on the page combined.
- The **map is full width** with the facts as a reflowing card grid beneath. A fixed side column left
  a tall void whenever a layer had no legend and no metadata — which is most of them.
- Links carry the **UID**, not the integer id: ids are per-kind sequences that renumber on a restore,
  so a bookmarked `/data/vector/12` could later point at a different layer. Integers still resolve.
- Saving a style **refreshes before redrawing**, instead of leaving you to reload the page.

## Reversible raster palettes

Depth, deprivation and error read dark-for-high, the opposite of most sequential ramps — a ramp the
wrong way round inverts what the map says. One flag, `colormap_reverse`, understood by every surface:

| | |
|---|---|
| Server | matplotlib's `_r` suffix at render time — never stored, so `viridis_r` can't become `viridis_r_r` |
| Explicit classes | no name to suffix, so the colours re-pair with the values in reverse |
| Browser | mirrors the same suffix rule, so preview matches tile |
| CLI | `--reverse-colormap` / `--no-reverse-colormap`, shown in the legend |
| QGIS | read from an inverted ramp — QGIS inverts in place, we keep name + flag |
| Legend | reports it, or a client draws the ramp forwards and contradicts its own map |

## External sources get the page too

They're layers on a portal like any other. With the facts they actually have (service, remote layer,
version, format, URL) and **without** the actions that aren't ours to offer — styling, tiling, share
links and sharing are hidden rather than shown and refused.

## Tests

19 colormap tests (including that reversing is idempotent and that a bare `reverse` with no palette
is inert), the plugin's raster translation across all five renderer kinds plus an inverted ramp, and
every touched script block parses.