### PR TITLE
fix(qgis): restore upload_active, and catch this class of bug in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,13 @@ jobs:
           python -c "import ast, pathlib; [ast.parse(p.read_text(encoding='utf-8')) for p in pathlib.Path('.').rglob('*.py')]"
           python -c "import sys; sys.path.insert(0, '.'); import connection, sources; print('ok')"
 
+      - name: The plugin loads the way QGIS loads it
+        # Importing is not enough, and shipping proved it: a patch that rewrote one method deleted
+        # `upload_active` with it. Every module still imported, CI was green, and the plugin died
+        # on the first click with AttributeError — because that name is only resolved when the dock
+        # is CONSTRUCTED. This builds the dock and checks every signal target exists.
+        run: python integrations/qgis-plugin/scripts/smoke.py
+
       - name: metadata.txt has what plugins.qgis.org requires
         run: |
           python - <<'PY'

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -658,6 +658,124 @@ class GeoDeployDock(QDockWidget):
                   base + "/p/" + str(doc.get("slug")) + detail)
         self.refresh_layers()
 
+    def upload_active(self):
+        if not self.instance:
+            self._say("Connect to an instance first.", Qgis.Warning)
+            return
+        if not self.instance.token:
+            self._say("Uploading needs a token with data:write. Public browsing does not.",
+                      Qgis.Warning)
+            return
+        # Whatever is SELECTED in the Layers panel, falling back to the active layer. Sending five
+        # layers is a normal thing to want, and doing it one at a time means five round trips
+        # through this dialog.
+        layers = list(self.iface.layerTreeView().selectedLayers() or [])
+        if not layers:
+            active = self.iface.activeLayer()
+            if active is None:
+                self._say("Select one or more layers in the Layers panel first.", Qgis.Warning)
+                return
+            layers = [active]
+
+        jobs = []           # (name, path, temporary, style)
+        refused = []
+        for layer in layers:
+            try:
+                # Not `layer.source()`: a filtered layer's file holds MORE than the layer does, and
+                # a memory or PostGIS layer has no file at all. `prepare` writes those out first.
+                path, temporary = export.prepare(
+                    layer, on_status=lambda t: self._say(t, bar=False))
+            except export.NotUploadable as exc:
+                refused.append("{0}: {1}".format(layer.name(), exc))
+                continue
+            # A raster's default style is a DIFFERENT shape — {colormap, rescale, bidx}, not
+            # classes — so it needs its own translation. Sending the vector shape is what made
+            # "Send its styling too" quietly do nothing for a GeoTIFF.
+            if not self.push_style.isChecked():
+                style = {}
+            elif isinstance(layer, QgsRasterLayer):
+                style = symbology.raster_from_qgis(layer, self._colormaps())
+            else:
+                style = symbology.from_qgis(layer)
+            jobs.append((layer.name(), path, temporary, style))
+
+        if not jobs:
+            # Everything was refused — say why, for each, rather than a generic failure.
+            self._say(" | ".join(refused) or "Nothing could be uploaded.", Qgis.Warning)
+            return
+
+        client = self.instance.client
+        total = len(jobs)
+
+        def work():
+            uploaded, styled, failed = [], [], list(refused)
+            for index, (name, path, temporary, style) in enumerate(jobs, start=1):
+                # Reported from the worker thread: a queue that looks frozen for four of five files
+                # is worse than no progress at all.
+                self._progress.emit("Uploading {0} ({1} of {2})…".format(name, index, total))
+                try:
+                    result = client.uploads.upload(path, wait=True)
+                    if style and getattr(result, "layer_id", None):
+                        # Styling travels with the upload: the portal then shows what the author
+                        # saw, instead of the next default colour in the palette.
+                        kind = result.plan.layer_type
+                        api = client.layers.api(kind)
+                        # The two kinds take different bodies. A raster's IS the style; a vector's
+                        # wraps it, alongside opacity and popup fields.
+                        body = (dict(style, opacity=1.0) if kind == "raster"
+                                else {"opacity": 1.0, "style": style, "popup_fields": []})
+                        api.set_default_style(result.layer_id, body)
+                        styled.append(name)
+                    uploaded.append(name)
+                except Exception as exc:            # noqa: BLE001 - one bad layer, not the batch
+                    # Four good layers must still arrive when the third one is broken.
+                    failed.append("{0}: {1}".format(name, exc))
+                finally:
+                    if temporary:
+                        # A multi-gigabyte export is not left behind in temp because upload failed.
+                        shutil.rmtree(os.path.dirname(path), ignore_errors=True)
+            return {"uploaded": uploaded, "styled": styled, "failed": failed}
+
+        self._busy(True)
+        self._say("Uploading {0} layer(s)… large files go straight to storage.".format(total),
+                  bar=False)
+        self._run(_Job("GeoDeploy: uploading", work), self._uploaded)
+
+    def _uploaded(self, job):
+        self._busy(False)
+        if job.error:
+            self._say(job.error, Qgis.Critical)
+            return
+        result = job.result or {}
+        uploaded = result.get("uploaded") or []
+        failed = result.get("failed") or []
+        styled = result.get("styled") or []
+        # Only claim what was actually sent. A renderer we cannot translate produces no style, and
+        # saying "styling sent" anyway is how a silent no-op passes for a feature.
+        if styled and len(styled) == len(uploaded):
+            styling = " Styling sent with " + ("it." if len(styled) == 1 else "them.")
+        elif styled:
+            styling = f" Styling sent for {len(styled)} of {len(uploaded)}."
+        elif uploaded and self.push_style.isChecked():
+            styling = " No styling was sent — this renderer has no GeoDeploy equivalent."
+        else:
+            styling = ""
+
+        if uploaded and not failed:
+            what = uploaded[0] if len(uploaded) == 1 else f"{len(uploaded)} layers"
+            self._say(f"Uploaded {what}.{styling}")
+        elif uploaded and failed:
+            # Partial success is its own outcome. Reporting it as failure hides work that landed;
+            # reporting it as success hides work that did not.
+            self._say(f"Uploaded {len(uploaded)}, but {len(failed)} did not: " + " | ".join(failed),
+                      Qgis.Warning)
+        else:
+            self._say(" | ".join(failed) or "Nothing was uploaded.", Qgis.Critical)
+        if uploaded:
+            self.refresh_layers()
+
+    # -- task plumbing ------------------------------------------------------------------------------
+
     # -- task plumbing ------------------------------------------------------------------------------
 
     def _run(self, job, on_done):

--- a/integrations/qgis-plugin/scripts/smoke.py
+++ b/integrations/qgis-plugin/scripts/smoke.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Load the plugin the way QGIS does, with QGIS stubbed out.
+
+Importing every module is not enough, and shipping proved it: a patch that rewrote one method
+deleted `upload_active` along with it, every module still imported cleanly, and the plugin died the
+moment someone clicked its toolbar button —
+
+    AttributeError: 'GeoDeployDock' object has no attribute 'upload_active'
+
+because the name is only looked up when the dock is CONSTRUCTED. So this builds the dock, and then
+checks that every method the UI wires a signal to actually exists. Both are cheap; neither needs
+QGIS; both would have caught it.
+
+Run by CI (`.github/workflows`) and by `scripts/build.py`-adjacent checks:
+
+    python integrations/qgis-plugin/scripts/smoke.py
+"""
+import os
+import re
+import sys
+import types
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_DIR = os.path.dirname(HERE)
+PACKAGE = os.path.join(PLUGIN_DIR, "geodeploy_qgis")
+
+
+def _stub_qgis():
+    """A `qgis` package with just enough shape to import and construct the dock."""
+    qgis = types.ModuleType("qgis")
+    core = types.ModuleType("qgis.core")
+    pyqt = types.ModuleType("qgis.PyQt")
+    for sub in ("QtCore", "QtGui", "QtWidgets"):
+        setattr(pyqt, sub, types.ModuleType("qgis.PyQt." + sub))
+
+    class _AnyMeta(type):
+        """Class-level attribute access too — Qt enums are read off the CLASS
+        (`QLineEdit.Password`, `QDialogButtonBox.Ok`), which an instance `__getattr__` never sees."""
+
+        def __getattr__(cls, name):
+            return _Any()
+
+    class _Any(metaclass=_AnyMeta):
+        """Accepts anything: construction, attributes, calls, and signal connections."""
+
+        def __init__(self, *a, **k):
+            pass
+
+        def __getattr__(self, name):
+            return _Any()
+
+        def __call__(self, *a, **k):
+            return _Any()
+
+    for name in ("Qgis", "QgsApplication", "QgsProject", "QgsRasterLayer", "QgsVectorLayer",
+                 "QgsCategorizedSymbolRenderer", "QgsGraduatedSymbolRenderer", "QgsRendererCategory",
+                 "QgsRendererRange", "QgsSimpleFillSymbolLayer", "QgsSimpleLineSymbolLayer",
+                 "QgsSimpleMarkerSymbolLayer", "QgsSymbol", "QgsSingleSymbolRenderer",
+                 "QgsClassificationRange", "QgsMultiBandColorRenderer", "QgsSingleBandGrayRenderer",
+                 "QgsSingleBandPseudoColorRenderer", "QgsHillshadeRenderer",
+                 "QgsPalettedRasterRenderer", "QgsCoordinateTransformContext",
+                 "QgsVectorFileWriter", "QgsNetworkAccessManager", "QgsProperty", "QgsSymbolLayer",
+                 "QgsMessageLog"):
+        setattr(core, name, _AnyMeta(name, (_Any,), {}))
+    core.Qgis = type("Qgis", (), {"Info": 0, "Warning": 1, "Critical": 2, "Success": 3})
+
+    pyqt.QtCore.Qt = type("Qt", (), {"RightDockWidgetArea": 2, "UserRole": 32, "DashLine": 2,
+                                     "DotLine": 3, "NoPen": 0})
+    pyqt.QtCore.QUrl = _AnyMeta("QUrl", (_Any,), {})
+    pyqt.QtCore.pyqtSignal = lambda *a, **k: type("Signal", (), {"connect": lambda self, f: None,
+                                                                 "emit": lambda self, *x: None})()
+    pyqt.QtGui.QColor = _AnyMeta("QColor", (_Any,), {})
+    pyqt.QtGui.QDesktopServices = _AnyMeta("QDesktopServices", (_Any,), {})
+    for name in ("QAbstractItemView", "QAction", "QCheckBox", "QComboBox",
+                 "QHBoxLayout", "QLabel", "QLineEdit", "QMessageBox", "QProgressBar", "QPushButton",
+                 "QTreeWidget", "QTreeWidgetItem", "QVBoxLayout", "QWidget", "QDialog",
+                 "QDialogButtonBox", "QTextEdit"):
+        setattr(pyqt.QtWidgets, name, _AnyMeta(name, (_Any,), {}))
+
+    # The classes the plugin SUBCLASSES must not answer to every attribute name. With the
+    # permissive metaclass, `hasattr(GeoDeployDock, "anything")` was True through inheritance —
+    # which silently defeated the missing-method check this script exists for. Verified by deleting
+    # a method and watching it still pass. Instance access stays permissive (so `self.setWidget(…)`
+    # works); CLASS access does not.
+    class _Base:
+        def __init__(self, *a, **k):
+            pass
+
+        def __getattr__(self, name):        # instances only — never the class
+            return _Any()
+
+    pyqt.QtWidgets.QDockWidget = type("QDockWidget", (_Base,), {})
+    core.QgsTask = type("QgsTask", (_Base,), {"CanCancel": 1})
+
+    qgis.core, qgis.PyQt = core, pyqt
+    sys.modules.update({"qgis": qgis, "qgis.core": core, "qgis.PyQt": pyqt,
+                        "qgis.PyQt.QtCore": pyqt.QtCore, "qgis.PyQt.QtGui": pyqt.QtGui,
+                        "qgis.PyQt.QtWidgets": pyqt.QtWidgets})
+    return _Any
+
+
+def main() -> int:
+    Any = _stub_qgis()
+    sys.path.insert(0, PLUGIN_DIR)
+
+    import importlib
+    modules = ("connection", "sources", "symbology", "export", "portals", "diffdialog", "plugin")
+    for name in modules:
+        importlib.import_module("geodeploy_qgis." + name)
+    print("imported {0} modules".format(len(modules)))
+
+    from geodeploy_qgis import plugin as plugin_mod
+
+    # 1. CONSTRUCT the dock. This is what QGIS does on the first click, and it is where a missing
+    #    method surfaces — every `connect(self.x)` resolves `x` right here.
+    plugin_mod.GeoDeployDock(Any())
+    print("constructed GeoDeployDock")
+
+    # 2. Belt and braces: every method the UI names must exist on the class, including any wired
+    #    somewhere construction happens not to reach.
+    source = open(os.path.join(PACKAGE, "plugin.py"), encoding="utf-8").read()
+    wired = set(re.findall(r"connect\(self\.([a-zA-Z_]\w*)\)", source))
+    # Both classes wire signals — the dock its buttons, the plugin its menu action — so a name is
+    # satisfied by either. Checking only the dock reported `show` (which is the plugin's) missing.
+    owners = (plugin_mod.GeoDeployDock, plugin_mod.GeoDeployPlugin)
+    missing = sorted(n for n in wired if not any(hasattr(o, n) for o in owners))
+    if missing:
+        print("MISSING methods referenced by the UI: {0}".format(", ".join(missing)))
+        return 1
+    print("all {0} wired methods exist: {1}".format(len(wired), ", ".join(sorted(wired))))
+
+    # 3. The plugin object QGIS instantiates, and the menu wiring it does at startup.
+    plugin_mod.GeoDeployPlugin(Any()).initGui()
+    print("initGui ran")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The plugin died the moment its button was clicked:

```
AttributeError: 'GeoDeployDock' object has no attribute 'upload_active'
  File ".../geodeploy_qgis/plugin.py", line 136, in __init__
    self.upload_btn.clicked.connect(self.upload_active)
```

**I deleted it.** A patch that rewrote `push_group` replaced everything between two markers, and
`upload_active` and `_uploaded` sat between them. `git log -S` puts the loss in #39 — so uploading
has been broken in every build since, including the one shipped as "test everything at once".

## The fix

Both methods restored from `3be6999`, the last commit that had them with **both** the multi-layer
selection and the raster-styling branch — not retyped. They carry the sequential queue, the
per-file failure handling and the progress reporting; rewriting from memory would have quietly
dropped one.

## Why nothing caught it, and what does now

Every module imported cleanly, so the import check passed: `self.upload_active` is only resolved
when the dock is **constructed**, which nothing did.

`scripts/smoke.py` now builds the dock the way QGIS does on first click, runs `initGui`, and asserts
every method named in a `connect(self.…)` exists on one of the two classes. CI runs it.

The stub needed care to be worth anything: a permissive metaclass made `hasattr(GeoDeployDock,
"anything")` true through inheritance, so **the first version of this check passed with the method
still deleted**. Verified by deleting it and watching it pass. The classes the plugin subclasses are
plain now — instance access stays permissive so `self.setWidget(…)` works, class access does not.

Proven in both directions before committing:

```
current code                 -> exit 0
upload_active deleted        -> MISSING methods referenced by the UI: upload_active,  exit 1
restored                     -> exit 0
```