### PR TITLE
fix(legend): entries look like the thing they label — shapes, size, and layout

### DIFF
--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -207,6 +207,9 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
                 "geodeploy:bbox": json.loads(layer.bbox) if layer.bbox else None,
                 "geodeploy:geometry": _geom_kind(layer.geometry_type),
                 "geodeploy:marker": (cfg.get("style") or {}).get("marker", "circle"),
+                # The legend draws a line layer's classes AS LINES, dashed the way the map dashes
+                # them — so the dash has to travel with the rest of the symbology.
+                "geodeploy:lineType": (cfg.get("style") or {}).get("lineType", "solid"),
                 "geodeploy:markerColor": (cfg.get("style") or {}).get("color", "#3b82f6"),
                 "geodeploy:markerSize": (cfg.get("style") or {}).get("radius", 5),
                 # EVERY marker bitmap this layer needs — one per class for a classified point layer.

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -1721,7 +1721,8 @@
         (type === 'raster' && !meta['geodeploy:external']
           ? '<div class="layer-legend" data-legend="' + layer.id + '">' + rasterLegendHtml(layer) + '</div>'
           : vectorLegendHtml(meta['geodeploy:legend'], geom,
-                             meta['geodeploy:legendField'], meta['geodeploy:sizeLegend'], color));
+                             meta['geodeploy:legendField'], meta['geodeploy:sizeLegend'], color,
+                             meta['geodeploy:lineType'], meta['geodeploy:marker']));
       container.appendChild(card);
     });
 
@@ -2485,15 +2486,19 @@
       '</div></div>';
   }
 
-  function vectorLegendHtml(entries, geom, field, size, color) {
+  function vectorLegendHtml(entries, geom, field, size, color, dash, shape) {
     const sizeHtml = sizeLegendHtml(size, geom, color);
     // Size can vary while colour does not — they are independent dimensions — so a layer with no
     // classes may still have a legend worth showing.
     if (!Array.isArray(entries) || !entries.length)
       return sizeHtml ? '<div class="layer-legend legend-classes">' + sizeHtml + '</div>' : '';
+    // The SHAPE of the thing, not a square standing in for it. A line layer's classes are lines,
+    // a point layer's are its marker — which is part of the symbology, so a square swatch actively
+    // misreports a layer drawn with stars. `legendSwatch` is the same function the layer's own
+    // swatch button uses; it was simply never reached from here.
     const rows = entries.map(function (e) {
       return '<div class="legend-class">' +
-        '<span class="legend-chip" style="background:' + escHtml(e.color || '#999') + '"></span>' +
+        legendSwatch(geom, e.color || '#999', dash, shape) +
         '<span class="legend-label">' + escHtml(e.label == null ? '' : String(e.label)) + '</span>' +
         '</div>';
     }).join('');

--- a/ui/src/components/LegendSwatch.vue
+++ b/ui/src/components/LegendSwatch.vue
@@ -1,0 +1,76 @@
+<!--
+  A legend swatch that looks like what it stands for.
+
+  A square for everything says "this colour appears somewhere". A circle, a line and a filled
+  rectangle say WHICH KIND OF THING is that colour — and for a point layer the marker shape is part
+  of the symbology, so a square swatch actively misreports a layer drawn with stars.
+
+  Deliberately the same geometry as `templates/shared/portal.js::legendSwatch` / `markerSvg`: the
+  published portal draws its legend with those, and a reader who sees the layer in both places must
+  not see two different keys. That runtime is a standalone bundle the app cannot import, so the
+  shapes are matched by hand — change one, change the other (the parity note in CLAUDE.md).
+-->
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 18 18" class="flex-shrink-0" aria-hidden="true">
+    <!-- Line: a stroke, dashed the way the layer is dashed. -->
+    <line v-if="geom === 'line'" x1="2" y1="9" x2="16" y2="9"
+      :stroke="color" stroke-width="3" stroke-linecap="round"
+      :stroke-dasharray="dash === 'dashed' ? '3 2' : (dash === 'dotted' ? '0.6 3' : undefined)" />
+
+    <!-- Polygon: a fill with its outline, at the same 45% the map uses. -->
+    <rect v-else-if="geom === 'polygon'" x="2.5" y="4" width="13" height="10"
+      :fill="color" fill-opacity="0.45" :stroke="color" stroke-width="1.5" />
+
+    <!-- Raster: a small chequer, standing for a grid of cells. -->
+    <g v-else-if="geom === 'raster'">
+      <rect x="2" y="2" width="14" height="14" :fill="color" fill-opacity="0.35"
+        :stroke="color" stroke-width="1.2" />
+      <line x1="9" y1="2" x2="9" y2="16" :stroke="color" stroke-width="1" stroke-opacity="0.6" />
+      <line x1="2" y1="9" x2="16" y2="9" :stroke="color" stroke-width="1" stroke-opacity="0.6" />
+    </g>
+
+    <!-- Point: the actual marker shape. -->
+    <rect v-else-if="marker === 'square'" x="3" y="3" width="12" height="12"
+      :fill="color" v-bind="outline" />
+    <polygon v-else-if="marker === 'triangle'" points="9,2.5 15.5,15 2.5,15"
+      :fill="color" v-bind="outline" />
+    <polygon v-else-if="marker === 'diamond'" points="9,2 16,9 9,16 2,9"
+      :fill="color" v-bind="outline" />
+    <polygon v-else-if="marker === 'star'" :points="starPoints" :fill="color" v-bind="outline" />
+    <polygon v-else-if="marker === 'cross'" :points="crossPoints" :fill="color" v-bind="outline" />
+    <circle v-else cx="9" cy="9" r="5.5" :fill="color" v-bind="outline" />
+  </svg>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  geom: { type: String, default: 'point' },     // point | line | polygon | raster
+  color: { type: String, default: '#3b82f6' },
+  marker: { type: String, default: 'circle' },
+  dash: { type: String, default: 'solid' },     // solid | dashed | dotted
+  size: { type: Number, default: 16 },
+})
+
+const outline = { stroke: '#fff', 'stroke-width': 1.5, 'stroke-linejoin': 'round' }
+
+// Same construction as portal.js::starPoints / crossPoints, at the swatch's radius.
+const starPoints = computed(() => {
+  const cx = 9, cy = 9, r = 6.5
+  const pts = []
+  for (let i = 0; i < 10; i++) {
+    const rad = i % 2 ? r * 0.5 : r
+    const a = (Math.PI / 5) * i - Math.PI / 2
+    pts.push(`${(cx + rad * Math.cos(a)).toFixed(2)},${(cy + rad * Math.sin(a)).toFixed(2)}`)
+  }
+  return pts.join(' ')
+})
+
+const crossPoints = computed(() => {
+  const cx = 9, cy = 9, r = 6.5, t = r * 0.38
+  return [[-t, -r], [t, -r], [t, -t], [r, -t], [r, t], [t, t], [t, r], [-t, r],
+          [-t, t], [-r, t], [-r, -t], [-t, -t]]
+    .map(([dx, dy]) => `${cx + dx},${cy + dy}`).join(' ')
+})
+</script>

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -26,8 +26,8 @@
           <span aria-hidden="true">←</span> My Data
         </RouterLink>
         <div class="flex items-center gap-2 mt-1">
-          <span class="w-3 h-3 rounded-sm flex-shrink-0 ring-1 ring-black/20"
-            :style="{ background: swatch }" :title="`Drawn in ${swatch}`" />
+          <LegendSwatch :geom="swatchGeom" :color="swatch" :marker="markerShape"
+            :dash="lineDash" :size="18" />
           <h1 v-if="!renaming" class="text-2xl font-semibold truncate">{{ layer.name }}</h1>
           <input v-else ref="nameInput" v-model="draftName" @keyup.enter="commitRename"
             @keyup.esc="renaming = false" @blur="commitRename"
@@ -57,13 +57,13 @@
         <div id="gd-layer-map" class="w-full h-[52vh] min-h-[340px] bg-muted/40" />
         <!-- The legend, in the map where a portal keeps it — above the zoom controls, and closed
              until asked for, because on most layers it is one swatch. -->
-        <div v-if="layer" class="absolute top-2.5 right-2.5 z-10 max-w-[15rem]">
+        <div v-if="layer" class="absolute top-2.5 left-2.5 z-10 max-w-[15rem]">
           <button @click="legendOpen = !legendOpen"
             class="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium
                    bg-card/95 border border-border shadow backdrop-blur hover:bg-muted"
             :title="legendOpen ? 'Hide the legend' : 'Show the legend'">
-            <span class="w-3 h-3 rounded-sm flex-shrink-0 ring-1 ring-black/25"
-              :style="{ background: swatch }" />
+            <LegendSwatch :geom="swatchGeom" :color="swatch" :marker="markerShape"
+              :dash="lineDash" :size="16" />
             <span class="truncate">Legend</span>
             <span class="ml-auto text-muted-foreground/70" aria-hidden="true">
               {{ legendOpen ? '▾' : '▸' }}
@@ -78,8 +78,8 @@
             </p>
             <div v-if="legend.length" class="space-y-1">
               <div v-for="(e, i) in legend" :key="i" class="flex items-center gap-2">
-                <span class="w-3 h-3 rounded-sm flex-shrink-0 ring-1 ring-black/25"
-                  :style="{ background: e.color }" />
+                <LegendSwatch :geom="swatchGeom" :color="e.color" :marker="markerShape"
+                  :dash="lineDash" :size="16" />
                 <span class="text-[11px] text-muted-foreground truncate">{{ e.label }}</span>
               </div>
             </div>
@@ -91,9 +91,34 @@
               </div>
             </div>
             <div v-else class="flex items-center gap-2">
-              <span class="w-3 h-3 rounded-sm flex-shrink-0 ring-1 ring-black/25"
-                :style="{ background: swatch }" />
+              <LegendSwatch :geom="swatchGeom" :color="swatch" :marker="markerShape"
+                :dash="lineDash" :size="16" />
               <span class="text-[11px] text-muted-foreground">Single symbol</span>
+            </div>
+            <!-- Size varies independently of colour, so a legend showing only classes
+                 describes half the map. Two ends, because the size expression interpolates. -->
+            <div v-if="sizeLegend" class="mt-2 pt-2 border-t border-border/50">
+              <p class="text-[11px] text-muted-foreground/70 mb-1">
+                Size by <span class="font-medium">{{ sizeLegend.field }}</span>
+              </p>
+              <div class="flex items-end gap-4">
+                <div v-for="(end, i) in sizeLegend.ends" :key="i"
+                  class="flex flex-col items-center gap-1">
+                  <span class="flex items-end justify-center" style="min-height:26px">
+                    <span v-if="swatchGeom === 'line'" :style="{
+                      display: 'block', width: '22px',
+                      height: Math.max(2, Math.min(22, end.px)) + 'px',
+                      borderRadius: (Math.max(2, Math.min(22, end.px)) / 2) + 'px',
+                      background: swatch }" />
+                    <span v-else :style="{
+                      display: 'block',
+                      width: (Math.max(2, Math.min(13, end.px)) * 2) + 'px',
+                      height: (Math.max(2, Math.min(13, end.px)) * 2) + 'px',
+                      borderRadius: '50%', background: swatch }" />
+                  </span>
+                  <span class="text-[10px] text-muted-foreground/80 tabular-nums">{{ end.value }}</span>
+                </div>
+              </div>
             </div>
             <p class="text-[10px] text-muted-foreground/60 mt-1.5 pt-1.5 border-t border-border/50">
               Dashed outline = the layer's extent
@@ -118,7 +143,7 @@
     <!-- Facts. `auto-fit` rather than a fixed column count: with two cards in a four-column grid
          two thirds of the row was empty. They now share the width they have. -->
     <div v-if="layer"
-      class="grid gap-5 items-start"
+      class="grid gap-5"
       style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))">
       <section class="card p-4">
         <h2 class="text-sm font-semibold mb-3">What it is</h2>
@@ -241,6 +266,7 @@ import SharingModal from '@/components/data/SharingModal.vue'
 import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
 import ConfirmDeleteModal from '@/components/data/ConfirmDeleteModal.vue'
 import CreatePortalModal from '@/components/portal/CreatePortalModal.vue'
+import LegendSwatch from '@/components/LegendSwatch.vue'
 
 // A label/value row. Rendered rather than templated because it must vanish entirely when the value
 // is absent — a "Bands: —" line on a vector layer is noise pretending to be information.
@@ -317,6 +343,30 @@ const rampCss = computed(() => {
 const rampRange = computed(() => {
   const parts = String(rasterStyle.value.rescale || '').split(',')
   return parts.length === 2 ? parts : ['min', 'max']
+})
+
+// What KIND of thing this layer draws, for the swatch shape.
+const swatchGeom = computed(() => {
+  if (isRaster.value) return 'raster'
+  const g = (layer.value?.geometry_type || '').toLowerCase()
+  if (g.includes('line')) return 'line'
+  if (g.includes('polygon')) return 'polygon'
+  return 'point'
+})
+const markerShape = computed(() => vectorStyle.value.marker || 'circle')
+const lineDash = computed(() => vectorStyle.value.lineType || 'solid')
+
+/** The two ends of a proportional size scale — mirrors services/symbology.size_legend. */
+const sizeLegend = computed(() => {
+  const st = vectorStyle.value
+  if ((st.size_mode || 'fixed') !== 'proportional') return null
+  const stops = (st.size_stops || []).filter(x => Array.isArray(x) && x.length === 2)
+  if (!st.size_field || stops.length < 2) return null
+  const ordered = [...stops].sort((a, b) => a[0] - b[0])
+  const lo = ordered[0], hi = ordered[ordered.length - 1]
+  return { field: st.size_field,
+           ends: [{ value: lo[0], px: Number(lo[1]) || 2 },
+                  { value: hi[0], px: Number(hi[1]) || 8 }] }
 })
 
 const swatch = computed(() => (isRaster.value ? '#64748b' : representativeColor(vectorStyle.value)))


### PR DESCRIPTION
> *"is the portal shapes already correct?"*

**No.** Its *layer* swatch has always been shape-aware, but every class **row** was a flat square —
in the portal and on the layer page alike.

A square for a line layer says "this colour appears somewhere" rather than naming what is that
colour. For points it is worse than vague: the marker shape **is** part of the symbology, so a
square swatch misreports a layer drawn with stars.

## Both surfaces now draw the real thing

- **line** — a stroke, dashed the way the map dashes it
- **polygon** — a filled rectangle with its outline, at the same 45%
- **point** — the actual marker (circle / square / triangle / diamond / star / cross)

The portal reaches its **own** `legendSwatch` for this — the function its layer button already used
and the class rows never called — so nothing new was invented there. `lineType` is baked alongside
the marker, because a legend drawing solid lines for a dashed layer disagrees with its map.

The app gets `LegendSwatch.vue`, matching those shapes deliberately: the portal runtime is a
standalone bundle the app cannot import, so this is a parity pair like the symbology twins.

## Size is in the legend now too

A layer sized by one column and coloured by another was showing only its colours — half the map.
Two ends, because the size expression interpolates between them.

## From the screenshots

- Fact cards **stretch to equal height** — `items-start` made each shrink to its own content.
- The legend moved to the map's **top left**; it was covering the zoom and 3D controls.

34 portal/legend tests pass.