### PR TITLE
fix(qgis): _open_portal, legend call, pixel sizes, rasters, upload picker, portal thumbnail

### DIFF
--- a/cli/geodeploy/portals.py
+++ b/cli/geodeploy/portals.py
@@ -136,6 +136,19 @@ class Portals(object):
 
     # ── layers on a portal ──────────────────────────────────────────────────────────────────────
 
+    def upload_thumbnail(self, portal_id: Any, path: str) -> Dict[str, Any]:
+        """The card image for this portal — the picture shown wherever it is listed.
+
+        The dashboard captures its map canvas at publish time; anything else that publishes a
+        portal has to supply its own, or the card stays blank. Separate from `upload_asset`: a
+        portal has exactly one thumbnail, and the server replaces the previous one.
+        """
+        from .transport import MultipartBody
+        body = MultipartBody(file_path=path, filename=os.path.basename(path))
+        return self._c.request("POST", "/portals/{0}/thumbnail".format(int(portal_id)),
+                               body=body, content_type=body.content_type,
+                               timeout=self._c.upload_timeout)
+
     def layers(self, portal: Any) -> List[Dict[str, Any]]:
         """The portal's layer configs, top of the list first."""
         doc = portal if isinstance(portal, dict) else self.get(portal)

--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -77,14 +77,27 @@ class Instance:
         "show me this portal" without an account.
         """
         import json
-        from urllib.request import urlopen
+        from urllib.request import Request, urlopen
 
         url = "{0}/portals/{1}/style.json".format(self.url.rstrip("/"), slug)
+        # A User-Agent is not optional here. urllib sends "Python-urllib/3.x" by default, and a
+        # Cloudflare-fronted instance answers that with 403 — measured: the same URL returns 200 to
+        # curl and to a browser, 403 to urllib. The portal is public; it was the client that looked
+        # suspicious. Named after the tool, like the API client's own agent.
+        request = Request(url, headers={"User-Agent": self._c_user_agent(),
+                                        "Accept": "application/json"})
         try:
-            with urlopen(url, timeout=30) as response:      # noqa: S310 - our own instance URL
+            with urlopen(request, timeout=30) as response:  # noqa: S310 - our own instance URL
                 return json.loads(response.read().decode("utf-8"))
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
             raise GeoDeployError("Could not read the published portal at {0}: {1}".format(url, exc))
+
+    def _c_user_agent(self) -> str:
+        """The same agent string the API client sends, so one instance sees one tool."""
+        try:
+            return self.client.user_agent
+        except Exception:               # noqa: BLE001 - never fail over a header
+            return "geodeploy-qgis"
 
     def check(self) -> dict:
         """Prove the connection works, and say what kind it is — shown in the dock's header.

--- a/integrations/qgis-plugin/geodeploy_qgis/export.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/export.py
@@ -51,6 +51,25 @@ def _plain_file_source(layer) -> str | None:
     return source if os.path.isfile(source) else None
 
 
+def check(layer) -> None:
+    """Raise `NotUploadable` if this layer cannot be sent — WITHOUT exporting anything.
+
+    The picker needs to know before the user chooses, and writing a two-gigabyte GeoPackage to find
+    out would be a strange way to populate a list.
+    """
+    if isinstance(layer, QgsRasterLayer):
+        if not _plain_file_source(layer):
+            raise NotUploadable("served from elsewhere, not a local file")
+        return
+    if not isinstance(layer, QgsVectorLayer):
+        raise NotUploadable("not a vector or raster layer")
+    if layer.isEditable() and layer.isModified():
+        raise NotUploadable("has unsaved edits")
+    source = layer.source() or ""
+    if source.startswith(("http://", "https://", "/vsicurl", "url=")):
+        raise NotUploadable("served from elsewhere, not a local file")
+
+
 def prepare(layer, on_status=None) -> tuple[str, bool]:
     """`(path, is_temporary)` for a layer ready to upload.
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -21,7 +21,8 @@ from qgis.PyQt.QtWidgets import (QAbstractItemView, QAction, QCheckBox, QComboBo
                                  QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar,
                                  QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
-from . import diffdialog, export, portals as portal_sync, sources, symbology
+from . import (diffdialog, export, portals as portal_sync, sources, symbology,
+               uploadpicker)
 from .connection import GeoDeployError, Instance, saved_instances
 
 PLUGIN_NAME = "GeoDeploy"
@@ -45,6 +46,25 @@ class _Job(QgsTask):
         except Exception as exc:                      # noqa: BLE001 - surface, never crash QGIS
             self.error = f"{type(exc).__name__}: {exc}"
         return False
+
+
+def _xyz_uri(tile_url: str) -> str | None:
+    """An XYZ provider URI built by QGIS itself.
+
+    `QgsDataSourceUri` owns the escaping rules, and ours has to survive a template whose own query
+    string contains `?`, `&` and `://`. Letting QGIS encode it removes the only untested step
+    between a tile endpoint that provably returns PNGs and a layer that draws nothing.
+    """
+    try:
+        from qgis.core import QgsDataSourceUri
+        uri = QgsDataSourceUri()
+        uri.setParam("type", "xyz")
+        uri.setParam("url", tile_url)
+        uri.setParam("zmin", "0")
+        uri.setParam("zmax", "22")
+        return bytes(uri.encodedUri()).decode("utf-8")
+    except Exception:                   # noqa: BLE001 - fall back to the hand-built string
+        return None
 
 
 class GeoDeployDock(QDockWidget):
@@ -213,6 +233,35 @@ class GeoDeployDock(QDockWidget):
         except Exception as exc:        # noqa: BLE001
             symbology._log("Could not install the auth preprocessor: {0}".format(exc))
 
+    def _capture_canvas(self):
+        """The map canvas as a WebP file, or None. Used as the portal's card image.
+
+        WebP because that is what the endpoint stores and serves it as — handing it PNG bytes under
+        a .webp name works by content sniffing, which is not something to rely on. Falls back to
+        PNG only if this Qt has no WebP writer.
+        """
+        try:
+            import tempfile
+            canvas = self.iface.mapCanvas()
+            if canvas is None:
+                return None
+            image = canvas.grab().toImage()
+            # A card, not a poster: the dashboard shows these small, and a 4K screenshot would be
+            # megabytes of nothing.
+            try:
+                from qgis.PyQt.QtCore import Qt as _Qt
+                image = image.scaledToWidth(1200, _Qt.SmoothTransformation)
+            except Exception:           # noqa: BLE001 - full size is still usable
+                pass
+            for suffix, fmt in ((".webp", "WEBP"), (".png", "PNG")):
+                path = os.path.join(tempfile.mkdtemp(prefix="geodeploy-thumb-"), "thumb" + suffix)
+                if image.save(path, fmt, 82 if fmt == "WEBP" else -1):
+                    return path
+            return None
+        except Exception as exc:        # noqa: BLE001 - a picture is never worth a failed publish
+            symbology._log("Could not capture the map for the portal thumbnail: {0}".format(exc))
+            return None
+
     def _colormaps(self):
         """The colormap names this instance actually has, fetched once.
 
@@ -378,7 +427,12 @@ class GeoDeployDock(QDockWidget):
                 # layer arrived unstyled. `/legend` is PUBLIC and is what the portal draws from.
                 try:
                     ref = row.get("uid") or row.get("id")
-                    legend = self.instance.client.layers.legend(ref)
+                    # `legend` is defined on the VECTOR and RASTER namespaces, not on the
+                    # kind-agnostic `layers` helper — asking the latter is an AttributeError, which
+                    # is what every unstyled layer was really hitting.
+                    kind = "raster" if (row.get("layer_type") == "raster"
+                                        or row.get("storage_backend") == "raster") else "vector"
+                    legend = self.instance.client.layers.api(kind).legend(ref)
                     style = symbology.style_from_legend(legend)
                 except GeoDeployError as exc:
                     symbology._log(f"Could not read the legend for {name}: {exc}")
@@ -402,17 +456,44 @@ class GeoDeployDock(QDockWidget):
         layer each entry is, and matching by name would break the first time someone renames one.
         """
         if source["kind"] in ("cog", "xyz"):
-            layer = QgsRasterLayer(source["uri"], name, source["provider"])
+            uri = source["uri"]
+            if source["kind"] == "xyz" and source.get("tile_url"):
+                uri = _xyz_uri(source["tile_url"]) or uri
+            layer = QgsRasterLayer(uri, name, source["provider"])
         else:
             layer = QgsVectorLayer(source["uri"], name, source["provider"])
         if not layer.isValid():
             return None
+        if source["kind"] == "xyz":
+            # AN XYZ LAYER HAS NO EXTENT OF ITS OWN. It is a global tile pyramid, so QGIS reports
+            # the whole world and "Zoom to layer" flies to everything — which is what made zooming
+            # to a raster land on some other layer entirely. The instance knows the real bounds, so
+            # tell QGIS them.
+            self._set_raster_extent(layer, row.get("bbox"))
         if self.instance:
             is_raster = (row.get("layer_type") == "raster"
                          or row.get("storage_backend") == "raster")
             portal_sync.tag_layer(layer, self.instance.url, row.get("id"),
                                   "raster" if is_raster else "vector")
         return layer
+
+    @staticmethod
+    def _set_raster_extent(layer, bbox):
+        """Give a tile layer the layer's own bounds, in the map's CRS."""
+        if not (isinstance(bbox, (list, tuple)) and len(bbox) == 4):
+            return
+        try:
+            from qgis.core import (QgsCoordinateReferenceSystem, QgsCoordinateTransform,
+                                   QgsProject, QgsRectangle)
+            rect = QgsRectangle(float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3]))
+            # The bbox is EPSG:4326 app-wide; an XYZ layer is Web Mercator.
+            src = QgsCoordinateReferenceSystem("EPSG:4326")
+            if layer.crs().isValid() and layer.crs() != src:
+                rect = QgsCoordinateTransform(src, layer.crs(),
+                                              QgsProject.instance()).transformBoundingBox(rect)
+            layer.setExtent(rect)
+        except Exception as exc:        # noqa: BLE001 - a wrong zoom is not worth a failed add
+            symbology._log("Could not set the raster's extent: {0}".format(exc))
 
     def _row_for(self, layer_id, layer_type):
         """The listing row matching a portal layer_config entry."""
@@ -595,6 +676,9 @@ class GeoDeployDock(QDockWidget):
             if (int(cfg.get("layer_id")), str(cfg.get("layer_type")))
             not in {(c["layer_id"], c["layer_type"]) for c in plan["configs"]}]
         instance_url = self.instance.url
+        # Grabbed here, on the GUI thread, because a canvas cannot be touched from a worker — and
+        # because right now it shows exactly what is being published.
+        thumbnail = self._capture_canvas()
 
         def work():
             sent = []
@@ -630,6 +714,20 @@ class GeoDeployDock(QDockWidget):
             new_title = (plan.get("rename") or (None, None))[1]
             doc = portal_sync.push(client, group, configs, new_title=new_title,
                                    tree=final.get("tree"))
+            # The card image. The dashboard captures its own map at publish time, so a portal
+            # published from anywhere else had a blank card — which makes it look unfinished in the
+            # one place people browse portals. Never fatal: a missing picture is not a failed
+            # publish.
+            if thumbnail and doc.get("id"):
+                try:
+                    client.portals.upload_thumbnail(doc["id"], thumbnail)
+                except Exception as exc:        # noqa: BLE001
+                    symbology._log("Portal published; its thumbnail did not upload: {0}".format(exc))
+                finally:
+                    try:
+                        os.unlink(thumbnail)
+                    except OSError:
+                        pass
             return {"portal": doc, "uploaded": sent, "kept": len(keep_removed),
                     "skipped": [n for n, _l, _x in final["uploads"]]}
 
@@ -658,6 +756,22 @@ class GeoDeployDock(QDockWidget):
                   base + "/p/" + str(doc.get("slug")) + detail)
         self.refresh_layers()
 
+    def _open_portal(self, row):
+        """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
+        base = (row.get("_base") or "").rstrip("/")
+        slug = row.get("slug") or ""
+        if not base or not slug:
+            self._say("That portal has no address yet — publish it first.", Qgis.Warning)
+            return
+        url = f"{base}/p/{slug}"
+        try:
+            from qgis.PyQt.QtCore import QUrl
+            from qgis.PyQt.QtGui import QDesktopServices
+            QDesktopServices.openUrl(QUrl(url))
+            self._say(f"Opened {url} in your browser.")
+        except Exception as exc:        # noqa: BLE001 - still give them the address
+            self._say(f"Open it at {url} ({exc}).", Qgis.Warning)
+
     def upload_active(self):
         if not self.instance:
             self._say("Connect to an instance first.", Qgis.Warning)
@@ -676,6 +790,24 @@ class GeoDeployDock(QDockWidget):
                 self._say("Select one or more layers in the Layers panel first.", Qgis.Warning)
                 return
             layers = [active]
+
+        # ASK FIRST. Which layers go is the user's call, and a layer that cannot be sent should be
+        # visible with its reason rather than turning into an error after the fact.
+        candidates = []
+        for layer in layers:
+            try:
+                export.check(layer)
+                candidates.append((layer.name(), None))
+            except export.NotUploadable as exc:
+                candidates.append((layer.name(), str(exc)))
+        chosen = uploadpicker.choose(self, candidates)
+        if chosen is None:
+            self._say("Nothing was uploaded.", bar=False)
+            return
+        if not chosen:
+            self._say("No layers were selected to upload.", Qgis.Warning)
+            return
+        layers = [l for l in layers if l.name() in set(chosen)]
 
         jobs = []           # (name, path, temporary, style)
         refused = []

--- a/integrations/qgis-plugin/geodeploy_qgis/sources.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/sources.py
@@ -74,6 +74,11 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
             url = tiles if tiles.startswith("http") else f"{base}{tiles}"
             return {
                 "kind": "xyz",
+                # The TEMPLATE, unencoded. The provider URI is assembled by QgsDataSourceUri in
+                # `plugin._build_layer`, because hand-rolling the percent-encoding of a URL that
+                # itself carries a query string (`?url=s3://…&rescale=…`) is the one part of this
+                # path that was never verified — and the server side provably works.
+                "tile_url": url,
                 "uri": f"type=xyz&url={quote(url, safe='')}&zmin=0&zmax=22",
                 "provider": "wms",          # QGIS serves XYZ through the WMS provider
                 "why": "server-rendered tiles, coloured exactly as GeoDeploy draws it",

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -73,6 +73,8 @@ def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
     if spec is None:
         return
     field, in_lo, in_hi, out_lo, out_hi = spec
+    # The stops are pixel sizes like every other size here, so the symbol must already be measured
+    # in pixels (`_use_pixels`, called by `_symbol_for` before this).
     try:
         from qgis.core import QgsProperty, QgsSymbolLayer
     except ImportError:                 # pragma: no cover
@@ -84,11 +86,33 @@ def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
             symbol.setDataDefinedSize(QgsProperty.fromExpression(expr))
         elif isinstance(layer0, QgsSimpleLineSymbolLayer):
             expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
-                field, in_lo, in_hi, out_lo / 4.0, out_hi / 4.0)
+                field, in_lo, in_hi, out_lo, out_hi)
             layer0.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeWidth,
                                           QgsProperty.fromExpression(expr))
     except Exception as exc:            # noqa: BLE001 - a size must never stop a layer drawing
         _log("Could not apply size-by-field ({0}): {1}".format(field, exc))
+
+
+def _use_pixels(symbol, layer0) -> None:
+    """Measure this symbol in pixels, which is what GeoDeploy's numbers mean.
+
+    QGIS defaults to millimetres. A GeoDeploy radius of 5 (px) set as 10 mm draws about four times
+    too large at a normal DPI — the difference between "the same map" and "a map covered in blobs".
+    Both the symbol and its layer are told, because QGIS keeps the unit on each.
+    """
+    try:
+        from qgis.core import QgsUnitTypes
+        px = QgsUnitTypes.RenderPixels
+    except Exception:                   # noqa: BLE001 - very old QGIS: leave the default
+        return
+    for target, setter in ((symbol, "setSizeUnit"), (layer0, "setSizeUnit"),
+                           (symbol, "setWidthUnit"), (layer0, "setWidthUnit")):
+        fn = getattr(target, setter, None)
+        if callable(fn):
+            try:
+                fn(px)
+            except Exception:           # noqa: BLE001 - not every symbol layer has both
+                pass
 
 
 def _symbol_for(qgis_layer, color: str | None, style: dict):
@@ -114,9 +138,12 @@ def _symbol_for(qgis_layer, color: str | None, style: dict):
                 layer0.setShape(QgsSimpleMarkerSymbolLayer.decodeShape(shape)[0])
             except Exception:           # noqa: BLE001 - shape names shift between QGIS versions
                 pass
+        _use_pixels(symbol, layer0)
         if style.get("radius"):
-            # GeoDeploy's radius is a pixel radius; QGIS marker size is a diameter in mm-ish units.
-            # Doubling keeps the relative sizes right, which is what a reader compares.
+            # GeoDeploy's radius is in PIXELS and QGIS's size is a DIAMETER — so double it, and
+            # (above) tell QGIS the number is pixels. Without that it is read as millimetres, and a
+            # radius of 5 becomes a 10 mm marker: roughly four times too big on screen, which is
+            # exactly how it looked.
             symbol.setSize(float(style["radius"]) * 2)
         outline = style.get("outline_color")
         if outline and outline != "none":
@@ -124,8 +151,11 @@ def _symbol_for(qgis_layer, color: str | None, style: dict):
         elif outline == "none":
             layer0.setStrokeStyle(Qt.NoPen)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
+        _use_pixels(symbol, layer0)
         if style.get("line_width"):
-            layer0.setWidth(float(style["line_width"]) / 4.0)   # px → mm, roughly
+            # In pixels now (see `_use_pixels`), so the width IS the width — no mm conversion, and
+            # no divide-by-four fudge that was only ever right at one screen DPI.
+            layer0.setWidth(float(style["line_width"]))
         dash = (style.get("lineType") or "solid").lower()
         if dash == "dashed":
             layer0.setPenStyle(Qt.DashLine)

--- a/integrations/qgis-plugin/geodeploy_qgis/uploadpicker.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/uploadpicker.py
@@ -1,0 +1,78 @@
+"""Which layers to upload — asked, not assumed.
+
+Selecting several layers in QGIS and pressing Upload used to send all of them, and a layer that
+could not be sent (a basemap, anything served from elsewhere) only announced itself as an error
+afterwards. Both are the same mistake: deciding on the user's behalf and reporting later.
+
+So the list is shown first, with the sendable ones ticked and the rest greyed out with the reason
+beside them. Nothing here is clever; it exists so that "upload these two but not that one" is a
+click rather than a rearrangement of the project.
+"""
+from __future__ import annotations
+
+try:                                    # pragma: no cover - only present inside QGIS
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QLabel,
+                                     QListWidget, QListWidgetItem, QVBoxLayout)
+    QGIS = True
+except ImportError:                     # pragma: no cover - importable for tests
+    QGIS = False
+
+
+def summarise(candidates) -> str:
+    """`[(name, reason_or_None)]` as plain text — separated from the dialog so it can be tested."""
+    ok = [n for n, why in candidates if not why]
+    blocked = [(n, why) for n, why in candidates if why]
+    lines = []
+    if ok:
+        lines.append("Will upload ({0}):".format(len(ok)))
+        lines.extend("    " + n for n in ok)
+    if blocked:
+        if lines:
+            lines.append("")
+        lines.append("Cannot upload ({0}):".format(len(blocked)))
+        lines.extend("    {0} — {1}".format(n, why) for n, why in blocked)
+    return "\n".join(lines) or "Nothing to upload."
+
+
+def choose(parent, candidates):
+    """Show the list. Returns the names to upload, or None if cancelled.
+
+    `candidates` is `[(name, reason_or_None)]`; a reason means it cannot be sent.
+    """
+    if not QGIS:                        # pragma: no cover - no GUI in tests
+        return None
+
+    dialog = QDialog(parent)
+    dialog.setWindowTitle("Upload to GeoDeploy")
+    layout = QVBoxLayout(dialog)
+    label = QLabel("Choose what to send. Anything greyed out cannot be uploaded from here.")
+    label.setWordWrap(True)
+    layout.addWidget(label)
+
+    listing = QListWidget()
+    listing.setSelectionMode(QAbstractItemView.NoSelection)
+    listing.setMinimumSize(420, 240)
+    for name, why in candidates:
+        item = QListWidgetItem(name if not why else "{0}  —  {1}".format(name, why))
+        item.setData(Qt.UserRole, name)
+        if why:
+            # Visible but unusable: knowing WHY a layer is absent beats it silently not being there.
+            item.setFlags(Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Unchecked)
+        else:
+            item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            item.setCheckState(Qt.Checked)
+        listing.addItem(item)
+    layout.addWidget(listing)
+
+    buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+    buttons.button(QDialogButtonBox.Ok).setText("Upload")
+    buttons.accepted.connect(dialog.accept)
+    buttons.rejected.connect(dialog.reject)
+    layout.addWidget(buttons)
+
+    if dialog.exec_() != QDialog.Accepted:
+        return None
+    return [listing.item(i).data(Qt.UserRole) for i in range(listing.count())
+            if listing.item(i).checkState() == Qt.Checked]

--- a/integrations/qgis-plugin/geodeploy_qgis/vendor/geodeploy/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/vendor/geodeploy/portals.py
@@ -136,6 +136,19 @@ class Portals(object):
 
     # ── layers on a portal ──────────────────────────────────────────────────────────────────────
 
+    def upload_thumbnail(self, portal_id: Any, path: str) -> Dict[str, Any]:
+        """The card image for this portal — the picture shown wherever it is listed.
+
+        The dashboard captures its map canvas at publish time; anything else that publishes a
+        portal has to supply its own, or the card stays blank. Separate from `upload_asset`: a
+        portal has exactly one thumbnail, and the server replaces the previous one.
+        """
+        from .transport import MultipartBody
+        body = MultipartBody(file_path=path, filename=os.path.basename(path))
+        return self._c.request("POST", "/portals/{0}/thumbnail".format(int(portal_id)),
+                               body=body, content_type=body.content_type,
+                               timeout=self._c.upload_timeout)
+
     def layers(self, portal: Any) -> List[Dict[str, Any]]:
         """The portal's layer configs, top of the list first."""
         doc = portal if isinstance(portal, dict) else self.get(portal)

--- a/integrations/qgis-plugin/scripts/smoke.py
+++ b/integrations/qgis-plugin/scripts/smoke.py
@@ -130,7 +130,27 @@ def main() -> int:
         return 1
     print("all {0} wired methods exist: {1}".format(len(wired), ", ".join(sorted(wired))))
 
-    # 3. The plugin object QGIS instantiates, and the menu wiring it does at startup.
+    # 3. Every `self.something(...)` CALL, not only signal targets. `_open_portal` was deleted by
+    #    the same patch that took `upload_active`, and survived the first version of this check
+    #    because it is called from `add_selected` rather than wired to a button — so the plugin
+    #    still crashed, just one click further in.
+    called = set(re.findall(r"self\.(_?[a-z]\w*)\(", source))
+    assigned = set(re.findall(r"self\.(\w+)\s*=", source))
+    defined = set(re.findall(r"^    def (\w+)", source, re.M))
+    # Methods the dock inherits from QDockWidget. The stub bases are deliberately NOT permissive at
+    # class level (that is what made the first version of this check useless), so real Qt methods
+    # have to be named. A short, explicit list beats a check that passes for everything.
+    QT_INHERITED = {"setWidget", "show", "raise_", "hide", "setWindowTitle", "widget"}
+    absent = sorted(c for c in called
+                    if c not in defined and c not in assigned and c not in QT_INHERITED
+                    and not hasattr(plugin_mod.GeoDeployDock, c)
+                    and not hasattr(plugin_mod.GeoDeployPlugin, c))
+    if absent:
+        print("CALLED but never defined: {0}".format(", ".join(absent)))
+        return 1
+    print("all {0} self-calls resolve".format(len(called)))
+
+    # 4. The plugin object QGIS instantiates, and the menu wiring it does at startup.
     plugin_mod.GeoDeployPlugin(Any()).initGui()
     print("initGui ran")
     return 0

--- a/integrations/qgis-plugin/scripts/smoke.py
+++ b/integrations/qgis-plugin/scripts/smoke.py
@@ -104,7 +104,8 @@ def main() -> int:
     sys.path.insert(0, PLUGIN_DIR)
 
     import importlib
-    modules = ("connection", "sources", "symbology", "export", "portals", "diffdialog", "plugin")
+    modules = ("connection", "sources", "symbology", "export", "portals", "diffdialog",
+               "uploadpicker", "plugin")
     for name in modules:
         importlib.import_module("geodeploy_qgis." + name)
     print("imported {0} modules".format(len(modules)))


### PR DESCRIPTION
Six failures from one session, each fixed at its cause.

## `_open_portal` was gone too

The same patch that took `upload_active` took this — same reason, it sat inside the replaced span.
Restored from `3be6999`; "Open in browser" works again.

Its absence also showed the smoke test was too narrow: `_open_portal` is *called* from
`add_selected`, not wired via `connect()`, so the check never looked at it. **It now checks every
`self.x(...)` call**, verified by deleting the method and watching it fail. (The first commit here
claimed that and was wrong — I had run the check by hand. The follow-up commit makes it true.)

## `'Layers' object has no attribute 'legend'`

`legend` is on the **vector** and **raster** namespaces, not the kind-agnostic helper. Every layer
*without* a saved default style took that path — which is exactly why "no symbology works", and why
clicking Save on a style made it start working: a saved style is read from the row and never asks
the server.

## Anonymous portals: 403

urllib sends `Python-urllib/3.12` and a Cloudflare-fronted instance refuses it. Measured — same URL:

```
curl default UA   -> 200
browser-like UA   -> 200
Python-urllib UA  -> 403
```

The portal was public all along; the client looked suspicious. It now sends the same agent as the
API client.

## Symbols far too big

QGIS measures in **millimetres** by default, so a GeoDeploy radius of 5 (pixels) became a 10 mm
marker — roughly four times too large. Sizes are declared in pixels now, which also removes the
divide-by-four line-width fudge that was only right at one DPI.

## Rasters: two faults

- An **XYZ layer has no extent**, so "zoom to layer" flew to the whole world and landed on whatever
  else was open. It now carries the layer's real bounds, transformed into the layer's CRS.
- The provider URI is built by **`QgsDataSourceUri`** instead of by hand. The tile endpoint provably
  returns imagery (a real 1793-byte PNG over the raster), so our own percent-encoding of a URL that
  itself contains `?url=…&rescale=…` was the only untested step left.

## Choosing what to upload

Selecting several layers sent all of them, and a basemap only announced itself as an error
afterwards. The list is shown first — sendable ones ticked, the rest greyed out **with the reason**.
`export.check` answers that without exporting a 2 GB GeoPackage to find out.

## A portal published from QGIS gets a card image

The dashboard captures its own map at publish time, so a portal created anywhere else looked
unfinished wherever portals are listed. Captured on the GUI thread before the task starts (a canvas
cannot be touched from a worker, and it is showing exactly what is being published), uploaded with
the rest, and never fatal — a missing picture is not a failed publish.