### PR TITLE
fix(qgis): the fast surface by default, public portals that actually open

### DIFF
--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -69,6 +69,25 @@ class Instance:
                 pass
         return (self.client.catalog.public() or {}).get("portals") or []
 
+    def fetch_json(self, url: str) -> dict:
+        """GET any URL on this instance as JSON, with the token when there is one.
+
+        The layer surfaces (TileJSON, WMTS, legends) are ordinary URLs rather than client methods,
+        and a private layer's are behind the credential — so this carries it, and the same
+        User-Agent as everything else.
+        """
+        import json
+        from urllib.request import Request, urlopen
+
+        headers = {"User-Agent": self._c_user_agent(), "Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = "Bearer {0}".format(self.token)
+        try:
+            with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
+                return json.loads(response.read().decode("utf-8"))
+        except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
+            raise GeoDeployError("Could not read {0}: {1}".format(url, exc))
+
     def published_style(self, slug: str) -> dict:
         """A published portal's own style.json — served to anyone, no credential involved.
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -15,7 +15,7 @@ import os
 import shutil
 
 from qgis.core import (Qgis, QgsApplication, QgsProject, QgsRasterLayer, QgsTask,
-                       QgsVectorLayer)
+                       QgsVectorLayer, QgsVectorTileLayer)
 from qgis.PyQt.QtCore import Qt, pyqtSignal
 from qgis.PyQt.QtWidgets import (QAbstractItemView, QAction, QCheckBox, QComboBox, QDockWidget,
                                  QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar,
@@ -48,7 +48,7 @@ class _Job(QgsTask):
         return False
 
 
-def _xyz_uri(tile_url: str) -> str | None:
+def _xyz_uri(tile_url: str, zmin=None, zmax=None) -> str | None:
     """An XYZ provider URI built by QGIS itself.
 
     `QgsDataSourceUri` owns the escaping rules, and ours has to survive a template whose own query
@@ -60,8 +60,8 @@ def _xyz_uri(tile_url: str) -> str | None:
         uri = QgsDataSourceUri()
         uri.setParam("type", "xyz")
         uri.setParam("url", tile_url)
-        uri.setParam("zmin", "0")
-        uri.setParam("zmax", "22")
+        uri.setParam("zmin", str(int(zmin)) if zmin is not None else "0")
+        uri.setParam("zmax", str(int(zmax)) if zmax is not None else "22")
         return bytes(uri.encodedUri()).decode("utf-8")
     except Exception:                   # noqa: BLE001 - fall back to the hand-built string
         return None
@@ -155,6 +155,13 @@ class GeoDeployDock(QDockWidget):
             "rest still go.")
         self.upload_btn.clicked.connect(self.upload_active)
         outer.addWidget(self.upload_btn)
+
+        self.save_style_btn = QPushButton("Save styling to GeoDeploy")
+        self.save_style_btn.setToolTip(
+            "Send the selected layer's CURRENT QGIS styling to the layer it came from, as its "
+            "default style. No re-upload — the data is already there.")
+        self.save_style_btn.clicked.connect(self.save_style)
+        outer.addWidget(self.save_style_btn)
 
         self.push_style = QCheckBox("Send its styling too")
         self.push_style.setChecked(True)
@@ -375,7 +382,12 @@ class GeoDeployDock(QDockWidget):
             parent.setExpanded(True)
             for portal in self._portals:
                 slug = portal.get("slug") or ""
+                # A portal in the PUBLIC index is published by definition — that is what being
+                # in it means. The anonymous listing has no `published` field, so reading one gave
+                # every public portal the word "draft".
                 published = portal.get("is_published", portal.get("published"))
+                if published is None:
+                    published = bool(portal.get("published_at") or portal.get("url"))
                 item = QTreeWidgetItem(parent, [
                     portal.get("title") or portal.get("name") or slug,
                     portal.get("experience") or portal.get("archetype") or "portal",
@@ -455,7 +467,23 @@ class GeoDeployDock(QDockWidget):
         The tag is what makes the portal round trip safe: a group pushed back has to know WHICH
         layer each entry is, and matching by name would break the first time someone renames one.
         """
-        if source["kind"] in ("cog", "xyz"):
+        if source["kind"] == "vector-tiles":
+            uri = _xyz_uri(source["uri"])
+            layer = QgsVectorTileLayer(uri, name) if uri else None
+            if layer is None or not layer.isValid():
+                return None
+            # A vector tile layer is not a feature layer: QGIS renders it through a different
+            # renderer entirely, so `apply_to_qgis` cannot style it. Give it the layer's own colour
+            # at least, rather than QGIS's random one, and say what was not applied.
+            symbology.apply_to_vector_tiles(layer, row, source.get("source_layer"))
+            if self.instance:
+                portal_sync.tag_layer(layer, self.instance.url, row.get("id"), "vector")
+            return layer
+        if source["kind"] == "tilejson":
+            layer = self._raster_from_tilejson(source["tilejson_url"], name)
+            if layer is None:
+                return None
+        elif source["kind"] in ("cog", "xyz"):
             uri = source["uri"]
             if source["kind"] == "xyz" and source.get("tile_url"):
                 uri = _xyz_uri(source["tile_url"]) or uri
@@ -475,6 +503,57 @@ class GeoDeployDock(QDockWidget):
                          or row.get("storage_backend") == "raster")
             portal_sync.tag_layer(layer, self.instance.url, row.get("id"),
                                   "raster" if is_raster else "vector")
+        return layer
+
+    def _layer_from_portal_source(self, cfg, name):
+        """One layer built from the source the PORTAL draws it from."""
+        src = cfg.get("source") or {}
+        kind, url = src.get("kind"), (src.get("url") or "").strip()
+        if not kind or not url:
+            return None
+        try:
+            if kind == "raster-xyz":
+                uri = _xyz_uri(url)
+                layer = QgsRasterLayer(uri, name, "wms") if uri else None
+            elif kind == "pmtiles":
+                layer = QgsVectorLayer("/vsicurl/" + url, name, "ogr")
+            elif kind == "vector-tiles":
+                uri = _xyz_uri(url)
+                layer = QgsVectorTileLayer(uri, name) if uri else None
+            else:
+                return None
+        except Exception as exc:        # noqa: BLE001 - one layer must not stop the group
+            symbology._log("Could not build {0} from the portal's source: {1}".format(name, exc))
+            return None
+        if layer is None or not layer.isValid():
+            return None
+        if self.instance:
+            portal_sync.tag_layer(layer, self.instance.url, cfg.get("layer_id"),
+                                  cfg.get("layer_type") or "vector")
+        return layer
+
+    def _raster_from_tilejson(self, url, name):
+        """A styled raster layer from the instance's TileJSON: template, zooms and bounds.
+
+        Everything a tile layer is missing comes from this one document — which is why the server
+        publishes it and labels it for QGIS. Nothing here is derived: the template is the server's,
+        and so are the bounds that make "zoom to layer" land on the data.
+        """
+        try:
+            doc = self.instance.fetch_json(url) if self.instance else None
+        except GeoDeployError as exc:
+            symbology._log("Could not read the raster's TileJSON: {0}".format(exc))
+            return None
+        tiles = (doc or {}).get("tiles") or []
+        if not tiles:
+            return None
+        uri = _xyz_uri(tiles[0], doc.get("minzoom"), doc.get("maxzoom"))
+        if not uri:
+            return None
+        layer = QgsRasterLayer(uri, name, "wms")
+        if not layer.isValid():
+            return None
+        self._set_raster_extent(layer, doc.get("bounds"))
         return layer
 
     @staticmethod
@@ -582,18 +661,21 @@ class GeoDeployDock(QDockWidget):
                 cfg = by_key.get(key)
                 if cfg is None:
                     continue
+                label = str(cfg.get("name") or cfg.get("layer_id"))
                 layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
-                if layer_row is None:
-                    missing.append(str(cfg.get("name") or cfg.get("layer_id")))
-                    continue
-                source = sources.describe(layer_row,
-                                          prefer_attributes=self.attributes.isChecked())
-                if not source:
-                    missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
-                    continue
-                layer = self._build_layer(layer_row, source, layer_row.get("name") or "layer")
+                if layer_row is not None:
+                    source = sources.describe(layer_row,
+                                              prefer_attributes=self.attributes.isChecked())
+                    layer = (self._build_layer(layer_row, source,
+                                               layer_row.get("name") or "layer")
+                             if source else None)
+                else:
+                    # Not in the listing: a layer that is not itself published, on a portal that
+                    # is. The portal's own style says where it draws from, and that source is
+                    # readable by anyone who can read the portal — which is the whole point.
+                    layer = self._layer_from_portal_source(cfg, label)
                 if layer is None:
-                    missing.append(str(layer_row.get("name") or cfg.get("layer_id")))
+                    missing.append(label)
                     continue
                 project.addMapLayer(layer, False)   # False: placed into the group, not the root
                 tree_node = parent.addLayer(layer)
@@ -758,12 +840,17 @@ class GeoDeployDock(QDockWidget):
 
     def _open_portal(self, row):
         """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
-        base = (row.get("_base") or "").rstrip("/")
-        slug = row.get("slug") or ""
-        if not base or not slug:
-            self._say("That portal has no address yet — publish it first.", Qgis.Warning)
-            return
-        url = f"{base}/p/{slug}"
+        # The instance publishes the portal's OWN url; `/p/<slug>` was a guess, and it lands on
+        # the dashboard's SPA — which sends a signed-out visitor to the login page for a portal
+        # that is public.
+        url = (row.get("url") or "").strip()
+        if not url:
+            base = (row.get("_base") or "").rstrip("/")
+            slug = row.get("slug") or ""
+            if not base or not slug:
+                self._say("That portal has no address yet — publish it first.", Qgis.Warning)
+                return
+            url = f"{base}/portals/{slug}/"
         try:
             from qgis.PyQt.QtCore import QUrl
             from qgis.PyQt.QtGui import QDesktopServices
@@ -771,6 +858,73 @@ class GeoDeployDock(QDockWidget):
             self._say(f"Opened {url} in your browser.")
         except Exception as exc:        # noqa: BLE001 - still give them the address
             self._say(f"Open it at {url} ({exc}).", Qgis.Warning)
+
+    def save_style(self):
+        """Push the selected layer's QGIS styling back as its GeoDeploy default style.
+
+        Restyling a layer you already have should not mean uploading it again. Only layers that
+        CAME from an instance can be saved this way — they carry the id, so there is no guessing
+        which layer on the server is meant.
+        """
+        if not self.instance or not self.instance.token:
+            self._say("Saving a style needs a token with write access.", Qgis.Warning)
+            return
+        view = self.iface.layerTreeView()
+        chosen = [l for l in (view.selectedLayers() if view else []) if l is not None]
+        if not chosen:
+            active = self.iface.activeLayer()
+            chosen = [active] if active is not None else []
+        if not chosen:
+            self._say("Select a layer that came from this instance.", Qgis.Warning)
+            return
+
+        jobs, skipped = [], []
+        for layer in chosen:
+            identity = portal_sync.layer_identity(layer)
+            if identity is None:
+                skipped.append(layer.name())
+                continue
+            layer_id, kind = identity
+            style = (symbology.raster_from_qgis(layer, self._colormaps()) if kind == "raster"
+                     else symbology.from_qgis(layer))
+            if not style:
+                skipped.append("{0} (nothing translatable)".format(layer.name()))
+                continue
+            jobs.append((layer.name(), layer_id, kind, style))
+
+        if not jobs:
+            self._say("Nothing to save: " + (", ".join(skipped) or "no layer from this instance") +
+                      ". A layer must have been ADDED from GeoDeploy to be saved back to it.",
+                      Qgis.Warning)
+            return
+
+        client = self.instance.client
+
+        def work():
+            saved = []
+            for name, layer_id, kind, style in jobs:
+                body = (dict(style, opacity=1.0) if kind == "raster"
+                        else {"opacity": 1.0, "style": style, "popup_fields": []})
+                client.layers.api(kind).set_default_style(layer_id, body)
+                saved.append(name)
+            return {"saved": saved, "skipped": skipped}
+
+        self._busy(True)
+        self._say("Saving styling for {0} layer(s)…".format(len(jobs)), bar=False)
+        self._run(_Job("GeoDeploy: saving style", work), self._style_saved)
+
+    def _style_saved(self, job):
+        self._busy(False)
+        if job.error:
+            self._say(job.error, Qgis.Critical)
+            return
+        result = job.result or {}
+        saved, skipped = result.get("saved") or [], result.get("skipped") or []
+        note = " Skipped: " + ", ".join(skipped[:3]) + "." if skipped else ""
+        self._say("Saved styling for " + ", ".join(saved[:3]) +
+                  (" and {0} more".format(len(saved) - 3) if len(saved) > 3 else "") + "." + note,
+                  Qgis.Warning if skipped else Qgis.Info)
+        self.refresh_layers()
 
     def upload_active(self):
         if not self.instance:

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -136,9 +136,41 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
             "opacity": meta.get("geodeploy:opacity", 1.0),
             "style": style_from_legend(legend) or {},
             "popup_fields": [],
+            # WHERE THE DATA COMES FROM, taken from the portal's own style.
+            #
+            # A public portal may include layers that are not themselves published — that is a
+            # normal thing to do, and the portal serves them because the PORTAL is public. Looking
+            # each one up in the public layer index therefore found nothing and the group opened
+            # empty. The style already names the source the portal itself draws from, and it is
+            # readable by anyone who can read the portal.
+            "source": _source_of(style_doc, ml),
         })
     configs.reverse()
     return configs
+
+
+def _source_of(style_doc: dict, ml_layer: dict):
+    """`{kind, url, source_layer}` for one baked layer, or None.
+
+    Only the shapes the generator actually emits: PMTiles for a tiled GeoParquet layer, an XYZ
+    template for PostGIS vector tiles and for rasters.
+    """
+    src_id = ml_layer.get("source")
+    src = ((style_doc.get("sources") or {}).get(src_id) or {}) if src_id else {}
+    if not src:
+        return None
+    url = (src.get("url") or "").strip()
+    tiles = src.get("tiles") or []
+    if src.get("type") == "vector":
+        if url.startswith("pmtiles://"):
+            return {"kind": "pmtiles", "url": url[len("pmtiles://"):],
+                    "source_layer": ml_layer.get("source-layer")}
+        if tiles:
+            return {"kind": "vector-tiles", "url": tiles[0],
+                    "source_layer": ml_layer.get("source-layer")}
+    if src.get("type") == "raster" and tiles:
+        return {"kind": "raster-xyz", "url": tiles[0], "source_layer": None}
+    return None
 
 
 def _mode_of(meta: dict) -> str:

--- a/integrations/qgis-plugin/geodeploy_qgis/sources.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/sources.py
@@ -5,8 +5,12 @@ A GeoDeploy layer is published through several surfaces at once, and they are no
 * **PMTiles** is one pre-generalized archive, opened through the ordinary vector-layer path on
   GDAL 3.8+ (with `/vsicurl/` — see below). Geometry is generalized per zoom, features are clipped
   to tile boundaries, and attributes are only what the tiles carry.
+* **Vector tiles (MVT)** are the fast way to DRAW a PostGIS layer: generalized per zoom, cut
+  server-side, fetched for the viewport. A 350k-feature road layer draws like a small one.
 * **OGC API - Features** is the DATA: full attributes, exact geometry. QGIS has read it natively
   since 3.16, and its provider is VIEWPORT-DRIVEN — it asks the server for the extent on screen.
+  Correct and complete, and slow enough on a large layer to read as broken — which is why it is no
+  longer the default.
 * **COG** is a raster's real pixel values, read by range request through `/vsicurl/` — and
   rendered by QGIS's own defaults, NOT by GeoDeploy's styling.
 * **Raster tiles** are the same raster as the portal draws it: colormap, stretch and band choice
@@ -45,6 +49,18 @@ def gdal_supports_pmtiles() -> bool:
     return version >= _PMTILES_MIN_GDAL
 
 
+def _link(layer: dict, link_id: str) -> str | None:
+    """A URL from the layer's own `links` list, which the public index provides.
+
+    Asking the instance beats deriving: it knows which surfaces it actually serves, and the list is
+    the same one the share-links dialog shows a human.
+    """
+    for link in (layer.get("links") or []):
+        if isinstance(link, dict) and link.get("id") == link_id and link.get("url"):
+            return str(link["url"])
+    return None
+
+
 def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
     """`{kind, uri, provider, why}` for the best source, or None when there is nothing to add.
 
@@ -67,6 +83,21 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
         #
         # Neither is "correct", so the same switch that chooses attributes over speed for a vector
         # chooses values over appearance here.
+        # THE SERVER PUBLISHES A TILEJSON FOR EXACTLY THIS, and its own hint says why: it "carries
+        # the tile template AND the layer bounds, so 'zoom to layer' works (a bare XYZ URL has no
+        # bounds)". Both problems this path had, answered by the instance rather than by us.
+        #
+        # It is also the only styled source an ANONYMOUS caller can use: the public index omits
+        # `tile_url`, so without this a public raster fell back to the COG and arrived unstyled.
+        tilejson = _link(layer, "tilejson") or f"{base}/api/data/raster/{ref}/tilejson"
+        if tilejson and not prefer_attributes:
+            return {
+                "kind": "tilejson",
+                "tilejson_url": tilejson,
+                "provider": "wms",
+                "why": "server-rendered tiles, coloured exactly as GeoDeploy draws it",
+            }
+
         tiles = (layer.get("tile_url") or "").strip()
         if tiles and not prefer_attributes:
             # Relative to the instance (that is how the API returns it), and QGIS's XYZ provider
@@ -91,7 +122,12 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
                     "defaults rather than GeoDeploy's styling"),
         }
 
-    tiled = bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready"
+    # A tiled layer says so in three different ways depending on who is asking: the authenticated
+    # row carries `pmtiles_key`/`tile_status`, and the PUBLIC index carries neither — it advertises
+    # the archive as a link instead. Checking only the fields meant an anonymous caller silently
+    # got the slow path for a layer that had been tiled precisely to be fast.
+    pmtiles_link = _link(layer, "pmtiles")
+    tiled = bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready" or bool(pmtiles_link)
     if tiled and not prefer_attributes and gdal_supports_pmtiles():
         return {
             "kind": "pmtiles",
@@ -99,19 +135,50 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
             # on disk and fails with "does not exist in the file system" — it says so itself, and
             # suggests this prefix. It is also what QGIS's own Add Vector Layer builds when you give
             # it an HTTP(S) source, which is why adding one by hand worked where this did not.
-            "uri": f"/vsicurl/{base}/api/data/vector/{ref}/pmtiles",
+            "uri": "/vsicurl/" + (pmtiles_link or f"{base}/api/data/vector/{ref}/pmtiles"),
             "provider": "ogr",
             "why": "one pre-generalized archive, read by range request instead of re-queried",
         }
 
+    # POSTGIS: MARTIN'S VECTOR TILES, not OGC API - Features.
+    #
+    # Both are offered; they are not close. Tiles are generalized per zoom, cut server-side and
+    # fetched for the viewport, so a 350k-feature road layer draws as fast as a small one. OAPIF
+    # asks the server for features and pages through them — exact and complete, and slow enough on
+    # a large layer that it reads as broken. Defaulting to the slower one was simply wrong.
+    #
+    # The trade is real and is what the checkbox is for: tiles carry generalized geometry and only
+    # the attributes the tiles hold, so "prefer the real data" still gets OAPIF.
+    mvt = _link(layer, "xyz-mvt")
+    if mvt and not prefer_attributes:
+        return {
+            "kind": "vector-tiles",
+            "uri": mvt,
+            "source_layer": layer.get("source_layer") or _mvt_source_layer(layer),
+            "provider": "vectortile",
+            "why": "vector tiles, generalized per zoom and fetched for the view",
+        }
+
     # OAPIF is addressed by COLLECTION here, not by the service: QGIS's own dialog needs the service
     # and then asks the user to pick, but a URI built in code names the collection directly.
+    why = "full attributes and exact geometry, paged by the server"
+    if not prefer_attributes and (layer.get("storage_backend") == "geoparquet"
+                                  or layer.get("kind") == "vector"):
+        # The one remaining slow default, and it is slow because the layer has no fast surface yet
+        # — not because a faster one was passed over. Say so, since tiling is one click away.
+        why += " — this layer is not tiled, so there is no faster source; tile it in My Data"
     return {
         "kind": "oapif",
         "uri": f"url='{base}/api/ogc' typename='vector-{ref}'",
         "provider": "OAPIF",
-        "why": "full attributes and exact geometry, paged by the server",
+        "why": why,
     }
+
+
+def _mvt_source_layer(layer: dict) -> str | None:
+    """The layer name inside the tiles: Martin names it `<schema>.<table>`."""
+    schema, table = layer.get("schema_name"), layer.get("table_name")
+    return f"{schema}.{table}" if schema and table else None
 
 
 def alternatives(layer: dict) -> list[dict]:

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -82,27 +82,35 @@ def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
     try:
         if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
             expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
-                field, in_lo, in_hi, out_lo * 2, out_hi * 2)
+                field, in_lo, in_hi, out_lo * 2 * CSS_PX_TO_POINTS, out_hi * 2 * CSS_PX_TO_POINTS)
             symbol.setDataDefinedSize(QgsProperty.fromExpression(expr))
         elif isinstance(layer0, QgsSimpleLineSymbolLayer):
             expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
-                field, in_lo, in_hi, out_lo, out_hi)
+                field, in_lo, in_hi, out_lo * CSS_PX_TO_POINTS, out_hi * CSS_PX_TO_POINTS)
             layer0.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeWidth,
                                           QgsProperty.fromExpression(expr))
     except Exception as exc:            # noqa: BLE001 - a size must never stop a layer drawing
         _log("Could not apply size-by-field ({0}): {1}".format(field, exc))
 
 
-def _use_pixels(symbol, layer0) -> None:
-    """Measure this symbol in pixels, which is what GeoDeploy's numbers mean.
+#: GeoDeploy's sizes are CSS pixels — what MapLibre draws with, and device-INDEPENDENT (1/96 inch).
+#: QGIS's "pixels" are RENDER pixels, which on a scaled or high-DPI display are physically smaller,
+#: so the same number came out too small. Points are device-independent too (1/72 inch), so one CSS
+#: pixel is 0.75 pt and the symbol keeps its size on screen wherever it is drawn.
+CSS_PX_TO_POINTS = 0.75
 
-    QGIS defaults to millimetres. A GeoDeploy radius of 5 (px) set as 10 mm draws about four times
-    too large at a normal DPI — the difference between "the same map" and "a map covered in blobs".
-    Both the symbol and its layer are told, because QGIS keeps the unit on each.
+
+def _use_points(symbol, layer0) -> None:
+    """Measure this symbol in POINTS, so it matches the size GeoDeploy draws.
+
+    Millimetres (the QGIS default) made a radius of 5 into a 10 mm marker — roughly four times too
+    big. Render pixels fixed that but went too far the other way on a scaled display, because they
+    are device pixels while GeoDeploy's are CSS pixels. Points are the unit that means the same
+    thing on both sides.
     """
     try:
         from qgis.core import QgsUnitTypes
-        px = QgsUnitTypes.RenderPixels
+        pt = QgsUnitTypes.RenderPoints
     except Exception:                   # noqa: BLE001 - very old QGIS: leave the default
         return
     for target, setter in ((symbol, "setSizeUnit"), (layer0, "setSizeUnit"),
@@ -110,7 +118,7 @@ def _use_pixels(symbol, layer0) -> None:
         fn = getattr(target, setter, None)
         if callable(fn):
             try:
-                fn(px)
+                fn(pt)
             except Exception:           # noqa: BLE001 - not every symbol layer has both
                 pass
 
@@ -138,24 +146,24 @@ def _symbol_for(qgis_layer, color: str | None, style: dict):
                 layer0.setShape(QgsSimpleMarkerSymbolLayer.decodeShape(shape)[0])
             except Exception:           # noqa: BLE001 - shape names shift between QGIS versions
                 pass
-        _use_pixels(symbol, layer0)
+        _use_points(symbol, layer0)
         if style.get("radius"):
             # GeoDeploy's radius is in PIXELS and QGIS's size is a DIAMETER — so double it, and
             # (above) tell QGIS the number is pixels. Without that it is read as millimetres, and a
             # radius of 5 becomes a 10 mm marker: roughly four times too big on screen, which is
             # exactly how it looked.
-            symbol.setSize(float(style["radius"]) * 2)
+            symbol.setSize(float(style["radius"]) * 2 * CSS_PX_TO_POINTS)
         outline = style.get("outline_color")
         if outline and outline != "none":
             layer0.setStrokeColor(QColor(outline))
         elif outline == "none":
             layer0.setStrokeStyle(Qt.NoPen)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
-        _use_pixels(symbol, layer0)
+        _use_points(symbol, layer0)
         if style.get("line_width"):
             # In pixels now (see `_use_pixels`), so the width IS the width — no mm conversion, and
             # no divide-by-four fudge that was only ever right at one screen DPI.
-            layer0.setWidth(float(style["line_width"]))
+            layer0.setWidth(float(style["line_width"]) * CSS_PX_TO_POINTS)
         dash = (style.get("lineType") or "solid").lower()
         if dash == "dashed":
             layer0.setPenStyle(Qt.DashLine)
@@ -306,6 +314,62 @@ def _hex(color) -> str:
 #: request, so the ceiling is set by what a proxy accepts, not by taste — 128 classes is ~5 kB,
 #: against nginx's default 8 kB request line.
 MAX_COLOR_CLASSES = 128
+
+
+def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None) -> bool:
+    """Colour a vector TILE layer with the layer's own colour.
+
+    QGIS renders vector tiles through `QgsVectorTileBasicRenderer`, which takes styles per geometry
+    type rather than a feature renderer — so the classified symbology `apply_to_qgis` builds does
+    not apply here. This is the honest subset: the right colour and the right geometry, instead of
+    whichever colour QGIS picked at random.
+
+    Anything richer needs the feature data, which is what "prefer the real data" is for.
+    """
+    if not QGIS:
+        return False
+    try:
+        from qgis.core import (QgsVectorTileBasicRenderer, QgsVectorTileBasicRendererStyle,
+                               QgsSymbol, QgsWkbTypes)
+        from qgis.PyQt.QtGui import QColor
+    except ImportError:                 # pragma: no cover - older QGIS
+        return False
+
+    style = ((row.get("default_style") or {}).get("style")
+             if isinstance(row.get("default_style"), dict) else {}) or {}
+    colour = QColor(style.get("color") or "#3b82f6")
+    geom = (row.get("geometry_type") or "").lower()
+    if "polygon" in geom:
+        kinds = [(QgsWkbTypes.PolygonGeometry, QgsSymbol.Fill)]
+    elif "line" in geom:
+        kinds = [(QgsWkbTypes.LineGeometry, QgsSymbol.Line)]
+    else:
+        kinds = [(QgsWkbTypes.PointGeometry, QgsSymbol.Marker)]
+
+    try:
+        styles = []
+        for geometry_type, symbol_type in kinds:
+            symbol = QgsSymbol.defaultSymbol(geometry_type)
+            if symbol is None:
+                continue
+            symbol.setColor(colour)
+            entry = QgsVectorTileBasicRendererStyle("geodeploy", source_layer or "", geometry_type)
+            entry.setSymbol(symbol)
+            entry.setEnabled(True)
+            styles.append(entry)
+        if not styles:
+            return False
+        renderer = QgsVectorTileBasicRenderer()
+        renderer.setStyles(styles)
+        tile_layer.setRenderer(renderer)
+        tile_layer.triggerRepaint()
+        if style.get("color_mode") in ("graduated", "categorized"):
+            _log("Drawn as vector tiles for speed, so only the base colour was applied. Tick "
+                 "'Prefer the real data' to get the full classified symbology.")
+        return True
+    except Exception as exc:            # noqa: BLE001 - never stop a layer loading over a colour
+        _log("Could not style the vector tiles: {0}".format(exc))
+        return False
 
 
 def raster_from_qgis(qgis_layer, colormaps=None) -> dict:

--- a/integrations/qgis-plugin/scripts/smoke.py
+++ b/integrations/qgis-plugin/scripts/smoke.py
@@ -53,6 +53,11 @@ def _stub_qgis():
             return _Any()
 
     for name in ("Qgis", "QgsApplication", "QgsProject", "QgsRasterLayer", "QgsVectorLayer",
+                 "QgsVectorTileLayer", "QgsDataSourceUri", "QgsUnitTypes",
+                 "QgsVectorTileBasicRenderer", "QgsVectorTileBasicRendererStyle",
+                 "QgsWkbTypes",
+                 "QgsCoordinateReferenceSystem", "QgsCoordinateTransform",
+                 "QgsRectangle",
                  "QgsCategorizedSymbolRenderer", "QgsGraduatedSymbolRenderer", "QgsRendererCategory",
                  "QgsRendererRange", "QgsSimpleFillSymbolLayer", "QgsSimpleLineSymbolLayer",
                  "QgsSimpleMarkerSymbolLayer", "QgsSymbol", "QgsSingleSymbolRenderer",


### PR DESCRIPTION
## Speed was the default nobody chose

A PostGIS layer was added as **OGC API - Features** — the slowest thing the instance offers — while
that same instance publishes `xyz-mvt` and a TileJSON labelled *"vector tiles (fast rendering)"*.

Worse: **a tiled GeoParquet layer fell back to OAPIF for anyone not signed in.** The authenticated
row carries `pmtiles_key`/`tile_status`; the public index carries neither and advertises the archive
as a **link**. So a layer tiled precisely to be fast was served the slow way to exactly the visitors
it was tiled for.

Where each backend lands now — confirmed against the live instance:

| layer | source |
|---|---|
| GeoParquet, tiled | **PMTiles** (authenticated *and* anonymous) |
| PostGIS | **vector tiles (MVT)** |
| raster | **XYZ from TileJSON** |
| GeoParquet, not tiled | OAPIF — and it says *"tile it in My Data"*, because nothing faster exists yet |
| anything, *"prefer the real data"* | OAPIF / the COG |

Sources come from each layer's own `links` now, which is what the instance actually serves rather
than a URL we guess.

## Rasters take the TileJSON

Whose own hint states the problem it solves: it *"carries the tile template AND the layer bounds, so
'zoom to layer' works (a bare XYZ URL has no bounds)"*. Both faults answered by the server rather
than by us — and it is the only styled raster source an anonymous caller has, since the public index
omits `tile_url`.

## Portals

- **They opened the login page.** `/p/<slug>` was a guess and lands on the dashboard SPA, which
  bounces a signed-out visitor to `/login` — for a portal that is public. The index publishes each
  portal's own `url`.
- **Public portals said "draft"** — the anonymous listing has no `published` field. Being in the
  public index *is* being published.
- **A public portal's layers now open anonymously.** They were looked up in the public *layer*
  index, but a public portal may include layers that are not themselves published — normal, and the
  portal serves them because the portal is public. Each config carries the source the portal itself
  draws from.

## Sizes are in points

Millimetres (the QGIS default) made a radius of 5 into a 10 mm marker, ~4× too big. Render pixels
overshot the other way: those are *device* pixels, GeoDeploy's are *CSS* pixels. Points are
device-independent on both sides — 1 CSS px = 0.75 pt.

## Restyling without re-uploading

**"Save styling to GeoDeploy"** pushes the selected layer's current QGIS renderer as its default
style. Only layers added *from* an instance can be saved back, because only those carry the id.

## Known trade

A vector **tile** layer is rendered by a different QGIS renderer, so classified symbology cannot
apply to it. It gets the layer's own colour instead of a random one, and says plainly that the full
symbology needs *"prefer the real data"*.