### PR TITLE
fix(qgis): rasters over WMTS, and portal tile URLs that have a host

### DIFF
--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -88,6 +88,19 @@ class Instance:
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
             raise GeoDeployError("Could not read {0}: {1}".format(url, exc))
 
+    def fetch_text(self, url: str) -> str:
+        """GET a URL on this instance as text — WMTS capabilities are XML, not JSON."""
+        from urllib.request import Request, urlopen
+
+        headers = {"User-Agent": self._c_user_agent(), "Accept": "application/xml, text/xml, */*"}
+        if self.token:
+            headers["Authorization"] = "Bearer {0}".format(self.token)
+        try:
+            with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
+                return response.read().decode("utf-8", "replace")
+        except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
+            raise GeoDeployError("Could not read {0}: {1}".format(url, exc))
+
     def published_style(self, slug: str) -> dict:
         """A published portal's own style.json — served to anyone, no credential involved.
 

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -479,7 +479,17 @@ class GeoDeployDock(QDockWidget):
             if self.instance:
                 portal_sync.tag_layer(layer, self.instance.url, row.get("id"), "vector")
             return layer
-        if source["kind"] == "tilejson":
+        if source["kind"] == "wmts":
+            layer = self._raster_from_wmts(source["wmts_url"], name)
+            if layer is None:
+                # Fall back rather than fail: a bare tile template still draws, it just asks for
+                # tiles that do not exist at low zoom.
+                tj = source.get("tilejson_url") or (
+                    source["wmts_url"].rsplit("/", 1)[0] + "/tilejson")
+                layer = self._raster_from_tilejson(tj, name)
+            if layer is None:
+                return None
+        elif source["kind"] == "tilejson":
             layer = self._raster_from_tilejson(source["tilejson_url"], name)
             if layer is None:
                 return None
@@ -511,6 +521,12 @@ class GeoDeployDock(QDockWidget):
         kind, url = src.get("kind"), (src.get("url") or "").strip()
         if not kind or not url:
             return None
+        # A portal's style.json stores tile URLs RELATIVE ("/raster/cog/tiles/…") because the portal
+        # page resolves them against its own origin. QGIS has no such origin, so every tile request
+        # went out hostless and failed three times over — which is what filled the log with retries
+        # while the layer showed nothing.
+        if url.startswith("/") and self.instance:
+            url = self.instance.url.rstrip("/") + url
         try:
             if kind == "raster-xyz":
                 uri = _xyz_uri(url)
@@ -531,6 +547,50 @@ class GeoDeployDock(QDockWidget):
             portal_sync.tag_layer(layer, self.instance.url, cfg.get("layer_id"),
                                   cfg.get("layer_type") or "vector")
         return layer
+
+    def _raster_from_wmts(self, url, name):
+        """A raster layer from the instance's WMTS capabilities.
+
+        Read rather than assumed: the document names the layer identifier, its style, its format
+        and its tile matrix set, and QGIS needs all four in the URI. Guessing any of them produces
+        a layer that looks valid and draws nothing.
+        """
+        try:
+            import xml.etree.ElementTree as ET
+            from qgis.core import QgsDataSourceUri
+
+            text = self.instance.fetch_text(url) if self.instance else None
+            if not text:
+                return None
+            root = ET.fromstring(text)
+            ns = {"wmts": "http://www.opengis.net/wmts/1.0",
+                  "ows": "http://www.opengis.net/ows/1.1"}
+            node = root.find(".//wmts:Contents/wmts:Layer", ns)
+            if node is None:
+                return None
+            identifier = node.findtext("ows:Identifier", default="", namespaces=ns).strip()
+            matrix = node.findtext(".//wmts:TileMatrixSetLink/wmts:TileMatrixSet",
+                                   default="WebMercatorQuad", namespaces=ns).strip()
+            fmt = (node.findtext("wmts:Format", default="image/png", namespaces=ns) or "").strip()
+            style = node.findtext(".//wmts:Style/ows:Identifier", default="default",
+                                  namespaces=ns).strip()
+            if not identifier:
+                return None
+
+            uri = QgsDataSourceUri()
+            uri.setParam("url", url)
+            uri.setParam("layers", identifier)
+            uri.setParam("styles", style or "default")
+            uri.setParam("format", fmt or "image/png")
+            uri.setParam("tileMatrixSet", matrix or "WebMercatorQuad")
+            uri.setParam("crs", "EPSG:3857")
+            # 7 = "use the server's own DPI handling", which is what QGIS's own WMTS dialog sets.
+            uri.setParam("dpiMode", "7")
+            built = QgsRasterLayer(bytes(uri.encodedUri()).decode("utf-8"), name, "wms")
+            return built if built.isValid() else None
+        except Exception as exc:        # noqa: BLE001 - fall back to the tile template
+            symbology._log("Could not read the raster's WMTS: {0}".format(exc))
+            return None
 
     def _raster_from_tilejson(self, url, name):
         """A styled raster layer from the instance's TileJSON: template, zooms and bounds.

--- a/integrations/qgis-plugin/geodeploy_qgis/sources.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/sources.py
@@ -89,6 +89,21 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
         #
         # It is also the only styled source an ANONYMOUS caller can use: the public index omits
         # `tile_url`, so without this a public raster fell back to the COG and arrived unstyled.
+        # WMTS FIRST, because QGIS speaks it natively and the instance labels the link "for QGIS".
+        #
+        # An XYZ layer is a bare tile template: QGIS knows no extent and no zoom range, so it asks
+        # for z0/z1/z2 tiles that miss the raster entirely, retries each three times, and fills the
+        # log with failures while showing nothing. The WMTS capabilities carry the layer's
+        # WGS84BoundingBox and its tile matrix set, so QGIS asks only for tiles that exist.
+        wmts = _link(layer, "wmts") or f"{base}/api/data/raster/{ref}/wmts"
+        if wmts and not prefer_attributes:
+            return {
+                "kind": "wmts",
+                "wmts_url": wmts,
+                "provider": "wms",      # WMTS is served through the WMS provider
+                "why": "server-rendered tiles with the layer's own bounds, coloured as GeoDeploy draws it",
+            }
+
         tilejson = _link(layer, "tilejson") or f"{base}/api/data/raster/{ref}/tilejson"
         if tilejson and not prefer_attributes:
             return {


### PR DESCRIPTION
## The hostless tile URL

A portal's `style.json` stores raster tiles **relative** (`/raster/cog/tiles/…`) because the portal
page resolves them against its own origin. QGIS has no such origin, so every request went out
without a host and failed three times over:

```
Tile request max retry error … (url: /raster/cog/tiles/WebMercatorQuad/0/0/0?url=s3://…)
```

Resolved against the instance now.

## Rasters go over WMTS

Which is what the instance labels the link for — *"WMTS — for QGIS"*. An XYZ layer is a bare tile
template: QGIS knows no extent and no zoom range, so it asks for z0/z1/z2 tiles that miss the raster
entirely, retries each three times, and reports failures while drawing nothing.

The capabilities carry the layer's `WGS84BoundingBox` and its tile matrix set, so QGIS asks only for
tiles that exist — and "zoom to layer" lands on the data.

The document is **read, not assumed** — it names the identifier, style, format and matrix set, and
QGIS needs all four. Verified against the live instance:

```
identifier : 2          style : default
format     : image/png  matrix: WebMercatorQuad
bbox       : present
```

TileJSON remains the fallback.

## What "fast" actually is here

Measured against the instance:

| source | |
|---|---|
| MVT tile | 0.25 – 0.49 s |
| raster tile (styled) | 1.48 s |
| **OAPIF, one page** | **5.6 s for 6.4 MB** |

OAPIF is an order of magnitude slower per request and needs many of them — which is what a
`Bad Gateway` on `/items?limit=100` looks like from the other side. It is the right surface for
exact geometry and full attributes, and the wrong one to have had as a default.