### PR TITLE
Serve tiled layers a tile at a time, and let vector tiles carry their symbology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,16 @@ jobs:
         # is CONSTRUCTED. This builds the dock and checks every signal target exists.
         run: python integrations/qgis-plugin/scripts/smoke.py
 
+      - name: Vector-tile symbology really classifies
+        # A tile layer that arrives in the right colour and nothing else looks styled and is not.
+        # QGIS is not installable here, so this stubs the tile renderer and asserts on the filter
+        # expressions handed to it — including the two edges that silently drop features, an open
+        # outer bound and an inclusive top break.
+        run: python integrations/qgis-plugin/scripts/test_tile_symbology.py
+
+      - name: The plugin picks the fast source, and degrades when it is absent
+        run: python integrations/qgis-plugin/scripts/test_sources.py
+
       - name: metadata.txt has what plugins.qgis.org requires
         run: |
           python - <<'PY'

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -311,6 +311,16 @@ deliberately NOT visibility-filtered (published portals depend on them).
 - No rate limiting beyond nginx; no pagination on list endpoints (fine at current scale).
 
 ## Last updated
+2026-08-17 (`data/vector.py`: **`GET /{ref}/tiles/{z}/{x}/{y}`** — public XYZ vector tiles for a tiled
+GeoParquet layer, read a tile at a time from its PMTiles archive via `services/pmtiles_reader`. Same
+public terms as `/pmtiles` and Martin's `/tiles/` (a published portal is unauthenticated). **204, not
+404, for a tile the archive lacks** — sparse is normal and a 404 invites client retries. `vector_tilejson`
+now also serves **file-backed layers**, reading minzoom/maxzoom/bounds/layer-name from the archive
+header + metadata instead of guessing; and the PostGIS branch declares **`maxzoom: 18`, not 22** —
+Martin answers at any zoom, but a client that believes tiles exist at z22 fetches a fresh empty tile
+at every step past the real detail instead of over-zooming the last good one. Nothing in the UI,
+templates or `portal_generator` consumes this TileJSON — it is interop-only, so the portals are
+unaffected.)
 2026-08-12 (`public.py` — the anonymous instance index, with the admin toggle; `data/exports.py` —
 whole-layer and clipped downloads for both layer kinds. Both added to `main.py`'s `_PUBLIC_CORS`.)
 2026-08-07b (`portals.py`: **SVG accepted for portal assets** — a raster logo goes soft on any retina

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -655,14 +655,10 @@ async def vector_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
     layer = result.scalar_one_or_none()
     if not await _publicly_readable(layer, db):
         raise HTTPException(404, "Layer not found.")
-    if getattr(layer, "storage_backend", "postgis") != "postgis":
-        raise HTTPException(404, "No vector-tile TileJSON for this layer (file-backed — use the "
-                                 "GeoParquet or PMTiles asset).")
 
     proto = request.headers.get("x-forwarded-proto") or request.url.scheme
     host = request.headers.get("host") or request.url.netloc
     base = f"{proto}://{host}"
-    src = f"{layer.schema_name}.{layer.table_name}"
     fields = {}
     if layer.columns:
         try:
@@ -670,13 +666,60 @@ async def vector_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
                 fields[c["name"]] = c.get("type", "String")
         except (ValueError, KeyError, TypeError):
             pass
+
+    if getattr(layer, "storage_backend", "postgis") != "postgis":
+        # A TILED GeoParquet layer has a TileJSON too, pointing at the per-tile reader above. Until
+        # this existed the only vector-tile answer for these layers was "open the whole archive",
+        # which is the slow path this endpoint exists to replace — and the zoom range and bounds
+        # below are read from the archive itself rather than guessed, so a client knows exactly
+        # which tiles are worth asking for.
+        from ...services import pmtiles_reader
+
+        key = await _pmtiles_key(layer_ref, db)
+        if not key:
+            raise HTTPException(404, "No vector-tile TileJSON for this layer — it is file-backed "
+                                     "and not tiled yet. Tile it in My Data, or use the GeoParquet "
+                                     "asset.")
+        try:
+            fetch = _pmtiles_fetch(key)
+            header, _ = await run_in_threadpool(pmtiles_reader.open_archive, key, fetch)
+            meta = await run_in_threadpool(pmtiles_reader.metadata, key, fetch)
+        except Exception as exc:      # noqa: BLE001 - an unreadable archive is a missing TileJSON
+            raise HTTPException(404, f"Tiles unreadable: {exc}")
+        # tippecanoe names the layer inside the tiles; a consumer that guesses it draws nothing.
+        vector_layers = meta.get("vector_layers") or []
+        src = (vector_layers[0].get("id") if vector_layers else None) or "geodeploy"
+        from ...services.share_links import public_ref
+        api = f"{base}/api/data/vector/{public_ref(layer)}"
+        tj = {
+            "tilejson": "3.0.0",
+            "name": layer.name,
+            "scheme": "xyz",
+            "tiles": [f"{api}/tiles/{{z}}/{{x}}/{{y}}"],
+            "minzoom": header.min_zoom,
+            "maxzoom": header.max_zoom,
+            "bounds": header.bounds,
+            "center": [(header.min_lon + header.max_lon) / 2,
+                       (header.min_lat + header.max_lat) / 2, 0],
+            "vector_layers": vector_layers or [{"id": src, "fields": fields}],
+        }
+        return SafeJSONResponse(tj, headers={"Access-Control-Allow-Origin": "*",
+                                             "Cache-Control": "public, max-age=300"})
+
+    src = f"{layer.schema_name}.{layer.table_name}"
     tj = {
         "tilejson": "3.0.0",
         "name": layer.name,
         "scheme": "xyz",
         "tiles": [f"{base}/tiles/{src}/{{z}}/{{x}}/{{y}}"],
         "minzoom": 0,
-        "maxzoom": 22,
+        # NOT 22. Martin builds these tiles live from PostGIS, so it will answer at any zoom — but a
+        # client that believes tiles exist at z22 requests a fresh one at every zoom step past the
+        # point where they stop adding detail, and gets an empty tile back. Declaring the depth
+        # where the data is genuinely resolved lets QGIS and MapLibre OVER-ZOOM the last real tile
+        # instead: same picture, no request. Vector tiles scale without pixelating, which is what
+        # makes this safe.
+        "maxzoom": 18,
         "vector_layers": [{"id": src, "fields": fields}],
     }
     bbox = json.loads(layer.bbox) if layer.bbox else None
@@ -1055,6 +1098,62 @@ async def vector_pmtiles(layer_ref: str, request: Request, db: AsyncSession = De
     body = obj["Body"]
     return StreamingResponse(body.iter_chunks(256 * 1024), status_code=status,
                              media_type="application/octet-stream", headers=headers)
+
+
+def _pmtiles_fetch(key: str):
+    """A `fetch(offset, length) -> bytes` over the archive in object storage. SYNCHRONOUS —
+    `pmtiles_reader` is plain code, so the caller runs the whole lookup in a threadpool rather than
+    bouncing between loops for each of its one or two range reads."""
+    settings = get_settings()
+    from ...services.minio import get_s3_client
+    s3 = get_s3_client()
+
+    def fetch(offset: int, length: int) -> bytes:
+        obj = s3.get_object(Bucket=settings.storage_bucket, Key=key,
+                            Range=f"bytes={offset}-{offset + length - 1}")
+        return obj["Body"].read()
+    return fetch
+
+
+@router.get("/{layer_ref}/tiles/{z}/{x}/{y}")
+async def vector_pmtiles_tile(layer_ref: str, z: int, x: int, y: int,
+                              db: AsyncSession = Depends(get_db)):
+    """PUBLIC XYZ vector tiles for a tiled GeoParquet layer, read a tile at a time out of its
+    PMTiles archive.
+
+    THE POINT: a `{z}/{x}/{y}` URL is viewport-driven, and the archive is not. Handed the whole
+    archive, GDAL's PMTiles driver walks every tile at the deepest zoom just to answer "how many
+    features?" — on this project's own instance a FIVE-FEATURE layer tiles to 2.17 million entries,
+    which is why QGIS hung on small layers. Here the client asks for the four tiles under its
+    viewport and the server does one range read each (the header and root directory are cached).
+
+    Same public terms as `/pmtiles` and Martin's `/tiles/` — a published portal is unauthenticated,
+    so its display sources must be too. 204 for a tile the archive does not contain: sparse is
+    normal, and a 404 invites clients to retry.
+    """
+    from ...services import pmtiles_reader
+
+    key = await _pmtiles_key(layer_ref, db)
+    if not key:
+        raise HTTPException(404, "No tiles for this layer.")
+    try:
+        got = await run_in_threadpool(
+            pmtiles_reader.get_tile, key, _pmtiles_fetch(key), z, x, y)
+    except pmtiles_reader.PMTilesError as exc:
+        raise HTTPException(404, f"Tiles unreadable: {exc}")
+    except Exception:
+        # A re-tile repoints the layer at a new key; the cached one 404s at storage. Drop both
+        # caches so the next request re-reads, exactly as `/pmtiles` does.
+        _PMTILES_KEY_CACHE.pop(layer_ref, None)
+        pmtiles_reader.forget(key)
+        raise HTTPException(404, "Tiles not found.")
+
+    headers = {"Access-Control-Allow-Origin": "*",
+               "Cache-Control": "public, max-age=3600"}
+    if got is None:
+        return Response(status_code=204, headers=headers)
+    body, header = got
+    return Response(body, media_type=header.media_type, headers=headers)
 
 
 # layer_id → s3_key prefix for the parquet range proxy. Cached because duckdb-wasm issues MANY

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -131,6 +131,18 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   permalink it serves, never a substitute for the bbox queries.
 
 ## Last updated
+2026-08-17 (**new `pmtiles_reader.py` — one tile out of an archive, so tiled layers can be served as
+ordinary XYZ.** PMTiles v3 read-only, written by hand rather than pulled in as a dependency (fixed
+127-byte header, varint directories, a Hilbert curve, all frozen by the spec). Every read is an HTTP
+Range through a caller-supplied `fetch(offset, length)`; the header + root directory are cached per
+object key, so a tile costs ONE range read in the steady state. `forget(key)` on a re-tile.
+**Why it exists, measured:** GDAL's PMTiles driver is not viewport-driven — it presents the archive
+as one dataset, so a client's opening questions (feature count, extent) walk every tile at the
+deepest zoom. On geodeploy-lite a FIVE-FEATURE layer's archive holds 2,171,238 tile entries across
+z0–13 (tippecanoe's `--extend-zooms-if-still-dropping`), which is why QGIS hung worst on small
+layers. Consumed by `routers/data/vector.py::vector_pmtiles_tile` + `vector_tilejson`.
+`share_links.py`: a tiled GeoParquet layer now leads with **TileJSON**, not the archive — the archive
+link stays, relabelled for MapLibre/GDAL-copy use with a warning against opening it in QGIS.)
 2026-08-07c (**a 504 on one tile hangs the whole portal.** `bounds` stops MapLibre
 asking for tiles that MISS a raster; it does nothing about a tile that HITS it and spans a continent.
 A drone orthomosaic a few hundred metres across was still requested at z3 — one tile covering most of

--- a/api/geodeploy/services/pmtiles_reader.py
+++ b/api/geodeploy/services/pmtiles_reader.py
@@ -1,0 +1,332 @@
+"""Read ONE tile out of a PMTiles archive, so tiled layers can be served as ordinary XYZ.
+
+WHY THIS EXISTS — the measurement that forced it
+------------------------------------------------
+GeoParquet layers are tiled to a single `.pmtiles` archive, and until now the only way to consume
+one outside a browser was to open the whole archive with GDAL's PMTiles driver. That driver is not
+viewport-driven: it presents the archive as an ordinary dataset, so the first thing a desktop GIS
+does — ask for the feature count and the extent — makes it walk every tile at the archive's deepest
+zoom. On this project's own instance, a layer with **five features** produced an archive with
+**2,171,238 tile entries** across zooms 0–13 (tippecanoe's `--extend-zooms-if-still-dropping` keeps
+adding levels), each read over HTTP. That is why QGIS sat "loading forever" and drew nothing, and
+why it did so *worse* on small layers than on big ones.
+
+MapLibre never had this problem because it asks for the four tiles under the viewport and no more.
+This module gives every other client the same deal: a plain `{z}/{x}/{y}` URL.
+
+WHAT IT IMPLEMENTS
+------------------
+PMTiles v3 (https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md), read-only, by hand
+rather than by dependency — it is a fixed 127-byte header, varint directories and a Hilbert curve,
+and the archive format is versioned and frozen. The alternative was another pinned package in the
+API image for ~120 lines of parsing.
+
+Every read is an HTTP Range request through the caller's `fetch(offset, length)`, so nothing is ever
+downloaded whole; a tile costs one directory hop plus one range read, and the header and root
+directory are cached per archive so the steady state is a single read per tile.
+"""
+from __future__ import annotations
+
+import gzip
+import struct
+import zlib
+from dataclasses import dataclass
+
+HEADER_LEN = 127
+_MAGIC = b"PMTiles"
+
+# Compression ids from the spec. 1 = none, 2 = gzip, 3 = brotli, 4 = zstd.
+_NONE, _GZIP, _BROTLI, _ZSTD = 1, 2, 3, 4
+
+# Tile types, used to name the right media type back to the client.
+TILETYPE_MVT, TILETYPE_PNG, TILETYPE_JPEG, TILETYPE_WEBP, TILETYPE_AVIF = 1, 2, 3, 4, 5
+MEDIA_TYPES = {
+    TILETYPE_MVT: "application/vnd.mapbox-vector-tile",
+    TILETYPE_PNG: "image/png",
+    TILETYPE_JPEG: "image/jpeg",
+    TILETYPE_WEBP: "image/webp",
+    TILETYPE_AVIF: "image/avif",
+}
+
+
+class PMTilesError(Exception):
+    """The archive could not be read as PMTiles v3."""
+
+
+@dataclass(frozen=True)
+class Header:
+    root_offset: int
+    root_length: int
+    metadata_offset: int
+    metadata_length: int
+    leaf_offset: int
+    leaf_length: int
+    data_offset: int
+    data_length: int
+    addressed_tiles: int
+    tile_entries: int
+    tile_contents: int
+    clustered: bool
+    internal_compression: int
+    tile_compression: int
+    tile_type: int
+    min_zoom: int
+    max_zoom: int
+    min_lon: float
+    min_lat: float
+    max_lon: float
+    max_lat: float
+
+    @property
+    def bounds(self) -> list[float]:
+        return [self.min_lon, self.min_lat, self.max_lon, self.max_lat]
+
+    @property
+    def media_type(self) -> str:
+        return MEDIA_TYPES.get(self.tile_type, "application/octet-stream")
+
+
+def parse_header(raw: bytes) -> Header:
+    if len(raw) < HEADER_LEN or raw[:7] != _MAGIC:
+        raise PMTilesError("not a PMTiles archive")
+    if raw[7] != 3:
+        raise PMTilesError(f"PMTiles v{raw[7]} is not supported (v3 only)")
+    (root_offset, root_length, meta_offset, meta_length, leaf_offset, leaf_length,
+     data_offset, data_length, addressed, entries, contents) = struct.unpack_from("<11Q", raw, 8)
+    clustered, internal_comp, tile_comp, tile_type, min_zoom, max_zoom = struct.unpack_from(
+        "<6B", raw, 96)
+    min_lon, min_lat, max_lon, max_lat = struct.unpack_from("<4i", raw, 102)
+    return Header(
+        root_offset, root_length, meta_offset, meta_length, leaf_offset, leaf_length,
+        data_offset, data_length, addressed, entries, contents, bool(clustered),
+        internal_comp, tile_comp, tile_type, min_zoom, max_zoom,
+        min_lon / 1e7, min_lat / 1e7, max_lon / 1e7, max_lat / 1e7,
+    )
+
+
+def decompress(raw: bytes, compression: int) -> bytes:
+    """Undo one of the spec's compressions.
+
+    Brotli and zstd are decoded only if the interpreter has a decoder; tippecanoe writes gzip, so
+    the others are a courtesy for archives produced elsewhere and are reported honestly rather than
+    returned as garbage.
+    """
+    if compression in (_NONE, 0):
+        return raw
+    if compression == _GZIP:
+        # `gzip.decompress` rejects a bare deflate stream; some writers emit one. Try both.
+        try:
+            return gzip.decompress(raw)
+        except (OSError, EOFError, zlib.error):
+            return zlib.decompress(raw, -zlib.MAX_WBITS)
+    if compression == _BROTLI:
+        try:
+            import brotli
+        except ImportError:
+            raise PMTilesError("this archive is brotli-compressed and brotli is not installed")
+        return brotli.decompress(raw)
+    if compression == _ZSTD:
+        try:
+            import zstandard
+        except ImportError:
+            raise PMTilesError("this archive is zstd-compressed and zstandard is not installed")
+        return zstandard.ZstdDecompressor().decompress(raw)
+    raise PMTilesError(f"unknown compression {compression}")
+
+
+def _varints(raw: bytes, count: int, pos: int) -> tuple[list[int], int]:
+    """`count` LEB128 varints starting at `pos`, plus the new position."""
+    out = []
+    for _ in range(count):
+        value, shift = 0, 0
+        while True:
+            byte = raw[pos]
+            pos += 1
+            value |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                break
+            shift += 7
+        out.append(value)
+    return out, pos
+
+
+@dataclass(frozen=True)
+class Entry:
+    tile_id: int
+    offset: int
+    length: int
+    run_length: int     # 0 means "this points at a LEAF DIRECTORY, not at a tile"
+
+
+def parse_directory(raw: bytes) -> list[Entry]:
+    """A decompressed directory blob into entries, sorted by tile id (the spec guarantees that).
+
+    The serialization is columnar and delta-coded: all the ids, then all the run lengths, then all
+    the lengths, then all the offsets. An offset of 0 is the spec's "immediately after the previous
+    one" shorthand, which is what makes a clustered archive so compact.
+    """
+    count, pos = _varints(raw, 1, 0)
+    count = count[0]
+    deltas, pos = _varints(raw, count, pos)
+    runs, pos = _varints(raw, count, pos)
+    lengths, pos = _varints(raw, count, pos)
+    raw_offsets, pos = _varints(raw, count, pos)
+
+    entries: list[Entry] = []
+    tile_id = 0
+    for i in range(count):
+        tile_id += deltas[i]
+        if raw_offsets[i] == 0 and i > 0:
+            offset = entries[i - 1].offset + entries[i - 1].length
+        else:
+            offset = raw_offsets[i] - 1
+        entries.append(Entry(tile_id, offset, lengths[i], runs[i]))
+    return entries
+
+
+def zxy_to_tile_id(z: int, x: int, y: int) -> int:
+    """The Hilbert-curve index PMTiles addresses tiles by.
+
+    Zoom levels are laid end to end (all of z0, then all of z1, …) and within a level the tiles
+    follow a Hilbert curve, which is what keeps neighbouring tiles adjacent in the file — the
+    property that makes one range request serve a whole screenful.
+    """
+    if z < 0 or z > 26:
+        raise PMTilesError("zoom out of range")
+    n = 1 << z
+    if x < 0 or y < 0 or x >= n or y >= n:
+        raise PMTilesError("tile outside the zoom level")
+    # Tiles in all levels above this one: 1 + 4 + 16 + … = (4**z - 1) / 3.
+    acc = (n * n - 1) // 3
+    rx = ry = 0
+    d = 0
+    s = n >> 1
+    tx, ty = x, y
+    while s > 0:
+        rx = 1 if (tx & s) > 0 else 0
+        ry = 1 if (ty & s) > 0 else 0
+        d += s * s * ((3 * rx) ^ ry)
+        # Rotate the quadrant so the curve stays continuous.
+        if ry == 0:
+            if rx == 1:
+                tx = s - 1 - tx
+                ty = s - 1 - ty
+            tx, ty = ty, tx
+        s >>= 1
+    return acc + d
+
+
+def find(entries: list[Entry], tile_id: int) -> Entry | None:
+    """The entry covering `tile_id`, honouring RUN LENGTHS.
+
+    A run is how PMTiles stores "these N consecutive tiles are byte-identical" — overwhelmingly
+    common in a sparse archive, where thousands of empty ocean tiles share one blob. Binary search
+    for the last entry at or below the id, then check the run actually reaches it; forgetting that
+    check returns a neighbouring tile's bytes, which renders as data in the wrong place.
+    """
+    lo, hi = 0, len(entries) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if tile_id < entries[mid].tile_id:
+            hi = mid - 1
+        elif tile_id > entries[mid].tile_id:
+            lo = mid + 1
+        else:
+            return entries[mid]
+    if hi < 0:
+        return None
+    entry = entries[hi]
+    if entry.run_length == 0:                       # a leaf pointer covers everything after it
+        return entry
+    if tile_id - entry.tile_id < entry.run_length:
+        return entry
+    return None
+
+
+# Header + root directory per archive. Small (a root directory is capped at 16 KB by the spec) and
+# the hot path for every tile, so caching it turns a 3-request tile into a 1-request tile. Keyed by
+# the object key; `forget` is called when a re-tile repoints the layer at a new key.
+_CACHE: dict[str, tuple[Header, list[Entry]]] = {}
+_LEAVES: dict[tuple[str, int, int], list[Entry]] = {}
+_MAX_LEAVES = 256
+
+
+def forget(key: str | None = None) -> None:
+    if key is None:
+        _CACHE.clear()
+        _LEAVES.clear()
+        return
+    _CACHE.pop(key, None)
+    for k in [k for k in _LEAVES if k[0] == key]:
+        _LEAVES.pop(k, None)
+
+
+def open_archive(key: str, fetch) -> tuple[Header, list[Entry]]:
+    """`(header, root_directory)` for an archive, reading at most two ranges and caching both.
+
+    `fetch(offset, length) -> bytes` does one HTTP Range read.
+    """
+    cached = _CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = parse_header(fetch(0, HEADER_LEN))
+    root = parse_directory(decompress(
+        fetch(header.root_offset, header.root_length), header.internal_compression))
+    _CACHE[key] = (header, root)
+    return header, root
+
+
+def get_tile(key: str, fetch, z: int, x: int, y: int) -> tuple[bytes, Header] | None:
+    """One tile's DECOMPRESSED bytes, or None when the archive has no tile there.
+
+    "No tile" is the normal case, not an error — an archive is sparse, and a client scanning a
+    viewport asks for tiles that were never written. Returning None lets the route answer 204 rather
+    than manufacturing a 404 the client would retry.
+
+    Decompressed rather than passed through: the response then needs no `Content-Encoding` contract
+    with whatever proxy sits in front, and a tile is tens of kilobytes.
+    """
+    header, root = open_archive(key, fetch)
+    if z < header.min_zoom or z > header.max_zoom:
+        return None
+    try:
+        tile_id = zxy_to_tile_id(z, x, y)
+    except PMTilesError:
+        return None
+
+    entries = root
+    # The spec allows nested leaves; in practice one level. Bounded so a malformed archive cannot
+    # spin here.
+    for _ in range(4):
+        entry = find(entries, tile_id)
+        if entry is None:
+            return None
+        if entry.run_length > 0:
+            raw = fetch(header.data_offset + entry.offset, entry.length)
+            return decompress(raw, header.tile_compression), header
+        cache_key = (key, entry.offset, entry.length)
+        leaf = _LEAVES.get(cache_key)
+        if leaf is None:
+            leaf = parse_directory(decompress(
+                fetch(header.leaf_offset + entry.offset, entry.length),
+                header.internal_compression))
+            if len(_LEAVES) >= _MAX_LEAVES:
+                _LEAVES.pop(next(iter(_LEAVES)))
+            _LEAVES[cache_key] = leaf
+        entries = leaf
+    return None
+
+
+def metadata(key: str, fetch) -> dict:
+    """The archive's JSON metadata — tippecanoe puts the layer name and field types here."""
+    import json
+
+    header, _ = open_archive(key, fetch)
+    if not header.metadata_length:
+        return {}
+    try:
+        raw = decompress(fetch(header.metadata_offset, header.metadata_length),
+                         header.internal_compression)
+        return json.loads(raw)
+    except (PMTilesError, ValueError):
+        return {}

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -156,10 +156,15 @@ def vector_links(layer, base: str) -> list[dict]:
     # This used to promote the PMTiles archive instead, on the reasoning that one bounded download
     # beats paging OAPIF. That is true of MapLibre and false of every GDAL-based client, which reads
     # the archive whole — so the promoted link was the slow one for the tools this list names first.
-    for i, l in enumerate(links):
-        if l.get("id") == "tilejson":
-            links.insert(0, links.pop(i))
-            break
+    #
+    # Guarded by `_has_pmtiles`, because a PostGIS layer publishes a `tilejson` link too and it is
+    # NOT the recommended one there — `ogc-service` keeps that badge, and promoting the TileJSON to
+    # the top would put the first link and the "recommended" mark on two different rows.
+    if _has_pmtiles(layer):
+        for i, l in enumerate(links):
+            if l.get("id") == "tilejson":
+                links.insert(0, links.pop(i))
+                break
 
     links.append(_link(
         "stac", "STAC item (metadata + all assets)", stac_item_url(base, "vectors", layer),

--- a/api/geodeploy/services/share_links.py
+++ b/api/geodeploy/services/share_links.py
@@ -98,6 +98,25 @@ def vector_links(layer, base: str) -> list[dict]:
             hint=f"Add as a VECTOR-tile source (not 'XYZ tiles' raster). Source-layer name: '{src}'."))
     else:
         if getattr(layer, "pmtiles_key", None) and getattr(layer, "tile_status", None) == "ready":
+            # THE ONE TO REACH FOR IN A DESKTOP GIS, and it goes first for a measured reason. The
+            # `pmtiles` link below is the whole archive, which MapLibre reads a tile at a time but
+            # GDAL does not: its PMTiles driver has no viewport, so QGIS's first question — how many
+            # features? — walks every tile at the deepest zoom. A five-feature layer on this project
+            # tiles to 2.17 million entries, so the archive path was slowest exactly where it looked
+            # safest. This TileJSON points at a per-tile endpoint that reads one tile per request.
+            links.append(_link(
+                "tilejson", "TileJSON — vector tiles (fast rendering)", f"{api}/tilejson",
+                fmt="TileJSON 3.0", tools=["QGIS", "GeoLibre", "MapLibre", "deck.gl", "OpenLayers"],
+                primary=True,
+                hint="QGIS: Layer ▸ Add Layer ▸ Add Vector Tile Layer ▸ New ▸ paste this as the "
+                     "TileJSON URL. It carries the tile template, the layer's bounds and the real "
+                     "zoom range, so only tiles that exist are ever requested. Tiles are "
+                     "generalized per zoom — for full attributes use OGC API - Features."))
+            links.append(_link(
+                "xyz-mvt", "XYZ vector tiles (MVT)", f"{api}/tiles/{{z}}/{{x}}/{{y}}",
+                fmt="Mapbox Vector Tile", tools=["MapLibre", "OpenLayers", "deck.gl"],
+                hint="The tile template behind the TileJSON above, if your client wants it bare. "
+                     "Add as a VECTOR-tile source, not as 'XYZ tiles' (that is for images)."))
             # The PLAIN https URL — no `pmtiles://`. That prefix is a protocol handler the MapLibre
             # GL JS library registers INTERNALLY; it is not part of any address a person pastes.
             # Every consumer-facing field expects the plain URL, GeoLibre's own PMTiles input
@@ -105,15 +124,13 @@ def vector_links(layer, base: str) -> list[dict]:
             # never understood the prefix. GeoDeploy's OWN portals still emit `pmtiles://…` inside
             # their MapLibre style — see portal_generator — which is correct and unrelated to this.
             links.append(_link(
-                "pmtiles", "PMTiles archive — fastest way to draw this layer", f"{api}/pmtiles",
-                fmt="PMTiles (vector)", tools=["QGIS", "GeoLibre", "MapLibre", "GDAL"],
-                primary=True,
-                hint="QGIS: Layer > Add Layer > ADD VECTOR LAYER and paste this URL as-is — GDAL "
-                     "3.8+ opens it with its PMTiles driver (verified: driver=PMTiles, 1 layer). "
-                     "NOT Add Vector TILE Layer: that dialog builds an XYZ template and an archive "
-                     "is one file. No pmtiles:// prefix and no /vsicurl/ needed. For attributes and "
-                     "queries prefer the OGC API - Features service above — tiles are generalized "
-                     "per zoom."))
+                "pmtiles", "PMTiles archive (the whole file)", f"{api}/pmtiles",
+                fmt="PMTiles (vector)", tools=["MapLibre", "GeoLibre", "GDAL", "pmtiles CLI"],
+                hint="One file holding every tile — for MapLibre's pmtiles:// protocol, or for "
+                     "copying the archive. No pmtiles:// prefix and no /vsicurl/ needed here. "
+                     "GDAL 3.8+ CAN open it directly, but do not do that in QGIS: the driver has "
+                     "no viewport and reads the entire archive to answer basic questions about it. "
+                     "Use the TileJSON above instead."))
         links.append(_link(
             "features-geojson", "Viewport features (GeoDeploy native)",
             f"{api}/features.geojson?bbox=minx,miny,maxx,maxy&limit=50000",
@@ -131,13 +148,16 @@ def vector_links(layer, base: str) -> list[dict]:
                 fmt="JSON", tools=["DuckDB", "GDAL/ogr2ogr", "pyarrow"],
                 hint=f"Partition grid + file keys; each file is then at {api}/parquet/<key> "
                      "(HTTP Range supported)."))
-    # A tiled GeoParquet layer LEADS with PMTiles. These layers are the big ones — that is why they
-    # are GeoParquet — and for them the honest first answer is the one that draws: QGIS opens the
-    # archive through Add Vector Layer in seconds, where OAPIF pages millions of features one screen
-    # at a time. OGC API - Features stays directly below it for full attributes and queries, which
-    # tiles cannot give: they are generalized per zoom and clipped to tile boundaries.
+    # A tiled layer LEADS with its TileJSON. These layers are the big ones — that is why they are
+    # GeoParquet — and the honest first answer is the one that draws a screenful at a time. OGC API
+    # - Features stays below it for full attributes and queries, which tiles cannot give: they are
+    # generalized per zoom and clipped to tile boundaries.
+    #
+    # This used to promote the PMTiles archive instead, on the reasoning that one bounded download
+    # beats paging OAPIF. That is true of MapLibre and false of every GDAL-based client, which reads
+    # the archive whole — so the promoted link was the slow one for the tools this list names first.
     for i, l in enumerate(links):
-        if l.get("id") == "pmtiles":
+        if l.get("id") == "tilejson":
             links.insert(0, links.pop(i))
             break
 

--- a/api/tests/test_ogcapi.py
+++ b/api/tests/test_ogcapi.py
@@ -273,11 +273,19 @@ async def test_share_links_lead_with_ogc_features(client, db):
 
 
 @pytest.mark.asyncio
-async def test_a_tiled_geoparquet_layer_leads_with_pmtiles(client, db):
+async def test_a_tiled_geoparquet_layer_leads_with_its_tilejson(client, db):
     """These are the BIG layers — that is why they are GeoParquet — and for them the honest first
-    answer is the one that draws. QGIS opens the archive through Add Vector Layer in seconds, where
-    OAPIF pages millions of features a screen at a time. Verified against a live instance: GDAL
-    reports driver=PMTiles and reads features straight from the plain URL."""
+    answer is the one that draws a screenful at a time.
+
+    THIS TEST USED TO ASSERT THE OPPOSITE, and the reason is worth keeping. It promoted the PMTiles
+    ARCHIVE, on the reasoning that one bounded download beats paging OAPIF, and named QGIS as the
+    tool. That is true of MapLibre, which reads a tile at a time, and false of every GDAL-based
+    client: the PMTiles driver has no viewport, so QGIS's opening questions — feature count, extent
+    — walk every tile at the deepest zoom. Measured on the project's own instance, a FIVE-FEATURE
+    layer's archive holds 2,171,238 tile entries across z0-13, so the promoted link was the slow one
+    for exactly the tools it named. The per-tile endpoint the TileJSON points at is the fix; the
+    archive stays for MapLibre and for copying the file.
+    """
     from geodeploy.services.share_links import vector_links
 
     class _Tiled:
@@ -287,17 +295,22 @@ async def test_a_tiled_geoparquet_layer_leads_with_pmtiles(client, db):
         is_public, visibility = True, "public"
 
     links = vector_links(_Tiled(), "https://example.org")
-    assert links[0]["id"] == "pmtiles", "the fastest path should be first, not buried"
+    by_id = {l["id"]: l for l in links}
+    assert links[0]["id"] == "tilejson", "the viewport-driven path should be first, not buried"
     assert links[0]["primary"] is True
     assert "QGIS" in links[0]["tools"]
-    # Case-insensitive: the hint capitalises the menu name for emphasis, and pinning the shouting
-    # would make this a test of formatting rather than of content.
-    assert "add vector layer" in links[0]["hint"].lower()   # the dialog that actually works
-    assert "add vector tile layer" in links[0]["hint"].lower()  # …and the one that does not
+    assert links[0]["url"].endswith("/tilejson")
+    # The dialog that works for a TileJSON, named so nobody repeats the archive mistake by hand.
+    assert "add vector tile layer" in links[0]["hint"].lower()
     # Only ONE thing may wear the badge, or "recommended" means nothing.
-    assert [l["id"] for l in links if l.get("primary")] == ["pmtiles"]
+    assert [l["id"] for l in links if l.get("primary")] == ["tilejson"]
+    # The bare template is offered too, for a client that wants it without the wrapper.
+    assert by_id["xyz-mvt"]["url"].endswith("/tiles/{z}/{x}/{y}")
+    # The archive is still published — and no longer sold to QGIS users.
+    assert "pmtiles" in by_id and not by_id["pmtiles"].get("primary")
+    assert "QGIS" not in by_id["pmtiles"]["tools"]
     # …and the feature service is still right there for attributes, which tiles cannot carry.
-    assert "ogc-service" in [l["id"] for l in links]
+    assert "ogc-service" in by_id
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_pmtiles_reader.py
+++ b/api/tests/test_pmtiles_reader.py
@@ -1,0 +1,212 @@
+"""The PMTiles v3 reader, against an archive built here byte by byte.
+
+Why a hand-built archive instead of a fixture file: every one of these fields is a place where an
+off-by-one produces a tile that LOOKS fine and belongs somewhere else, which is the worst kind of
+bug in a map. Writing the bytes means the test states the expected layout rather than trusting a
+binary blob nobody can read in a diff.
+
+What this reader is for: serving one tile out of an archive so clients get an ordinary XYZ URL.
+Handed a whole archive, GDAL walks every tile at the deepest zoom just to report a feature count —
+on this project's own instance a five-feature layer tiles to 2.17 million entries — which is why
+QGIS hung on small layers. Everything below protects the code that replaced that.
+"""
+import gzip
+import json
+import struct
+
+import pytest
+
+from geodeploy.services import pmtiles_reader as pm
+
+
+def varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | (0x80 if value else 0))
+        if not value:
+            return bytes(out)
+
+
+def directory(entries) -> bytes:
+    """Serialize `[(tile_id, offset, length, run_length)]` the way the spec does: columnar, with
+    the ids delta-coded and an offset of 0 meaning "right after the previous one"."""
+    body = bytearray(varint(len(entries)))
+    last = 0
+    for tile_id, _o, _l, _r in entries:
+        body += varint(tile_id - last)
+        last = tile_id
+    for _t, _o, _l, run in entries:
+        body += varint(run)
+    for _t, _o, length, _r in entries:
+        body += varint(length)
+    for i, (_t, offset, _l, _r) in enumerate(entries):
+        if i > 0 and offset == entries[i - 1][1] + entries[i - 1][2]:
+            body += varint(0)                       # the contiguous shorthand
+        else:
+            body += varint(offset + 1)
+    return bytes(body)
+
+
+def build(tiles, *, leaf_at=None, min_zoom=0, max_zoom=2, tile_type=1):
+    """An archive from `{(z, x, y): payload}`. `leaf_at` splits the directory in two so the leaf
+    path is exercised — one level of leaves is what a real archive of any size has."""
+    blobs, entries, data = [], [], bytearray()
+    for (z, x, y), payload in sorted(tiles.items(), key=lambda kv: pm.zxy_to_tile_id(*kv[0])):
+        raw = gzip.compress(payload)
+        entries.append((pm.zxy_to_tile_id(z, x, y), len(data), len(raw), 1))
+        data += raw
+        blobs.append(raw)
+
+    if leaf_at is None:
+        root_entries, leaves = entries, b""
+    else:
+        head, tail = entries[:leaf_at], entries[leaf_at:]
+        leaves = gzip.compress(directory(tail))
+        # run_length 0 = "this is a pointer to a leaf directory", covering every id at or above it.
+        root_entries = head + [(tail[0][0], 0, len(leaves), 0)]
+    root = gzip.compress(directory(root_entries))
+    meta = gzip.compress(json.dumps({"vector_layers": [{"id": "geodeploy"}]}).encode())
+
+    root_off = pm.HEADER_LEN
+    meta_off = root_off + len(root)
+    leaf_off = meta_off + len(meta)
+    data_off = leaf_off + len(leaves)
+    header = bytearray(b"PMTiles" + bytes([3]))
+    header += struct.pack("<11Q", root_off, len(root), meta_off, len(meta), leaf_off, len(leaves),
+                          data_off, len(data), len(entries), len(entries), len(entries))
+    header += struct.pack("<6B", 1, 2, 2, tile_type, min_zoom, max_zoom)
+    header += struct.pack("<4i", -int(10.5 * 1e7), int(1.25 * 1e7), int(20 * 1e7), int(30 * 1e7))
+    header += struct.pack("<B", 1) + struct.pack("<2i", 0, 0)
+    assert len(header) == pm.HEADER_LEN, len(header)
+    return bytes(header) + root + meta + leaves + bytes(data)
+
+
+def reader(archive):
+    """A `fetch` over an in-memory archive that also RECORDS its reads, so the tests can assert on
+    how many range requests a tile costs — the whole point of the module."""
+    calls = []
+
+    def fetch(offset, length):
+        calls.append((offset, length))
+        return archive[offset:offset + length]
+    return fetch, calls
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    pm.forget()
+    yield
+    pm.forget()
+
+
+def test_hilbert_ids_match_the_spec():
+    # The published examples. Getting this wrong returns a neighbouring tile, which draws real data
+    # in the wrong place — the failure mode most likely to be mistaken for bad source data.
+    assert pm.zxy_to_tile_id(0, 0, 0) == 0
+    assert [pm.zxy_to_tile_id(1, *xy) for xy in ((0, 0), (0, 1), (1, 1), (1, 0))] == [1, 2, 3, 4]
+    assert pm.zxy_to_tile_id(2, 0, 0) == 5
+    assert pm.zxy_to_tile_id(3, 0, 0) == 21
+    # Levels are laid end to end: the first id at z is the count of every tile above it.
+    assert pm.zxy_to_tile_id(12, 0, 0) == (4 ** 12 - 1) // 3
+
+
+def test_a_tile_costs_one_range_read_once_the_archive_is_open():
+    tiles = {(0, 0, 0): b"zero", (1, 0, 0): b"one", (2, 1, 1): b"two"}
+    archive = build(tiles)
+    fetch, calls = reader(archive)
+
+    body, header = pm.get_tile("k", fetch, 0, 0, 0)
+    assert body == b"zero"
+    assert header.media_type == "application/vnd.mapbox-vector-tile"
+    assert len(calls) == 3, "the first tile pays for the header and the root directory too"
+
+    calls.clear()
+    assert pm.get_tile("k", fetch, 1, 0, 0)[0] == b"one"
+    assert pm.get_tile("k", fetch, 2, 1, 1)[0] == b"two"
+    assert len(calls) == 2, "one range read per tile after that — no directory re-read"
+
+
+def test_a_missing_tile_is_none_not_an_error():
+    # Sparse is the normal state of an archive. A 404 here would have clients retrying tiles that
+    # were never written, which is exactly the retry storm this work removed.
+    fetch, _ = reader(build({(0, 0, 0): b"zero"}))
+    assert pm.get_tile("k", fetch, 1, 1, 1) is None
+    assert pm.get_tile("k", fetch, 2, 3, 3) is None
+
+
+def test_zoom_outside_the_archive_is_refused_without_a_read():
+    fetch, calls = reader(build({(1, 0, 0): b"one"}, min_zoom=1, max_zoom=1))
+    pm.open_archive("k", fetch)
+    calls.clear()
+    assert pm.get_tile("k", fetch, 0, 0, 0) is None
+    assert pm.get_tile("k", fetch, 5, 1, 1) is None
+    assert calls == [], "a zoom the archive does not cover must not reach storage"
+
+
+def test_out_of_range_coordinates_are_refused():
+    fetch, _ = reader(build({(1, 0, 0): b"one"}))
+    assert pm.get_tile("k", fetch, 1, 2, 0) is None      # x >= 2**z
+    assert pm.get_tile("k", fetch, 1, -1, 0) is None
+
+
+def test_leaf_directories_are_followed_and_cached():
+    tiles = {(2, x, y): f"{x}-{y}".encode() for x in range(4) for y in range(4)}
+    archive = build(tiles, leaf_at=3)
+    fetch, calls = reader(archive)
+    pm.open_archive("k", fetch)
+
+    calls.clear()
+    assert pm.get_tile("k", fetch, 2, 3, 3)[0] == b"3-3"
+    assert len(calls) == 2, "the leaf, then the tile"
+    calls.clear()
+    assert pm.get_tile("k", fetch, 2, 2, 3)[0] == b"2-3"
+    assert len(calls) == 1, "the leaf is cached, so only the tile is read"
+
+
+def test_a_run_covers_its_range_and_stops_at_the_end_of_it():
+    # Runs are how identical tiles (empty ocean, repeated background) are stored once. Ignoring the
+    # run length returns the run's bytes for a tile that is not in it.
+    entries = [pm.Entry(tile_id=5, offset=0, length=4, run_length=3)]
+    assert pm.find(entries, 5).tile_id == 5
+    assert pm.find(entries, 7).tile_id == 5
+    assert pm.find(entries, 8) is None, "one past the run must miss"
+    assert pm.find(entries, 4) is None, "before the first entry must miss"
+    assert pm.find([], 1) is None
+
+
+def test_metadata_names_the_layer_inside_the_tiles():
+    # A consumer that guesses this name renders nothing at all, so the TileJSON reads it from here.
+    fetch, _ = reader(build({(0, 0, 0): b"zero"}))
+    assert pm.metadata("k", fetch)["vector_layers"][0]["id"] == "geodeploy"
+
+
+def test_the_header_carries_the_bounds_and_the_zoom_range():
+    fetch, _ = reader(build({(0, 0, 0): b"z"}, min_zoom=0, max_zoom=9))
+    header, _root = pm.open_archive("k", fetch)
+    assert (header.min_zoom, header.max_zoom) == (0, 9)
+    assert header.bounds == pytest.approx([-10.5, 1.25, 20.0, 30.0])
+
+
+def test_a_raster_archive_reports_its_own_media_type():
+    fetch, _ = reader(build({(0, 0, 0): b"png"}, tile_type=pm.TILETYPE_PNG))
+    assert pm.get_tile("k", fetch, 0, 0, 0)[1].media_type == "image/png"
+
+
+def test_forget_drops_a_stale_archive():
+    # A re-tile writes a NEW object at the same layer; the route calls `forget` so the next request
+    # re-reads instead of serving tiles from an archive that no longer exists.
+    fetch, calls = reader(build({(0, 0, 0): b"zero"}))
+    pm.open_archive("k", fetch)
+    calls.clear()
+    pm.forget("k")
+    pm.open_archive("k", fetch)
+    assert len(calls) == 2
+
+
+def test_not_a_pmtiles_archive_is_reported_clearly():
+    with pytest.raises(pm.PMTilesError):
+        pm.parse_header(b"not pmtiles" + b"\0" * 200)
+    with pytest.raises(pm.PMTilesError):
+        pm.parse_header(b"PMTiles" + bytes([2]) + b"\0" * 200)

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,4 +65,22 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17 (**speed and symbology, both measured.** `sources.describe` now sends EVERY vector layer
+down one viewport-driven path — a **TileJSON**, for PostGIS (Martin) and tiled GeoParquet (the new
+per-tile endpoint) alike — and `plugin._vector_tiles` READS it for the tile template, the real zoom
+range, the bounds and the name of the layer inside the tiles. The bare-template URI's `zmax=22` was
+the slowness: QGIS believed tiles existed at every zoom, kept requesting them past the depth the
+server has data, got empties back, retried each three times and drew nothing — "vanishes when I zoom
+in", "loading forever", and the retry storms in the log, all from one wrong number. Told the real
+range it over-zooms the deepest real tile instead. Opening a PMTiles archive through GDAL is now the
+LAST resort, not the first: the driver has no viewport (a five-feature layer = 2.17M tile entries).
+`sources.fallback` + `plugin._open_best` walk tiles → archive → OAPIF so an older instance still opens.
+**`symbology.apply_to_vector_tiles` now classifies** — one `QgsVectorTileBasicRendererStyle` per class
+with a filter expression, which is the same shape as the map's step/match expressions — through the
+SAME `_symbol_of` the feature path uses, so sizes/dashes/markers cannot drift. New **`symbology.apply`**
+is the single entry point: it picks the renderer from the layer's TYPE, which is what the portal-group
+path got wrong (it handed tile layers to `apply_to_qgis`, which silently did nothing). Tile layers get
+their real extent, so "zoom to layer" lands on the layer. Portal tree items keep the **whole portal
+row** — dropping everything but the slug is why QGIS group names showed ids while the dock showed
+titles. Tests: `scripts/test_tile_symbology.py`, `scripts/test_sources.py`, both in CI.)
 2026-08-14 (created — browse, add, upload, and styling in both directions)

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -392,9 +392,13 @@ class GeoDeployDock(QDockWidget):
                     portal.get("title") or portal.get("name") or slug,
                     portal.get("experience") or portal.get("archetype") or "portal",
                     "published" if published else "draft"])
-                # Marked so a double-click opens it instead of trying to add it as a layer.
-                item.setData(0, Qt.UserRole, {"_portal": True, "slug": slug,
-                                              "_base": self.instance.url if self.instance else ""})
+                # THE WHOLE ROW, not a three-key summary of it. Keeping only the slug is what put
+                # random-looking ids in the QGIS layer list: the tree showed `title` (above) while
+                # everything downstream — the group name, the status messages — read `title` off
+                # this dict, found nothing, and fell back to the slug. Anonymous rows carry a title
+                # like authenticated ones do, so there was never a reason for the two to differ.
+                item.setData(0, Qt.UserRole, dict(portal, _portal=True, slug=slug,
+                                                  _base=self.instance.url if self.instance else ""))
 
         if not self._rows and not self._portals:
             self._say("Nothing to list. Public data needs no account; a token shows the rest.")
@@ -424,7 +428,7 @@ class GeoDeployDock(QDockWidget):
             return
 
         name = row.get("name") or "GeoDeploy layer"
-        layer = self._build_layer(row, source, name)
+        layer, source = self._open_best(row, source, name)
         if layer is None:
             self._say(f"QGIS could not open the {source['kind']} source for {name}.", Qgis.Critical)
             return
@@ -450,8 +454,11 @@ class GeoDeployDock(QDockWidget):
                     symbology._log(f"Could not read the legend for {name}: {exc}")
                     style = None
             if style:
+                # `symbology.apply` picks the renderer from the layer's TYPE — feature layers and
+                # vector-tile layers need different ones, and choosing here by source kind is how
+                # the two drifted apart before.
                 applied = (", styled as the portal draws it"
-                           if symbology.apply_to_qgis(layer, style)
+                           if symbology.apply(layer, style, row)
                            else " — but its saved style could not be applied; the reason is in "
                                 "View > Panels > Log Messages, under GeoDeploy")
             else:
@@ -461,6 +468,29 @@ class GeoDeployDock(QDockWidget):
 
     # -- upload ------------------------------------------------------------------------------------
 
+    def _open_best(self, row, source, name):
+        """`(layer, source)` — the best source that actually OPENS, falling back down the list.
+
+        The fast path is now the first thing tried for every layer, and the fast path is newer than
+        some of the instances this plugin talks to. Without this, asking an older instance for a
+        per-tile URL it does not publish would turn "slow" into "will not open at all" — a speed
+        fix that breaks compatibility is not a fix. Each attempt is logged, so a layer that quietly
+        took the slow road says why.
+        """
+        tried = []
+        while source is not None and len(tried) < 4:
+            layer = self._build_layer(row, source, name)
+            if layer is not None:
+                return layer, source
+            tried.append(source["kind"])
+            nxt = sources.fallback(row, source)
+            if nxt is None or nxt["kind"] in tried:
+                return None, source
+            symbology._log("{0}: the {1} source did not open; trying {2}.".format(
+                name, source["kind"], nxt["kind"]))
+            source = nxt
+        return None, source
+
     def _build_layer(self, row, source, name):
         """One layer from a described source, tagged with its GeoDeploy identity.
 
@@ -468,14 +498,22 @@ class GeoDeployDock(QDockWidget):
         layer each entry is, and matching by name would break the first time someone renames one.
         """
         if source["kind"] == "vector-tiles":
-            uri = _xyz_uri(source["uri"])
-            layer = QgsVectorTileLayer(uri, name) if uri else None
-            if layer is None or not layer.isValid():
+            layer, doc = self._vector_tiles(source, name)
+            if layer is None:
                 return None
-            # A vector tile layer is not a feature layer: QGIS renders it through a different
-            # renderer entirely, so `apply_to_qgis` cannot style it. Give it the layer's own colour
-            # at least, rather than QGIS's random one, and say what was not applied.
-            symbology.apply_to_vector_tiles(layer, row, source.get("source_layer"))
+            # The tile renderer needs the name of the layer INSIDE the tiles for every style it
+            # builds. Recorded on the layer so a later restyle — the portal-group path, "apply the
+            # portal's style" — does not have to rediscover it.
+            layer.setCustomProperty(symbology.P_SOURCE_LAYER,
+                                    doc.get("_source_layer") or source.get("source_layer") or "")
+            # Classified symbology DOES survive here: a tile renderer takes one style per class
+            # with a filter, which is the same shape the map's step/match expressions have.
+            symbology.apply(layer, (row.get("default_style") or {}).get("style")
+                            if isinstance(row.get("default_style"), dict) else None, row)
+            # A tile layer is a global pyramid, so QGIS reports the whole world and "zoom to layer"
+            # flies somewhere the data is not. Prefer the TileJSON's bounds — they come from the
+            # tiles themselves — and fall back to the row's.
+            self._set_tile_extent(layer, doc.get("bounds") or row.get("bbox"))
             if self.instance:
                 portal_sync.tag_layer(layer, self.instance.url, row.get("id"), "vector")
             return layer
@@ -507,7 +545,7 @@ class GeoDeployDock(QDockWidget):
             # the whole world and "Zoom to layer" flies to everything — which is what made zooming
             # to a raster land on some other layer entirely. The instance knows the real bounds, so
             # tell QGIS them.
-            self._set_raster_extent(layer, row.get("bbox"))
+            self._set_tile_extent(layer, row.get("bbox"))
         if self.instance:
             is_raster = (row.get("layer_type") == "raster"
                          or row.get("storage_backend") == "raster")
@@ -528,14 +566,37 @@ class GeoDeployDock(QDockWidget):
         if url.startswith("/") and self.instance:
             url = self.instance.url.rstrip("/") + url
         try:
+            ref = cfg.get("layer_id")
+            base = self.instance.url.rstrip("/") if self.instance else ""
             if kind == "raster-xyz":
-                uri = _xyz_uri(url)
-                layer = QgsRasterLayer(uri, name, "wms") if uri else None
+                # The instance publishes a TileJSON for the same raster, and it carries the bounds
+                # a bare template has none of — so "zoom to layer" works on a portal group too.
+                layer = (self._raster_from_tilejson(
+                    f"{base}/api/data/raster/{ref}/tilejson", name) if base and ref else None)
+                if layer is None:
+                    uri = _xyz_uri(url)
+                    layer = QgsRasterLayer(uri, name, "wms") if uri else None
             elif kind == "pmtiles":
-                layer = QgsVectorLayer("/vsicurl/" + url, name, "ogr")
+                # NOT the archive. A portal names it because MapLibre reads it a tile at a time;
+                # GDAL cannot, and opening one here is what made a portal group hang. The same
+                # tiles are served per-{z}/{x}/{y} through the layer's TileJSON.
+                layer, doc = self._vector_tiles(
+                    {"tilejson_url": f"{base}/api/data/vector/{ref}/tilejson"}, name) \
+                    if base and ref else (None, {})
+                if layer is not None:
+                    layer.setCustomProperty(symbology.P_SOURCE_LAYER,
+                                            doc.get("_source_layer") or "")
+                    self._set_tile_extent(layer, doc.get("bounds"))
+                else:
+                    # An instance too old to publish that TileJSON: the archive still draws, slowly.
+                    layer = QgsVectorLayer("/vsicurl/" + url, name, "ogr")
             elif kind == "vector-tiles":
-                uri = _xyz_uri(url)
-                layer = QgsVectorTileLayer(uri, name) if uri else None
+                layer, doc = self._vector_tiles({"uri": url, "tilejson_url": (
+                    f"{base}/api/data/vector/{ref}/tilejson" if base and ref else None)}, name)
+                if layer is not None:
+                    layer.setCustomProperty(symbology.P_SOURCE_LAYER,
+                                            doc.get("_source_layer") or "")
+                    self._set_tile_extent(layer, doc.get("bounds"))
             else:
                 return None
         except Exception as exc:        # noqa: BLE001 - one layer must not stop the group
@@ -592,6 +653,42 @@ class GeoDeployDock(QDockWidget):
             symbology._log("Could not read the raster's WMTS: {0}".format(exc))
             return None
 
+    def _vector_tiles(self, source, name):
+        """`(layer, tilejson)` for a vector-tile source, described by the server rather than guessed.
+
+        THE SLOWNESS WAS HERE, and it was not the tiles' fault. A vector-tile layer built from a
+        bare template gets `zmin=0&zmax=22`, which tells QGIS that tiles exist at every zoom — so
+        past the depth where the server actually has data it keeps requesting fresh tiles, gets
+        empty ones back, retries each three times, draws nothing and calls that a rendered frame.
+        That is "the layer vanishes when I zoom in", "endless loading" and the retry storms in the
+        log, all from one wrong number.
+
+        The TileJSON carries the real range. Told it, QGIS OVER-ZOOMS the deepest real tile instead
+        of asking for one that was never made — same picture, no request. It also carries the
+        bounds, so "zoom to layer" lands on the layer, and the name of the layer inside the tiles,
+        which the renderer needs before it can style anything.
+        """
+        doc = {}
+        url = source.get("tilejson_url")
+        if url:
+            try:
+                doc = self.instance.fetch_json(url) if self.instance else {}
+            except GeoDeployError as exc:
+                symbology._log("Could not read the TileJSON for {0}: {1}".format(name, exc))
+                doc = {}
+        tiles = (doc or {}).get("tiles") or []
+        template = tiles[0] if tiles else source.get("uri")
+        if not template:
+            return None, {}
+        uri = _xyz_uri(template, (doc or {}).get("minzoom"), (doc or {}).get("maxzoom"))
+        layer = QgsVectorTileLayer(uri, name) if uri else None
+        if layer is None or not layer.isValid():
+            return None, {}
+        vls = (doc or {}).get("vector_layers") or []
+        if vls and vls[0].get("id"):
+            doc = dict(doc, _source_layer=vls[0]["id"])
+        return layer, (doc or {})
+
     def _raster_from_tilejson(self, url, name):
         """A styled raster layer from the instance's TileJSON: template, zooms and bounds.
 
@@ -613,12 +710,16 @@ class GeoDeployDock(QDockWidget):
         layer = QgsRasterLayer(uri, name, "wms")
         if not layer.isValid():
             return None
-        self._set_raster_extent(layer, doc.get("bounds"))
+        self._set_tile_extent(layer, doc.get("bounds"))
         return layer
 
     @staticmethod
-    def _set_raster_extent(layer, bbox):
-        """Give a tile layer the layer's own bounds, in the map's CRS."""
+    def _set_tile_extent(layer, bbox):
+        """Give a tile layer the layer's own bounds, in the map's CRS.
+
+        Raster OR vector: both are global pyramids that report the whole world until told
+        otherwise, and both send "zoom to layer" to the wrong place without this.
+        """
         if not (isinstance(bbox, (list, tuple)) and len(bbox) == 4):
             return
         try:
@@ -726,8 +827,8 @@ class GeoDeployDock(QDockWidget):
                 if layer_row is not None:
                     source = sources.describe(layer_row,
                                               prefer_attributes=self.attributes.isChecked())
-                    layer = (self._build_layer(layer_row, source,
-                                               layer_row.get("name") or "layer")
+                    layer = (self._open_best(layer_row, source,
+                                             layer_row.get("name") or "layer")[0]
                              if source else None)
                 else:
                     # Not in the listing: a layer that is not itself published, on a portal that
@@ -742,7 +843,10 @@ class GeoDeployDock(QDockWidget):
                 tree_node.setItemVisibilityChecked(bool(cfg.get("visible", True)))
                 style = (cfg.get("style") or {}) if self.styled.isChecked() else {}
                 if style and cfg.get("layer_type") != "raster":
-                    symbology.apply_to_qgis(layer, style)
+                    # THE PORTAL'S style wins over the layer's default here — that is what opening
+                    # a portal means. Through the dispatcher, so a tile layer gets the tile
+                    # renderer instead of silently keeping the colour it was born with.
+                    symbology.apply(layer, style, layer_row or {})
                 added += 1
 
         # A portal with no folders is a flat list — the configs themselves, in order.

--- a/integrations/qgis-plugin/geodeploy_qgis/sources.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/sources.py
@@ -137,41 +137,51 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
                     "defaults rather than GeoDeploy's styling"),
         }
 
-    # A tiled layer says so in three different ways depending on who is asking: the authenticated
-    # row carries `pmtiles_key`/`tile_status`, and the PUBLIC index carries neither — it advertises
-    # the archive as a link instead. Checking only the fields meant an anonymous caller silently
-    # got the slow path for a layer that had been tiled precisely to be fast.
-    pmtiles_link = _link(layer, "pmtiles")
-    tiled = bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready" or bool(pmtiles_link)
-    if tiled and not prefer_attributes and gdal_supports_pmtiles():
-        return {
-            "kind": "pmtiles",
-            # `/vsicurl/` is not optional. Handed the bare URL, GDAL looks for a file of that name
-            # on disk and fails with "does not exist in the file system" — it says so itself, and
-            # suggests this prefix. It is also what QGIS's own Add Vector Layer builds when you give
-            # it an HTTP(S) source, which is why adding one by hand worked where this did not.
-            "uri": "/vsicurl/" + (pmtiles_link or f"{base}/api/data/vector/{ref}/pmtiles"),
-            "provider": "ogr",
-            "why": "one pre-generalized archive, read by range request instead of re-queried",
-        }
-
-    # POSTGIS: MARTIN'S VECTOR TILES, not OGC API - Features.
+    # VECTOR TILES, FOR BOTH BACKENDS, DESCRIBED BY A TILEJSON.
     #
-    # Both are offered; they are not close. Tiles are generalized per zoom, cut server-side and
-    # fetched for the viewport, so a 350k-feature road layer draws as fast as a small one. OAPIF
-    # asks the server for features and pages through them — exact and complete, and slow enough on
-    # a large layer that it reads as broken. Defaulting to the slower one was simply wrong.
+    # One path now covers PostGIS (Martin builds the tiles from the table) and tiled GeoParquet (the
+    # server reads them out of the PMTiles archive a tile at a time). The plugin does not need to
+    # know which: it reads the TileJSON, which carries the tile template, the bounds, the real zoom
+    # range and the name of the layer inside the tiles.
     #
-    # The trade is real and is what the checkbox is for: tiles carry generalized geometry and only
-    # the attributes the tiles hold, so "prefer the real data" still gets OAPIF.
-    mvt = _link(layer, "xyz-mvt")
-    if mvt and not prefer_attributes:
+    # Reading it rather than guessing is what fixes three separate complaints at once — "zoom to
+    # layer goes somewhere the layer is not" (no bounds), "nothing displays after zooming in"
+    # (requests past the deepest real zoom come back empty instead of over-zooming the last good
+    # tile), and the retry storms in the log.
+    tilejson = _link(layer, "tilejson")
+    tiled = (bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready"
+             or bool(_link(layer, "pmtiles")))
+    if not tilejson and (layer.get("storage_backend") == "postgis" or tiled):
+        tilejson = f"{base}/api/data/vector/{ref}/tilejson"
+    if tilejson and not prefer_attributes:
         return {
             "kind": "vector-tiles",
-            "uri": mvt,
+            "tilejson_url": tilejson,
+            # Only used if the TileJSON cannot be read — see `_build_layer`.
+            "uri": _link(layer, "xyz-mvt") or "",
             "source_layer": layer.get("source_layer") or _mvt_source_layer(layer),
             "provider": "vectortile",
             "why": "vector tiles, generalized per zoom and fetched for the view",
+        }
+
+    # LAST RESORT FOR A TILED LAYER, and deliberately last.
+    #
+    # Opening the archive with GDAL looks like the obvious fast path and is the opposite. The driver
+    # has no viewport: it presents the archive as one dataset, so QGIS's opening questions — feature
+    # count, extent — walk every tile at the deepest zoom over HTTP. Measured on this project's own
+    # instance, a FIVE-FEATURE layer tiles to 2,171,238 entries across zooms 0–13, which is why the
+    # small layers hung worst. Only reached when the instance publishes no TileJSON (an older
+    # build), where it still beats paging millions of features through OAPIF.
+    pmtiles_link = _link(layer, "pmtiles")
+    if tiled and not prefer_attributes and pmtiles_link and gdal_supports_pmtiles():
+        return {
+            "kind": "pmtiles",
+            # `/vsicurl/` is not optional. Handed the bare URL, GDAL looks for a file of that name
+            # on disk and fails with "does not exist in the file system".
+            "uri": "/vsicurl/" + pmtiles_link,
+            "provider": "ogr",
+            "why": ("the whole tile archive — this instance publishes no TileJSON for it, so QGIS "
+                    "has to read the archive rather than a viewport, and opening it is slow"),
         }
 
     # OAPIF is addressed by COLLECTION here, not by the service: QGIS's own dialog needs the service
@@ -188,6 +198,35 @@ def describe(layer: dict, prefer_attributes: bool = False) -> dict | None:
         "provider": "OAPIF",
         "why": why,
     }
+
+
+def fallback(layer: dict, failed: dict) -> dict | None:
+    """The next source to try when `failed` could not be opened, or None when there is none left.
+
+    THE CASE THAT NEEDS THIS: an instance that has not been updated yet publishes no TileJSON for a
+    tiled GeoParquet layer. The plugin now asks for one first — rightly, it is the fast path — and
+    without a fallback that layer would simply refuse to open on every older instance, turning a
+    speed fix into a compatibility break. So a vector-tile source that fails drops to the archive
+    (slow, but it draws) and then to OGC API - Features (slower, but always there).
+    """
+    kind = (failed or {}).get("kind")
+    if kind == "vector-tiles":
+        pmtiles_link = _link(layer, "pmtiles")
+        tiled = (bool(layer.get("pmtiles_key")) or layer.get("tile_status") == "ready"
+                 or bool(pmtiles_link))
+        if tiled and pmtiles_link and gdal_supports_pmtiles():
+            return {
+                "kind": "pmtiles",
+                "uri": "/vsicurl/" + pmtiles_link,
+                "provider": "ogr",
+                "why": ("the whole tile archive — this instance publishes no per-tile URL for it, "
+                        "so QGIS has to read the archive, and opening it is slow"),
+            }
+    if kind in ("vector-tiles", "pmtiles"):
+        return describe(layer, prefer_attributes=True)
+    if kind in ("wmts", "tilejson", "xyz"):
+        return describe(layer, prefer_attributes=True)      # the COG
+    return None
 
 
 def _mvt_source_layer(layer: dict) -> str | None:

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -124,8 +124,19 @@ def _use_points(symbol, layer0) -> None:
 
 
 def _symbol_for(qgis_layer, color: str | None, style: dict):
-    """A single symbol of the right geometry kind, coloured and sized from `style`."""
-    symbol = QgsSymbol.defaultSymbol(qgis_layer.geometryType())
+    """A single symbol matching a LAYER's geometry kind, coloured and sized from `style`."""
+    return _symbol_of(qgis_layer.geometryType(), color, style)
+
+
+def _symbol_of(geometry_type, color: str | None, style: dict):
+    """A single symbol of the given geometry kind, coloured and sized from `style`.
+
+    Split out from `_symbol_for` for the vector-TILE renderer, which has no layer to ask: it takes
+    a geometry type directly. Everything below — marker shape, point radius, line width and dash,
+    fill opacity, data-defined size — has to behave identically for tiles and for features, so
+    there is one body and two ways in rather than two bodies that drift.
+    """
+    symbol = QgsSymbol.defaultSymbol(geometry_type)
     if symbol is None:
         return None
     if color:
@@ -246,6 +257,34 @@ def _log(message: str) -> None:
         pass
 
 
+#: Where a vector-tile layer remembers the name of the layer INSIDE its tiles. The tile renderer
+#: needs it for every style it builds, and only the code that read the TileJSON knows it — so it is
+#: written once, on the layer, rather than threaded through every caller that might restyle later.
+P_SOURCE_LAYER = "geodeploy/source_layer"
+
+
+def apply(qgis_layer, style: dict, row: dict | None = None) -> bool:
+    """Style ANY GeoDeploy layer — feature or vector tile — the way GeoDeploy draws it.
+
+    The one entry point every caller should use. A vector-TILE layer needs a completely different
+    renderer from a feature layer, and callers kept forgetting: the portal-group path handed tile
+    layers to `apply_to_qgis`, which silently did nothing, so a portal opened as a group came in
+    unstyled while the same layer added on its own came in styled. Deciding here, once, from the
+    layer's actual type is the only version of this that cannot rot.
+    """
+    if not QGIS or not style:
+        return False
+    try:
+        from qgis.core import QgsVectorTileLayer
+        is_tiles = isinstance(qgis_layer, QgsVectorTileLayer)
+    except ImportError:                 # pragma: no cover - older QGIS has no vector tiles
+        is_tiles = False
+    if is_tiles:
+        source_layer = qgis_layer.customProperty(P_SOURCE_LAYER) or None
+        return apply_to_vector_tiles(qgis_layer, row or {}, source_layer, style)
+    return apply_to_qgis(qgis_layer, style)
+
+
 def apply_to_qgis(qgis_layer, style: dict) -> bool:
     """Render `qgis_layer` the way GeoDeploy renders it. True when a renderer was set.
 
@@ -316,58 +355,104 @@ def _hex(color) -> str:
 MAX_COLOR_CLASSES = 128
 
 
-def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None) -> bool:
-    """Colour a vector TILE layer with the layer's own colour.
+def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None,
+                          style: dict | None = None) -> bool:
+    """Draw a vector TILE layer with the layer's real symbology — classes and all.
 
-    QGIS renders vector tiles through `QgsVectorTileBasicRenderer`, which takes styles per geometry
-    type rather than a feature renderer — so the classified symbology `apply_to_qgis` builds does
-    not apply here. This is the honest subset: the right colour and the right geometry, instead of
-    whichever colour QGIS picked at random.
+    QGIS renders tiles through `QgsVectorTileBasicRenderer`, which takes a LIST of styles, each with
+    its own filter expression. That is the same shape MapLibre's `step`/`match` expressions have, so
+    a graduated or categorized layer translates directly: one style per class, filtered to that
+    class's values. The earlier version only set a base colour and told the user to give up speed to
+    get their symbology back — a bad trade, and an unnecessary one.
 
-    Anything richer needs the feature data, which is what "prefer the real data" is for.
+    Falls back to a single style when there is nothing to classify, and returns False only when even
+    that is impossible.
     """
     if not QGIS:
         return False
     try:
         from qgis.core import (QgsVectorTileBasicRenderer, QgsVectorTileBasicRendererStyle,
-                               QgsSymbol, QgsWkbTypes)
-        from qgis.PyQt.QtGui import QColor
+                               QgsWkbTypes)
     except ImportError:                 # pragma: no cover - older QGIS
         return False
 
-    style = ((row.get("default_style") or {}).get("style")
-             if isinstance(row.get("default_style"), dict) else {}) or {}
-    colour = QColor(style.get("color") or "#3b82f6")
+    style = style if style is not None else (
+        (row.get("default_style") or {}).get("style")
+        if isinstance(row.get("default_style"), dict) else {}) or {}
+
     geom = (row.get("geometry_type") or "").lower()
     if "polygon" in geom:
-        kinds = [(QgsWkbTypes.PolygonGeometry, QgsSymbol.Fill)]
+        geometry_type = QgsWkbTypes.PolygonGeometry
     elif "line" in geom:
-        kinds = [(QgsWkbTypes.LineGeometry, QgsSymbol.Line)]
+        geometry_type = QgsWkbTypes.LineGeometry
     else:
-        kinds = [(QgsWkbTypes.PointGeometry, QgsSymbol.Marker)]
+        geometry_type = QgsWkbTypes.PointGeometry
 
+    model = None
     try:
-        styles = []
-        for geometry_type, symbol_type in kinds:
-            symbol = QgsSymbol.defaultSymbol(geometry_type)
-            if symbol is None:
-                continue
-            symbol.setColor(colour)
-            entry = QgsVectorTileBasicRendererStyle("geodeploy", source_layer or "", geometry_type)
-            entry.setSymbol(symbol)
-            entry.setEnabled(True)
-            styles.append(entry)
+        from geodeploy import parse_style
+        model = parse_style(style) if style else None
+    except Exception:                   # noqa: BLE001 - fall through to a single symbol
+        model = None
+
+    def _style(name, colour, expression):
+        # THE SAME symbol builder the feature path uses — marker shape, radius, line width, dash,
+        # fill opacity and data-defined size all included. A second implementation here is how the
+        # two surfaces would start drawing the same layer differently.
+        symbol = _symbol_of(geometry_type, colour, style)
+        if symbol is None:
+            return None
+        entry = QgsVectorTileBasicRendererStyle(name, source_layer or "", geometry_type)
+        entry.setSymbol(symbol)
+        entry.setEnabled(True)
+        if expression:
+            entry.setFilterExpression(expression)
+        return entry
+
+    styles = []
+    try:
+        if model is not None and model.mode == "graduated" and model.field and model.classes:
+            for i, cls in enumerate(model.classes):
+                # Open edges mean "everything below/above", exactly as they do on the map.
+                lo, hi = cls.get("min"), cls.get("max")
+                field = '"{0}"'.format(model.field)
+                parts = []
+                if lo is not None:
+                    parts.append("{0} >= {1}".format(field, lo))
+                if hi is not None:
+                    # The LAST class keeps its upper bound inclusive, or the largest value in the
+                    # data falls through every filter and disappears.
+                    op = "<=" if i == len(model.classes) - 1 else "<"
+                    parts.append("{0} {1} {2}".format(field, op, hi))
+                entry = _style("class-{0}".format(i), cls.get("color"), " AND ".join(parts) or None)
+                if entry:
+                    styles.append(entry)
+        elif model is not None and model.mode == "categorized" and model.field and model.categories:
+            for i, cat in enumerate(model.categories):
+                value = cat.get("value")
+                literal = ("'" + str(value).replace("'", "''") + "'"
+                           if not isinstance(value, (int, float)) else str(value))
+                entry = _style("cat-{0}".format(i), cat.get("color"),
+                               '"{0}" = {1}'.format(model.field, literal))
+                if entry:
+                    styles.append(entry)
+            # Everything not listed, drawn in the same "other" colour the map uses.
+            other = _style("other", model.other_color or "#9ca3af", None)
+            if other:
+                styles.insert(0, other)      # first = drawn underneath the named categories
+        if not styles:
+            single = _style("geodeploy", (style or {}).get("color") or "#3b82f6", None)
+            if single:
+                styles.append(single)
         if not styles:
             return False
+
         renderer = QgsVectorTileBasicRenderer()
         renderer.setStyles(styles)
         tile_layer.setRenderer(renderer)
         tile_layer.triggerRepaint()
-        if style.get("color_mode") in ("graduated", "categorized"):
-            _log("Drawn as vector tiles for speed, so only the base colour was applied. Tick "
-                 "'Prefer the real data' to get the full classified symbology.")
         return True
-    except Exception as exc:            # noqa: BLE001 - never stop a layer loading over a colour
+    except Exception as exc:            # noqa: BLE001 - never stop a layer loading over a style
         _log("Could not style the vector tiles: {0}".format(exc))
         return False
 

--- a/integrations/qgis-plugin/scripts/test_sources.py
+++ b/integrations/qgis-plugin/scripts/test_sources.py
@@ -1,0 +1,90 @@
+"""Which source the plugin picks, and what it falls back to.
+
+This is the file where a mistake is invisible until someone's QGIS hangs, so the choices are pinned
+here rather than left to be re-derived. Two things it exists to protect:
+
+* **Every vector layer takes the viewport-driven path.** Tiles that arrive four-per-screen, not an
+  archive read whole and not features paged one extent at a time.
+* **An older instance still works.** The per-tile URL is newer than some instances this plugin talks
+  to; asking for it first is right, and failing to open when it is absent would not be.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis"))
+
+import sources                                                                  # noqa: E402
+
+sources.gdal_supports_pmtiles = lambda: True
+BASE = "https://example.org"
+
+
+def row(**kw):
+    return dict({"_base": BASE, "uid": "abc123", "name": "layer"}, **kw)
+
+
+def links(*ids):
+    return [{"id": i, "url": f"{BASE}/{i}"} for i in ids]
+
+
+# ── PostGIS: the TileJSON, which carries bounds and the real zoom range ───────────────────────
+got = sources.describe(row(storage_backend="postgis", links=links("tilejson", "xyz-mvt")))
+assert got["kind"] == "vector-tiles" and got["tilejson_url"] == f"{BASE}/tilejson", got
+print("postgis            -> vector-tiles via its published TileJSON")
+
+# No links at all (an authenticated row, which carries fields instead) — derive the URL.
+got = sources.describe(row(storage_backend="postgis"))
+assert got["tilejson_url"] == f"{BASE}/api/data/vector/abc123/tilejson", got
+print("postgis, no links  -> derived TileJSON URL")
+
+# ── Tiled GeoParquet: tiles, NOT the archive ──────────────────────────────────────────────────
+tiled = row(storage_backend="geoparquet", tile_status="ready", links=links("pmtiles", "tilejson"))
+got = sources.describe(tiled)
+assert got["kind"] == "vector-tiles", got
+print("tiled geoparquet   -> vector-tiles, not the archive")
+
+# The measured reason, restated as a test: the archive must never be the FIRST choice, because
+# GDAL reads it whole — a five-feature layer on the project's own instance tiles to 2.17M entries.
+assert sources.describe(tiled)["kind"] != "pmtiles"
+
+# ── An instance too old to publish a per-tile URL ─────────────────────────────────────────────
+# `describe` still asks for the TileJSON (it cannot know), so what matters is where a failure goes.
+old = row(storage_backend="geoparquet", tile_status="ready", links=links("pmtiles"))
+first = sources.describe(old)
+assert first["kind"] == "vector-tiles", first
+second = sources.fallback(old, first)
+assert second["kind"] == "pmtiles" and second["uri"].startswith("/vsicurl/"), second
+third = sources.fallback(old, second)
+assert third["kind"] == "oapif", third
+assert sources.fallback(old, third) is None
+print("old instance       -> vector-tiles, then pmtiles, then oapif, then stop")
+
+# On GDAL older than 3.8 the archive cannot be opened at all, so it must be skipped, not offered.
+sources.gdal_supports_pmtiles = lambda: False
+assert sources.fallback(old, first)["kind"] == "oapif"
+sources.gdal_supports_pmtiles = lambda: True
+print("gdal < 3.8         -> skips the archive entirely")
+
+# ── The checkbox still means what it says ─────────────────────────────────────────────────────
+got = sources.describe(tiled, prefer_attributes=True)
+assert got["kind"] == "oapif", got
+print("prefer attributes  -> OGC API - Features")
+
+# An untiled GeoParquet layer has no fast surface, and the reason is said out loud.
+got = sources.describe(row(storage_backend="geoparquet"))
+assert got["kind"] == "oapif" and "not tiled" in got["why"], got
+print("untiled geoparquet -> oapif, and says why")
+
+# ── Raster: WMTS first (bounds + matrix set), COG when the real values are wanted ─────────────
+r = row(layer_type="raster", links=links("wmts", "tilejson", "cog"))
+assert sources.describe(r)["kind"] == "wmts"
+assert sources.describe(r, prefer_attributes=True)["kind"] == "cog"
+assert sources.fallback(r, sources.describe(r))["kind"] == "cog"
+print("raster             -> wmts, falling back to the COG")
+
+# ── Nothing to go on ──────────────────────────────────────────────────────────────────────────
+assert sources.describe({"name": "no base"}) is None
+print("no base/ref        -> None")
+
+print("\nALL SOURCE-SELECTION CASES PASS")

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -1,0 +1,291 @@
+"""Prove `apply_to_vector_tiles` really CLASSIFIES, with stand-ins for the QGIS tile classes.
+
+The complaint this exists to stop coming back: a layer added as vector tiles arrived in the right
+colour and nothing else — every feature drawn the same, whatever the portal showed. QGIS renders
+tiles through `QgsVectorTileBasicRenderer`, which takes a list of styles each carrying its own
+FILTER EXPRESSION, so the graduated/categorized breaks do translate; the earlier code simply did not
+translate them.
+
+QGIS is not importable here, so the renderer classes are replaced by recording stubs and the test
+asserts on what would have been handed to QGIS: one style per class, the right colour, and a filter
+that selects exactly that class — including the two edge cases that silently lose features, an open
+outer bound and an inclusive top break.
+"""
+import sys
+import types
+
+qgis = types.ModuleType("qgis")
+core = types.ModuleType("qgis.core")
+PyQt = types.ModuleType("qgis.PyQt")
+QtCore = types.ModuleType("qgis.PyQt.QtCore")
+QtGui = types.ModuleType("qgis.PyQt.QtGui")
+
+
+class _Stub:
+    pass
+
+
+class QgsWkbTypes:
+    PointGeometry, LineGeometry, PolygonGeometry = 0, 1, 2
+
+
+class _QColor:
+    def __init__(self, name="#000000"):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _SymbolLayer:
+    """The base every stub symbol layer shares.
+
+    Three SUBCLASSES below, one per geometry, because `_symbol_of` branches on `isinstance` — a
+    single do-everything stub would satisfy every assertion here while the real code took none of
+    those branches, which is the way a test like this quietly stops testing anything.
+    """
+
+    def __init__(self):
+        self.width = None
+        self.stroke = None
+        self.pen = None
+
+    def setWidth(self, w):
+        self.width = w
+
+    def setStrokeColor(self, c):
+        self.stroke = c
+
+    def setStrokeStyle(self, s):
+        self.pen = s
+
+    def setPenStyle(self, s):
+        self.pen = s
+
+    def setDataDefinedProperty(self, key, prop):
+        self.data_defined = prop
+
+
+class QgsSimpleMarkerSymbolLayer(_SymbolLayer):
+    def __init__(self):
+        super().__init__()
+        self.shape = None
+
+    @staticmethod
+    def decodeShape(name):
+        return (name, True)
+
+    def setShape(self, shape):
+        self.shape = shape
+
+
+class QgsSimpleLineSymbolLayer(_SymbolLayer):
+    pass
+
+
+class QgsSimpleFillSymbolLayer(_SymbolLayer):
+    pass
+
+
+_LAYER_FOR = {0: QgsSimpleMarkerSymbolLayer, 1: QgsSimpleLineSymbolLayer,
+              2: QgsSimpleFillSymbolLayer}
+
+
+class _Symbol:
+    def __init__(self, geometry_type):
+        self.geometry_type = geometry_type
+        self.color = None
+        self.size = None
+        self.opacity = None
+        self._layer = _LAYER_FOR[geometry_type]()
+
+    def setColor(self, c):
+        self.color = c.name() if hasattr(c, "name") else c
+
+    def setSize(self, s):
+        self.size = s
+
+    def setOpacity(self, o):
+        self.opacity = o
+
+    def setDataDefinedSize(self, p):
+        self.data_defined = p
+
+    def symbolLayerCount(self):
+        return 1
+
+    def symbolLayer(self, i):
+        return self._layer
+
+
+class QgsSymbol(_Stub):
+    @staticmethod
+    def defaultSymbol(geometry_type):
+        return _Symbol(geometry_type)
+
+
+class QgsVectorTileBasicRendererStyle(_Stub):
+    def __init__(self, name, source_layer, geometry_type):
+        self.name = name
+        self.source_layer = source_layer
+        self.geometry_type = geometry_type
+        self.symbol = None
+        self.filter = ""
+        self.enabled = False
+
+    def setSymbol(self, s):
+        self.symbol = s
+
+    def setEnabled(self, v):
+        self.enabled = v
+
+    def setFilterExpression(self, e):
+        self.filter = e
+
+
+class QgsVectorTileBasicRenderer(_Stub):
+    def __init__(self):
+        self.styles = []
+
+    def setStyles(self, styles):
+        self.styles = styles
+
+
+for name in ("QgsCategorizedSymbolRenderer", "QgsGraduatedSymbolRenderer", "QgsRendererCategory",
+             "QgsRendererRange", "QgsSingleSymbolRenderer", "QgsClassificationRange",
+             "QgsMultiBandColorRenderer", "QgsSingleBandGrayRenderer", "QgsHillshadeRenderer",
+             "QgsSingleBandPseudoColorRenderer", "QgsPalettedRasterRenderer", "QgsUnitTypes"):
+    setattr(core, name, type(name, (_Stub,), {}))
+core.QgsUnitTypes.RenderPoints = 3
+core.QgsSymbol = QgsSymbol
+core.QgsSimpleMarkerSymbolLayer = QgsSimpleMarkerSymbolLayer
+core.QgsSimpleLineSymbolLayer = QgsSimpleLineSymbolLayer
+core.QgsSimpleFillSymbolLayer = QgsSimpleFillSymbolLayer
+core.QgsWkbTypes = QgsWkbTypes
+core.QgsVectorTileBasicRenderer = QgsVectorTileBasicRenderer
+core.QgsVectorTileBasicRendererStyle = QgsVectorTileBasicRendererStyle
+QtCore.Qt = type("Qt", (), {"DashLine": 2, "DotLine": 3, "NoPen": 0})
+QtGui.QColor = _QColor
+qgis.core, qgis.PyQt = core, PyQt
+PyQt.QtCore, PyQt.QtGui = QtCore, QtGui
+sys.modules.update({"qgis": qgis, "qgis.core": core, "qgis.PyQt": PyQt,
+                    "qgis.PyQt.QtCore": QtCore, "qgis.PyQt.QtGui": QtGui})
+
+import os                                                                       # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis", "vendor"))
+
+lines = open(os.path.join(HERE, "..", "geodeploy_qgis", "symbology.py"),
+             encoding="utf-8").read().splitlines()
+src = "\n".join(l for l in lines if not l.startswith("from .connection"))
+ns = {}
+exec(compile(src, "symbology", "exec"), ns)                                     # noqa: S102
+apply_to_vector_tiles = ns["apply_to_vector_tiles"]
+assert ns["QGIS"] is True, "the fake qgis.core was not picked up"
+
+
+class TileLayer:
+    def __init__(self):
+        self.renderer = None
+        self.repainted = False
+
+    def setRenderer(self, r):
+        self.renderer = r
+
+    def triggerRepaint(self):
+        self.repainted = True
+
+
+def styles_for(row, style, source_layer="geodeploy"):
+    layer = TileLayer()
+    ok = apply_to_vector_tiles(layer, row, source_layer, style)
+    assert ok, "apply_to_vector_tiles refused the style"
+    assert layer.repainted, "the layer was never repainted, so nothing would redraw"
+    return layer.renderer.styles
+
+
+# ── graduated ────────────────────────────────────────────────────────────────────────────────
+row = {"geometry_type": "MultiPolygon"}
+style = {
+    "color_mode": "graduated",
+    "color_field": "pop",
+    "classes": [{"min": None, "max": 100, "color": "#fee5d9"},
+                {"min": 100, "max": 1000, "color": "#fb6a4a"},
+                {"min": 1000, "max": 9000, "color": "#a50f15"}],
+    "outline_color": "#333333",
+}
+out = styles_for(row, style)
+assert len(out) == 3, out
+assert [s.symbol.color for s in out] == ["#fee5d9", "#fb6a4a", "#a50f15"]
+assert all(s.geometry_type == QgsWkbTypes.PolygonGeometry for s in out)
+assert all(s.source_layer == "geodeploy" and s.enabled for s in out)
+# An open LOWER edge must not become `>= None` — that class has to keep drawing everything below it.
+assert out[0].filter == '"pop" < 100', out[0].filter
+assert out[1].filter == '"pop" >= 100 AND "pop" < 1000', out[1].filter
+# The TOP break is inclusive, or the single largest value in the layer matches nothing and vanishes.
+assert out[2].filter == '"pop" >= 1000 AND "pop" <= 9000', out[2].filter
+# The outline travelled through the shared symbol builder, not a tile-only copy of it.
+assert out[0].symbol.symbolLayer(0).stroke.name() == "#333333"
+print("graduated      -> 3 filtered styles, open low edge and inclusive top break")
+
+# ── categorized ──────────────────────────────────────────────────────────────────────────────
+row = {"geometry_type": "LineString"}
+style = {
+    "color_mode": "categorized",
+    "color_field": "surface",
+    "categories": [{"value": "paved", "color": "#1f78b4"},
+                   {"value": "unpaved", "color": "#b15928"},
+                   {"value": "O'Hare", "color": "#33a02c"}],
+    "other_color": "#cccccc",
+    "line_width": 2,
+}
+out = styles_for(row, style)
+# "Other" first so the named categories draw ON TOP of it, matching the map's fallback colour.
+assert out[0].name == "other" and out[0].filter == "" and out[0].symbol.color == "#cccccc"
+assert [s.filter for s in out[1:]] == ['"surface" = \'paved\'',
+                                       '"surface" = \'unpaved\'',
+                                       '"surface" = \'O\'\'Hare\''], [s.filter for s in out[1:]]
+assert all(s.geometry_type == QgsWkbTypes.LineGeometry for s in out)
+# A quote in a value must be ESCAPED, not concatenated into a broken expression.
+assert out[3].filter.count("''") == 1
+assert out[1].symbol.symbolLayer(0).width == 2 * 0.75, "line width lost the CSS-px→pt conversion"
+print("categorized    -> other + 3 filtered styles, quote escaped, width converted")
+
+# Numeric category values must NOT be quoted, or the filter never matches an integer column.
+out = styles_for({"geometry_type": "Point"},
+                 {"color_mode": "categorized", "color_field": "zone",
+                  "categories": [{"value": 1, "color": "#f00"}, {"value": 2, "color": "#0f0"}]})
+assert out[1].filter == '"zone" = 1', out[1].filter
+print("numeric values -> unquoted literals")
+
+# ── single symbol, and the degrade paths ─────────────────────────────────────────────────────
+out = styles_for({"geometry_type": "Point"}, {"color": "#3388ff", "radius": 6, "marker": "square"})
+assert len(out) == 1 and out[0].filter == ""
+assert out[0].symbol.color == "#3388ff"
+assert out[0].symbol.size == 6 * 2 * 0.75, "point radius lost the diameter/points conversion"
+print("single symbol  -> one unfiltered style, radius converted")
+
+# A graduated style with NO classes must still draw — in its base colour, not refuse.
+out = styles_for({"geometry_type": "Polygon"},
+                 {"color_mode": "graduated", "color_field": "pop", "classes": [],
+                  "color": "#654321"})
+assert len(out) == 1 and out[0].symbol.color == "#654321"
+print("no classes     -> falls back to one symbol")
+
+# An unknown geometry name is treated as points rather than dropping the layer's styling.
+out = styles_for({"geometry_type": None}, {"color": "#123456"})
+assert out[0].geometry_type == QgsWkbTypes.PointGeometry
+print("unknown geom   -> points")
+
+# The row's OWN stored style is used when the caller passes none — the add path relies on this.
+layer = TileLayer()
+assert apply_to_vector_tiles(
+    layer, {"geometry_type": "Polygon",
+            "default_style": {"style": {"color_mode": "categorized", "color_field": "k",
+                                        "categories": [{"value": "a", "color": "#abcdef"}]}}},
+    "geodeploy")
+assert any(s.filter == '"k" = \'a\'' for s in layer.renderer.styles)
+print("row default    -> read from default_style when no style is passed")
+
+print("\nALL VECTOR-TILE SYMBOLOGY CASES PASS")

--- a/ui/src/components/data/VectorRow.vue
+++ b/ui/src/components/data/VectorRow.vue
@@ -47,12 +47,9 @@
       @click="onTile" :disabled="tiling || layer.tile_status === 'tiling'"
       class="p-1.5 rounded transition-all text-muted-foreground/70 hover:text-violet-400 disabled:opacity-40"
       :class="layer.tile_status === 'tiling' ? '' : 'opacity-0 group-hover:opacity-100'"
-      :title="layer.tile_status === 'ready' ? 'Re-tile for fast display (regenerate PMTiles)' : 'Tile for fast seamless display (PMTiles)'"
+      :title="tileTitle(layer)"
     >
-      <svg class="w-4 h-4" :class="(tiling || layer.tile_status === 'tiling') ? 'animate-pulse' : ''"
-        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
-        <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+      <TilesIcon class="w-4 h-4" :class="(tiling || layer.tile_status === 'tiling') ? 'animate-pulse' : ''" />
     </button>
     <!-- Restart processing: a file-backed (GeoParquet) layer whose convert/prep stalled or failed —
          re-runs the right stage without a re-upload (e.g. the worker was restarted mid-job). Left of
@@ -106,7 +103,8 @@
 <script setup>
 import { RouterLink } from 'vue-router'
 import { computed, ref, nextTick } from 'vue'
-import { TrashIcon, RefreshIcon, LinkIcon } from '@/views/icons'
+import { TrashIcon, RefreshIcon, LinkIcon, TilesIcon } from '@/views/icons'
+import { tileTitle, confirmTiling } from '@/lib/tiling'
 import { useAuthStore } from '@/stores/auth'
 import { useDataStore } from '@/stores/data'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
@@ -156,6 +154,7 @@ async function onReprocess() {
 }
 async function onTile() {
   if (tiling.value || props.layer.tile_status === 'tiling') return
+  if (!confirmTiling(props.layer)) return
   tiling.value = true
   try { await dataStore.tileVector(props.layer.id) }
   catch (e) { alert(e.response?.data?.detail || 'Could not start tiling.') }

--- a/ui/src/lib/tiling.js
+++ b/ui/src/lib/tiling.js
@@ -1,0 +1,42 @@
+// What the "tile this layer" control says, and what it asks before it runs.
+//
+// Two surfaces offer it — the row in My Data and the layer's own page — and they were drifting:
+// one said "Tile…" for a layer that was already tiled, and neither warned that pressing it throws
+// away a finished archive and rebuilds it. Tiling a large layer is minutes of worker time, so that
+// is a real cost to trigger by accident. One definition here, imported by both.
+
+/** Has this layer got a finished PMTiles archive? */
+export function isTiled(layer) {
+  return layer?.tile_status === 'ready'
+}
+
+/** Is tiling running right now? */
+export function isTiling(layer) {
+  return layer?.tile_status === 'tiling'
+}
+
+/** The control's tooltip — never "Tile…" for something already tiled. */
+export function tileTitle(layer) {
+  if (isTiling(layer)) return 'Tiling…'
+  if (isTiled(layer)) return 'Restart tiling — this layer is already tiled (rebuilds the PMTiles archive)'
+  return 'Tile for fast seamless display (PMTiles)'
+}
+
+/** The control's label, where there is room for one. */
+export function tileLabel(layer) {
+  if (isTiling(layer)) return 'Tiling…'
+  return isTiled(layer) ? 'Restart tiling' : 'Tile for fast display'
+}
+
+/**
+ * True to go ahead. Silent for a first tiling — nothing is at stake there; a confirmation for a
+ * restart, which discards a working archive and takes the layer back through the whole job.
+ */
+export function confirmTiling(layer) {
+  if (!isTiled(layer)) return true
+  return window.confirm(
+    `Tiling is already complete for "${layer?.name || 'this layer'}".\n\n` +
+    'Restarting it rebuilds the PMTiles archive from scratch. That can take several minutes on a ' +
+    'large layer, and the current tiles keep serving until the new ones are ready.\n\n' +
+    'Restart tiling?')
+}

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -74,11 +74,12 @@
         </svg>
       </button>
 
-      <button v-if="auth.canEdit && canTile && ready" @click="onTile" :disabled="tiling"
-        class="gd-act disabled:opacity-40"
-        :title="layer.tile_status === 'ready' ? 'Re-tile for fast display (regenerate PMTiles)'
-                                              : 'Tile for fast seamless display (PMTiles)'">
-        <LayersIcon class="w-4 h-4" :class="tiling ? 'animate-pulse' : ''" />
+      <!-- The SAME grid icon and the same wording My Data uses for this action, from one shared
+           definition — it is one action and it should not look or read like two. -->
+      <button v-if="auth.canEdit && canTile && ready" @click="onTile"
+        :disabled="tiling || isTiling(layer)" class="gd-act disabled:opacity-40"
+        :title="tileTitle(layer)">
+        <TilesIcon class="w-4 h-4" :class="(tiling || isTiling(layer)) ? 'animate-pulse' : ''" />
       </button>
 
       <button v-if="auth.canEdit && isVector && !isExternal" @click="onReprocess"
@@ -303,7 +304,8 @@ import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
 import ConfirmDeleteModal from '@/components/data/ConfirmDeleteModal.vue'
 import CreatePortalModal from '@/components/portal/CreatePortalModal.vue'
 import LegendSwatch from '@/components/LegendSwatch.vue'
-import { LinkIcon, TrashIcon, RefreshIcon, LayersIcon } from '@/views/icons'
+import { LinkIcon, TrashIcon, RefreshIcon, TilesIcon } from '@/views/icons'
+import { tileTitle, isTiling, confirmTiling } from '@/lib/tiling'
 
 // A label/value row. Rendered rather than templated because it must vanish entirely when the value
 // is absent — a "Bands: —" line on a vector layer is noise pretending to be information.
@@ -590,8 +592,13 @@ async function onStyleClosed() {
 }
 
 async function onTile() {
+  // Already tiled? Ask first — a restart discards a finished archive and re-runs a job that can
+  // take minutes. See lib/tiling.js; My Data asks the same question in the same words.
+  if (!confirmTiling(layer.value)) return
   tiling.value = true
-  try { await dataStore.tileVector(layer.value.id) } finally { tiling.value = false }
+  try { await dataStore.tileVector(layer.value.id) }
+  catch (e) { alert(e.response?.data?.detail || 'Could not start tiling.') }
+  finally { tiling.value = false }
 }
 async function onReprocess() {
   restarting.value = true

--- a/ui/src/views/README.md
+++ b/ui/src/views/README.md
@@ -63,6 +63,11 @@ Page-level route components. All except SetupWizard/Login render inside `Layout.
 - Raster layer `bbox` from the API is in source CRS (not lon/lat) — using it directly for `fitToBbox` can throw "Invalid LngLat" (see tasks/raster notes). Prefer zooming via vector bounds or TiTiler TileJSON.
 
 ## Last updated
+2026-08-17 (`LayerPage.vue` + `components/data/VectorRow.vue` share the tiling control's icon and
+wording: new `TilesIcon` in `views/icons.js` (the four-square grid My Data always used — the page had
+reached for `LayersIcon`, so one action wore two symbols) and new **`lib/tiling.js`** holding
+`tileTitle`/`tileLabel`/`confirmTiling`. An already-tiled layer now reads **"Restart tiling"** and asks
+before it runs, because a restart discards a finished archive and re-runs a job that takes minutes.)
 2026-08-07c (**the INVISIBLE legacy map was flooding the console with raster 404s.** `#portal-preview-map`
 is mounted behind the iframe at `opacity-0` and its comment claims "the build watch is neutered so it
 loads no data" — it is NOT: `ready.value = true` (line ~1163) lets the deep watcher run `applyStyle`,

--- a/ui/src/views/icons.js
+++ b/ui/src/views/icons.js
@@ -59,6 +59,16 @@ export const CopyIcon = { render: () => h('svg', { viewBox: '0 0 24 24', fill: '
 ]) }
 // Stacked tiles — the PMTiles action, and the closest thing to "pre-cut into pieces".
 export const LayersIcon = icon('M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5')
+// Tiling — the four-square grid, NOT LayersIcon. My Data has drawn the "tile this layer" action as
+// this grid since it existed; the layer page reached for the stack of layers instead, so the same
+// action wore two symbols and the stack already means "a layer" everywhere else. Exported here so
+// the two places share one definition rather than each keeping an inline copy.
+export const TilesIcon = { render: () => h('svg', { viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', 'stroke-width': 2, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }, [
+  h('rect', { x: 3, y: 3, width: 7, height: 7 }),
+  h('rect', { x: 14, y: 3, width: 7, height: 7 }),
+  h('rect', { x: 14, y: 14, width: 7, height: 7 }),
+  h('rect', { x: 3, y: 14, width: 7, height: 7 }),
+]) }
 export const RefreshIcon = icon('M23 4v6h-6M1 20v-6h6M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15')
 export const MailIcon = { render: () => h('svg', { viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', 'stroke-width': 2, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }, [
   h('rect', { x: 2, y: 4, width: 20, height: 16, rx: 2 }),


### PR DESCRIPTION
Both halves of "QGIS is very very slow, even for a very light shapefile" — measured, not guessed.

## 1. `PMTiles` is fast in MapLibre, not in GDAL

GDAL's PMTiles driver has **no viewport**. It presents the archive as one dataset, so QGIS's opening questions (feature count, extent) walk every tile at the deepest zoom over HTTP.

Read from each archive's v3 header on the live instance:

| layer | features | zooms | tile entries |
|---|---|---|---|
| `example` | **5** | 0–13 | **2,171,238** |
| `heigit_ago_roadsurface_lines` | 349k | 0–13 | 41,991 |
| `CO` | 2.08M | 0–13 | 20,026 |

The five-feature layer is the pathological one — `--extend-zooms-if-still-dropping` builds a deep pyramid for sparse data — so the "obvious fast path" was slowest exactly where it looked safest.

**New:** `services/pmtiles_reader.py` (PMTiles v3, read-only, no new dependency) and `GET /api/data/vector/{ref}/tiles/{z}/{x}/{y}`. One S3 range read per tile in the steady state; header and root directory cached; 204 for a tile the archive lacks, since sparse is normal and a 404 invites retries.

## 2. `zmax=22`

A vector-tile layer built from a bare template asserts that tiles exist at every zoom. Past the depth the server has data, QGIS requests fresh tiles, gets empties, **retries each three times** and renders nothing — reported as "vanishes when I zoom in", "loading forever", and the retry storms in the log. Given the real range it over-zooms the deepest real tile instead: same picture, no request.

The plugin now reads the **TileJSON** for every vector layer — template, zoom range, bounds, and `vector_layers[].id` — for PostGIS (Martin) and tiled GeoParquet alike. `vector_tilejson` serves file-backed layers too, reading those values from the archive rather than guessing, and caps the PostGIS branch at `maxzoom: 18`.

Nothing in the UI, templates or `portal_generator` consumes this TileJSON — it is interop-only, so **the portals are untouched**.

## Symbology is no longer the price of speed

`QgsVectorTileBasicRenderer` takes a list of styles each with its own **filter expression** — structurally the same as MapLibre's `step`/`match` — so graduated and categorized styles translate directly, one style per class, through the same `_symbol_of` the feature path uses. New `symbology.apply` picks the renderer from the layer's **type**, which is what the portal-group path got wrong (it handed tile layers to `apply_to_qgis`, which silently did nothing).

## Also

- Portal tree items keep the whole row — QGIS group names showed slugs while the dock showed titles.
- Tile layers get their real extent, so "zoom to layer" lands on the layer.
- The layer page and My Data share one tile icon, one wording and one confirmation; an already-tiled layer reads **"Restart tiling"** and asks before rebuilding.
- `sources.fallback` + `_open_best` degrade tiles → archive → OAPIF, so an instance without the new endpoint still opens.

## Tests

12 for the reader against hand-built archives (Hilbert ids, leaf directories, run lengths, read counts), plus tile-symbology and source-selection suites. All three wired into CI.