### PR TITLE
Bump the QGIS plugin to 0.1.1

### DIFF
--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.0
+version=0.1.1
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,5 +21,10 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.0 - First release: browse an instance (public data without an account), add vector and
+changelog=0.1.1 - Vector layers are added through their TileJSON, so QGIS asks only for tiles that
+    exist: no more requests past the deepest real zoom, and "Zoom to layer" lands on the layer. A
+    PMTiles archive is no longer opened whole (GDAL reads every tile at the deepest zoom to answer
+    a feature count). Vector-tile layers now carry the layer's real symbology - graduated and
+    categorized classes, not just a base colour. Portal groups show the portal's title.
+    0.1.0 - First release: browse an instance (public data without an account), add vector and
     raster layers, upload the active layer.


### PR DESCRIPTION
The zip in `dist/` was built before the tile-speed and symbology work, and that zip is what gets dragged into *Install from ZIP* — so the plugin would have looked unchanged however much changed behind it. Bumping the version means which build is installed is never a guess.

The zip itself stays out of git: it is a build output of `scripts/build.py` (already covered by `.gitignore`), and plugins.qgis.org wants it uploaded there rather than carried in the repository.

One file changed: `metadata.txt` — version + a changelog entry naming the four user-visible changes.