### PR TITLE
Draw points at the size and colour the map draws them

### DIFF
--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,16 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17b (**points were drawn at a third of their size, under a dark outline.** `_use_points`
+switches a symbol's unit to points but left QGIS's default marker NUMBER (2.0, meant as mm) standing,
+so a style that names a colour and no radius — which most do; `/legend` returns `{"color": "#3b82f6"}`
+— came out at 0.7 mm, under QGIS's default dark-grey outline, which at that size covers the fill.
+Tiny black dots where the browser drew visible blue ones, and only POINT layers were affected, which
+is why some layers looked styled and some did not. `_symbol_of` now ALWAYS sets the size, defaulting
+to the portal's own `circle-radius: 5`, with the white 1 px stroke the map draws
+(`DEFAULT_POINT_RADIUS`/`DEFAULT_POINT_STROKE`, kept in step with mapStyle.js / portal_generator /
+portal.js). Verified against the live instance: the anonymous `/legend` path resolves a style for
+every public layer, so it was never the styles that were missing.)
 2026-08-17 (**speed and symbology, both measured.** `sources.describe` now sends EVERY vector layer
 down one viewport-driven path — a **TileJSON**, for PostGIS (Martin) and tiled GeoParquet (the new
 per-tile endpoint) alike — and `plugin._vector_tiles` READS it for the tile template, the real zoom

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.1
+version=0.1.2
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,11 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.1 - Vector layers are added through their TileJSON, so QGIS asks only for tiles that
+changelog=0.1.2 - Points are drawn at the size and colour the map draws them. A layer whose style
+    names a colour but no radius kept QGIS's default marker number under our points unit - a third
+    of the intended size - under QGIS's dark default outline, so styled point layers arrived as
+    tiny black dots. They now take the portal's own defaults: radius 5, white 1px stroke.
+    0.1.1 - Vector layers are added through their TileJSON, so QGIS asks only for tiles that
     exist: no more requests past the deepest real zoom, and "Zoom to layer" lands on the layer. A
     PMTiles archive is no longer opened whole (GDAL reads every tile at the deepest zoom to answer
     a feature count). Vector-tile layers now carry the layer's real symbology - graduated and

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -99,6 +99,26 @@ def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
 #: pixel is 0.75 pt and the symbol keeps its size on screen wherever it is drawn.
 CSS_PX_TO_POINTS = 0.75
 
+#: What the map draws a point as when its style says nothing: `circle-radius: 5` with a white 1 px
+#: stroke. Kept in step with `ui/src/lib/mapStyle.js`, `services/portal_generator.py` and
+#: `templates/shared/portal.js` — the same three surfaces the project's parity rule names. They are
+#: the defaults a layer with no saved style is ALREADY being drawn with in a browser, so matching
+#: them is what makes QGIS and the portal show the same map.
+DEFAULT_POINT_RADIUS = 5
+DEFAULT_POINT_STROKE = 1
+
+
+def _set_stroke_width(layer0, width: float) -> None:
+    """Set a marker's outline width, whatever this QGIS calls the setter."""
+    for name in ("setStrokeWidth", "setOutlineWidth"):
+        fn = getattr(layer0, name, None)
+        if callable(fn):
+            try:
+                fn(width)
+                return
+            except Exception:           # noqa: BLE001 - an outline is not worth failing the style
+                pass
+
 
 def _use_points(symbol, layer0) -> None:
     """Measure this symbol in POINTS, so it matches the size GeoDeploy draws.
@@ -158,21 +178,29 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
             except Exception:           # noqa: BLE001 - shape names shift between QGIS versions
                 pass
         _use_points(symbol, layer0)
-        if style.get("radius"):
-            # GeoDeploy's radius is in PIXELS and QGIS's size is a DIAMETER — so double it, and
-            # (above) tell QGIS the number is pixels. Without that it is read as millimetres, and a
-            # radius of 5 becomes a 10 mm marker: roughly four times too big on screen, which is
-            # exactly how it looked.
-            symbol.setSize(float(style["radius"]) * 2 * CSS_PX_TO_POINTS)
+        # ALWAYS set the size — never leave QGIS's default number standing under a unit we just
+        # changed. QGIS's default marker is 2.0 in MILLIMETRES; switching the unit to points turns
+        # the same 2.0 into 0.7 mm, a third of the size, which is how a styleless point layer came
+        # out as dots too small to see next to the same layer in a browser. The fallback is the
+        # portal's own default (`circle-radius: 5` in mapStyle.js, portal_generator and portal.js
+        # alike), so a layer with no saved radius matches the web instead of matching nothing.
+        #
+        # GeoDeploy's radius is in CSS PIXELS and QGIS's size is a DIAMETER, hence the doubling.
+        symbol.setSize(float(style.get("radius") or DEFAULT_POINT_RADIUS) * 2 * CSS_PX_TO_POINTS)
         outline = style.get("outline_color")
-        if outline and outline != "none":
-            layer0.setStrokeColor(QColor(outline))
-        elif outline == "none":
+        if outline == "none":
             layer0.setStrokeStyle(Qt.NoPen)
+        else:
+            # A WHITE hairline by default, because that is what the map draws
+            # (`circle-stroke-color: #ffffff`, `circle-stroke-width: 1`) — and because QGIS's own
+            # default is a dark grey outline, which on a small marker covers the fill completely
+            # and turns every point black whatever colour the style asked for.
+            layer0.setStrokeColor(QColor(outline or "#ffffff"))
+            _set_stroke_width(layer0, DEFAULT_POINT_STROKE * CSS_PX_TO_POINTS)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
         _use_points(symbol, layer0)
         if style.get("line_width"):
-            # In pixels now (see `_use_pixels`), so the width IS the width — no mm conversion, and
+            # In points now (see `_use_points`), so the width IS the width — no mm conversion, and
             # no divide-by-four fudge that was only ever right at one screen DPI.
             layer0.setWidth(float(style["line_width"]) * CSS_PX_TO_POINTS)
         dash = (style.get("lineType") or "solid").lower()

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -48,10 +48,16 @@ class _SymbolLayer:
     def __init__(self):
         self.width = None
         self.stroke = None
+        self.stroke_width = None
         self.pen = None
 
     def setWidth(self, w):
         self.width = w
+
+    def setStrokeWidth(self, w):
+        # A marker's OUTLINE width — a different setter from setWidth, which is a line's own width.
+        # Missing it here is how the first run of this test passed while the stroke went unset.
+        self.stroke_width = w
 
     def setStrokeColor(self, c):
         self.stroke = c
@@ -258,6 +264,30 @@ out = styles_for({"geometry_type": "Point"},
                   "categories": [{"value": 1, "color": "#f00"}, {"value": 2, "color": "#0f0"}]})
 assert out[1].filter == '"zone" = 1', out[1].filter
 print("numeric values -> unquoted literals")
+
+# ── the defaults a styleless point layer gets ────────────────────────────────────────────────
+# THE BUG THIS PINS: a real layer's style is often just {"color": "#3b82f6"} — no radius. QGIS's
+# default marker is 2.0 in MILLIMETRES, and `_use_points` switches the unit to points without
+# touching the number, so the same 2.0 became 0.7 mm: dots too small to see. QGIS's default outline
+# is dark grey, which at that size covers the fill entirely and turns every point black whatever
+# colour was asked for. Both symptoms, one screenshot, one cause.
+out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6"})
+assert out[0].symbol.color == "#3b82f6"
+assert out[0].symbol.size == 5 * 2 * 0.75, ("a point with no radius must take the PORTAL's default "
+                                            "(circle-radius 5), not QGIS's number under our unit")
+stroke = out[0].symbol.symbolLayer(0)
+assert stroke.stroke.name() == "#ffffff", "the map draws circle-stroke-color #ffffff"
+assert stroke.stroke_width == 1 * 0.75, "…at circle-stroke-width 1"
+print("styleless point -> portal defaults: radius 5, white 1px stroke")
+
+# An explicit outline still wins over the default.
+out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6", "outline_color": "#000000"})
+assert out[0].symbol.symbolLayer(0).stroke.name() == "#000000"
+# …and "none" still means none.
+out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6", "outline_color": "none"})
+assert out[0].symbol.symbolLayer(0).pen == 0, "outline_color 'none' must set NoPen"
+print("point outline   -> explicit colour wins, 'none' means none")
+
 
 # ── single symbol, and the degrade paths ─────────────────────────────────────────────────────
 out = styles_for({"geometry_type": "Point"}, {"color": "#3388ff", "radius": 6, "marker": "square"})


### PR DESCRIPTION
A styled point layer arrived in QGIS as dots too small to see, in near-black rather than its own colour — while the same layer in a browser drew visible blue ones.

**One cause, both symptoms.** `_use_points` switches a symbol's unit to points, but the size was only set when the style carried an explicit `radius`. Most styles do not: `/legend` returns `{"color": "#3b82f6"}` for a single-symbol layer. So QGIS's default marker number of `2.0` — meant as *millimetres* — was reinterpreted as 2 **points**, i.e. 0.7 mm. At that size QGIS's default dark-grey outline covers the fill completely, which is where the colour went.

Only **point** layers were affected. That is why some layers looked styled and some did not.

`_symbol_of` now always sets the size, falling back to the portal's own defaults — `circle-radius: 5` and a white `circle-stroke-width: 1`, the same in `mapStyle.js`, `portal_generator.py` and `portal.js`.

## Verified before changing anything

Ran the vendored client against the live instance with **no token**, the plugin's own anonymous path:

```
OK  average-latitude-longitude-countries   color_mode=single       entries=1
OK  average-latitude-longitude-countries   color_mode=graduated    entries=5
OK  referentiel_administratif              color_mode=categorized  entries=5
OK  shapefiles_dresden                     color_mode=single       entries=1
OK  CO / example / heigit_ago / heigit_tza  …
```

Every public layer resolves a correct style anonymously. The styles were never missing — they were invisible.

Tests pin the defaults, including that an explicit `outline_color` still wins and `"none"` still means none. Plugin bumped to 0.1.2.