### PR TITLE
A portal's raster keeps the portal's styling, and opacity travels both ways

### DIFF
--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,21 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17c (**a portal's raster was drawn in the layer's DEFAULT style.** A raster is coloured by
+the server, and a portal bakes its colormap/stretch/band/hillshade into its OWN tile URL — proven on
+the live instance, where one `Degfert_DEM_restr.tif` appears as `&colormap_name=terrain` in one
+portal and a bare `&rescale=264.9,298.33` in another, and `Degfert_DEM.tif` as
+`&algorithm=hillshade&expression=b1*5.0` in a third. `open_portal_as_group` now prefers
+`_layer_from_portal_source` for rasters, and that path keeps the PORTAL's template (an earlier edit
+had it reach for the layer's TileJSON, which would have reintroduced the default style); bounds come
+separately from `_raster_bounds`. **Opacity travels IN now too** — `_set_opacity`, applied from the
+portal's `layer_configs[].opacity` and from a layer's stored `default_style.opacity`. The push side
+already sent it, so a portal opened solid and then reported a change nobody made.
+**Push semantics, confirmed unchanged and correct:** `portals.push` writes `layer_configs` only, so
+restyling inside a group changes that PORTAL; "Save styling to GeoDeploy" writes the layer's DEFAULT
+style. **Units:** symbols are measured in POINTS — device-independent and constant across zoom, the
+same behaviour as the browser's CSS pixels. Nothing uses map units, which is the only thing that
+would resize on zoom; the "too small when zoomed in" report was the 0.1.2 size bug, not the unit.)
 2026-08-17b (**points were drawn at a third of their size, under a dark outline.** `_use_points`
 switches a symbol's unit to points but left QGIS's default marker NUMBER (2.0, meant as mm) standing,
 so a style that names a colour and no radius — which most do; `/legend` returns `{"color": "#3b82f6"}`

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.2
+version=0.1.3
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,11 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.2 - Points are drawn at the size and colour the map draws them. A layer whose style
+changelog=0.1.3 - A raster opened as part of a portal is drawn the way THAT portal draws it, not
+    in the layer's default style - the portal bakes its colormap, stretch and hillshade into its own
+    tile URL, and the same raster can look different in two portals. Layer opacity now travels in as
+    well as out, so a half-transparent overlay opens half-transparent.
+    0.1.2 - Points are drawn at the size and colour the map draws them. A layer whose style
     names a colour but no radius kept QGIS's default marker number under our points unit - a third
     of the intended size - under QGIS's dark default outline, so styled point layers arrived as
     tiny black dots. They now take the portal's own defaults: radius 5, white 1px stroke.

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -67,6 +67,32 @@ def _xyz_uri(tile_url: str, zmin=None, zmax=None) -> str | None:
         return None
 
 
+def _set_opacity(layer, opacity) -> None:
+    """Draw `layer` at the portal's opacity. Silent when there is nothing to apply.
+
+    Two APIs, because QGIS has two: `QgsMapLayer.setOpacity` covers vector, vector-tile and (from
+    3.18) raster layers, while an older QGIS puts a raster's opacity on its renderer. Trying both
+    is cheaper than version-sniffing and cannot be wrong.
+    """
+    try:
+        value = float(opacity)
+    except (TypeError, ValueError):
+        return
+    if not 0.0 <= value <= 1.0 or value == 1.0:
+        return                          # out of range, or nothing to change
+    try:
+        setter = getattr(layer, "setOpacity", None)
+        if callable(setter):
+            setter(value)
+        else:
+            renderer = getattr(layer, "renderer", lambda: None)()
+            if renderer is not None and hasattr(renderer, "setOpacity"):
+                renderer.setOpacity(value)
+        layer.triggerRepaint()
+    except Exception as exc:            # noqa: BLE001 - never fail an add over transparency
+        symbology._log("Could not set the opacity: {0}".format(exc))
+
+
 class GeoDeployDock(QDockWidget):
     # Progress arrives from the QgsTask's worker thread, and Qt widgets may only be touched on the
     # GUI thread. A signal is the crossing: emitting is safe from anywhere, and the connected slot
@@ -434,6 +460,10 @@ class GeoDeployDock(QDockWidget):
             return
 
         QgsProject.instance().addMapLayer(layer)
+        # The stored style is `{opacity, style: {...}, popup_fields}` — the plugin only ever read
+        # the inner `style`, so a layer saved at 50% arrived opaque.
+        if isinstance(row.get("default_style"), dict):
+            _set_opacity(layer, row["default_style"].get("opacity"))
         applied = ""
         if self.styled.isChecked() and source["kind"] != "cog":
             style = (row.get("default_style") or {}).get("style") if row.get("default_style") else None
@@ -569,13 +599,18 @@ class GeoDeployDock(QDockWidget):
             ref = cfg.get("layer_id")
             base = self.instance.url.rstrip("/") if self.instance else ""
             if kind == "raster-xyz":
-                # The instance publishes a TileJSON for the same raster, and it carries the bounds
-                # a bare template has none of — so "zoom to layer" works on a portal group too.
-                layer = (self._raster_from_tilejson(
-                    f"{base}/api/data/raster/{ref}/tilejson", name) if base and ref else None)
-                if layer is None:
-                    uri = _xyz_uri(url)
-                    layer = QgsRasterLayer(uri, name, "wms") if uri else None
+                # THE PORTAL'S OWN TEMPLATE, deliberately — not the layer's TileJSON. A raster is
+                # coloured by the server, and this URL is where that colouring lives: the same
+                # raster appears as `&colormap_name=terrain` in one portal and
+                # `&algorithm=hillshade&expression=b1*5.0` in another. Swapping in the layer's
+                # TileJSON would draw every portal in the layer's DEFAULT style, which is the one
+                # style none of them chose.
+                uri = _xyz_uri(url)
+                layer = QgsRasterLayer(uri, name, "wms") if uri else None
+                # The bounds still come from the instance, since a bare template has none — that
+                # part of the TileJSON is about WHERE the raster is, not how it is drawn.
+                if layer is not None and layer.isValid():
+                    self._set_tile_extent(layer, self._raster_bounds(ref))
             elif kind == "pmtiles":
                 # NOT the archive. A portal names it because MapLibre reads it a tile at a time;
                 # GDAL cannot, and opening one here is what made a portal group hang. The same
@@ -608,6 +643,26 @@ class GeoDeployDock(QDockWidget):
             portal_sync.tag_layer(layer, self.instance.url, cfg.get("layer_id"),
                                   cfg.get("layer_type") or "vector")
         return layer
+
+    def _raster_bounds(self, ref):
+        """WGS84 bounds for a raster, from the listing if we have it or the instance if we do not.
+
+        Only the bounds — the STYLING for a portal layer comes from the portal's own tile URL, and
+        reading both from the same document is how a portal ended up drawn in the layer's default
+        colours.
+        """
+        row = self._row_for(ref, "raster")
+        if row and row.get("bbox"):
+            return row["bbox"]
+        if not (self.instance and ref is not None):
+            return None
+        try:
+            doc = self.instance.fetch_json(
+                "{0}/api/data/raster/{1}/tilejson".format(self.instance.url.rstrip("/"), ref))
+            return (doc or {}).get("bounds")
+        except GeoDeployError as exc:
+            symbology._log("Could not read the raster's bounds: {0}".format(exc))
+            return None
 
     def _raster_from_wmts(self, url, name):
         """A raster layer from the instance's WMTS capabilities.
@@ -824,13 +879,23 @@ class GeoDeployDock(QDockWidget):
                     continue
                 label = str(cfg.get("name") or cfg.get("layer_id"))
                 layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
-                if layer_row is not None:
+                is_raster = cfg.get("layer_type") == "raster"
+                layer = None
+                if is_raster and (cfg.get("source") or {}).get("url"):
+                    # THE PORTAL'S OWN TILES. A raster is styled by the server, and the portal bakes
+                    # its colormap, stretch, band choice and hillshade into the tile URL — so the
+                    # SAME raster reads `&colormap_name=terrain` in one portal, a bare `&rescale=`
+                    # in another and `&algorithm=hillshade&expression=b1*5.0` in a third. Building
+                    # it from the layer's own listing entry instead gave everyone the layer's
+                    # DEFAULT style, which is not what any of those portals shows.
+                    layer = self._layer_from_portal_source(cfg, label)
+                if layer is None and layer_row is not None:
                     source = sources.describe(layer_row,
                                               prefer_attributes=self.attributes.isChecked())
                     layer = (self._open_best(layer_row, source,
                                              layer_row.get("name") or "layer")[0]
                              if source else None)
-                else:
+                if layer is None and layer_row is None:
                     # Not in the listing: a layer that is not itself published, on a portal that
                     # is. The portal's own style says where it draws from, and that source is
                     # readable by anyone who can read the portal — which is the whole point.
@@ -841,6 +906,11 @@ class GeoDeployDock(QDockWidget):
                 project.addMapLayer(layer, False)   # False: placed into the group, not the root
                 tree_node = parent.addLayer(layer)
                 tree_node.setItemVisibilityChecked(bool(cfg.get("visible", True)))
+                # OPACITY IS PART OF THE PICTURE. The portal stores it per layer and the push path
+                # already sends it back, but nothing applied it on the way IN — so a half-transparent
+                # overlay opened solid, hid what it was drawn over, and pushing the group back then
+                # reported it as a change the user never made.
+                _set_opacity(layer, cfg.get("opacity"))
                 style = (cfg.get("style") or {}) if self.styled.isChecked() else {}
                 if style and cfg.get("layer_type") != "raster":
                     # THE PORTAL'S style wins over the layer's default here — that is what opening


### PR DESCRIPTION
## A portal's raster was drawn in the layer's default style

A raster is coloured by the server, and a portal bakes that colouring into its **own** tile URL. Read off the live instance — the same file, three portals:

```
Degfert_DEM_restr.tif&rescale=264.9,298.33&colormap_name=terrain
Degfert_DEM_restr.tif&rescale=264.9,298.33
Degfert_DEM.tif&bidx=1&algorithm=hillshade&expression=b1*5.0
```

Opening a portal as a group built rasters from the layer's own listing entry, so every portal came in wearing the layer's **default** style — the one style none of them chose.

The group path now prefers the portal's source for rasters, and that path keeps the **portal's** template rather than reaching for the layer's TileJSON (an earlier edit this week had it do exactly that, which would have put the default style straight back). Bounds come separately, from the listing row or the instance, since a bare template has none.

## Opacity travels in, not just out

Applied from a portal's `layer_configs[].opacity` and from a layer's stored `default_style.opacity`. The push side already sent it — so a half-transparent overlay opened solid, hid what it was drawn over, and then reported itself as a change nobody made.

## Two things checked and deliberately left alone

**Push semantics** are already what was asked for: `portals.push` writes `layer_configs` only, so restyling inside a group changes *that portal*; "Save styling to GeoDeploy" is the separate action that writes a layer's *default* style.

**Units** are correct. Symbols are measured in **points** — device-independent (1/72 inch) and constant across zoom, the same behaviour as the browser's CSS pixels. Nothing uses map units, which is the only thing that would resize on zoom. The "too small when zoomed in" report was the size bug fixed in 0.1.2: 2 pt ≈ 0.7 mm stayed 0.7 mm however far you zoomed.