### PR TITLE
One redraw per layer, no I/O mid-build, and a portal that looks like the portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,11 @@ jobs:
       - name: The plugin picks the fast source, and degrades when it is absent
         run: python integrations/qgis-plugin/scripts/test_sources.py
 
+      - name: An anonymous portal is rebuilt with the PORTAL's styling
+        # The style.json path has no token and no API behind it, so nothing else catches a portal
+        # that opens in the layers' default colours or quietly loses a layer to a clashing id.
+        run: python integrations/qgis-plugin/scripts/test_published_style.py
+
       - name: metadata.txt has what plugins.qgis.org requires
         run: |
           python - <<'PY'

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -315,6 +315,53 @@ async def rename_layer(
 # A bbox is REQUIRED here: the whole raster is already a single file, streamed by range request
 # from /cog, so a "whole raster export" would spend worker minutes re-encoding a worse copy.
 
+# ── Public-read authorization for the raster DESCRIPTION endpoints ────────────────────────────
+# `is_public` alone is too strict for these, and the inconsistency was visible from outside: a
+# raster that is public only THROUGH a published portal serves its tiles (200) while its own
+# TileJSON and WMTS answered 404 — so a client could draw the raster but not discover where it is.
+# QGIS hit exactly that: "Could not read the raster's bounds: HTTP Error 404". The vector side has
+# always used the wider rule (`vector._publicly_readable`); this is the raster twin of it.
+#
+# Deliberately NOT applied to `/cog` or `/export`: those hand over the pixels, and "shown in a
+# portal" is a licence to look at a picture, not to download the source data.
+_PUBLISHED_RASTER_IDS: set[int] | None = None
+
+
+def invalidate_public_rasters() -> None:
+    global _PUBLISHED_RASTER_IDS
+    _PUBLISHED_RASTER_IDS = None
+
+
+async def _published_raster_ids(db: AsyncSession) -> set[int]:
+    global _PUBLISHED_RASTER_IDS
+    if _PUBLISHED_RASTER_IDS is None:
+        import json as _json
+        from ...models import Portal
+        rows = (await db.execute(
+            select(Portal.layer_configs).where(Portal.published == True))).scalars().all()  # noqa: E712
+        ids: set[int] = set()
+        for cfg in rows:
+            try:
+                configs = _json.loads(cfg) if isinstance(cfg, str) else (cfg or [])
+                for lc in configs:
+                    if lc.get("layer_id") is not None and lc.get("layer_type") == "raster":
+                        ids.add(int(lc["layer_id"]))
+            except (ValueError, TypeError, AttributeError):
+                continue
+        _PUBLISHED_RASTER_IDS = ids
+    return _PUBLISHED_RASTER_IDS
+
+
+async def _describable(layer, db: AsyncSession) -> bool:
+    """True if this raster's DESCRIPTION may be served anonymously: shared, or drawn by a
+    published portal. Mirrors `vector._publicly_readable`."""
+    if not layer or layer.status != "ready" or not layer.s3_key:
+        return False
+    if getattr(layer, "is_public", False):
+        return True
+    return layer.id in await _published_raster_ids(db)
+
+
 @router.post("/{layer_ref}/export", status_code=202)
 async def start_raster_export(layer_ref: str, req: exports.LayerExportRequest,
                               db: AsyncSession = Depends(get_db)):
@@ -462,7 +509,7 @@ async def raster_tilejson(layer_ref: str, request: Request, db: AsyncSession = D
 
     result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
     layer = result.scalar_one_or_none()
-    if not layer or layer.status != "ready" or not layer.is_public or not layer.s3_key:
+    if not await _describable(layer, db):
         raise HTTPException(404, "No shared raster for this layer.")
 
     proto = request.headers.get("x-forwarded-proto") or request.url.scheme
@@ -548,7 +595,7 @@ async def raster_wmts(layer_ref: str, request: Request, db: AsyncSession = Depen
 
     result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
     layer = result.scalar_one_or_none()
-    if not layer or layer.status != "ready" or not layer.is_public or not layer.s3_key:
+    if not await _describable(layer, db):
         raise HTTPException(404, "No shared raster for this layer.")
 
     proto = request.headers.get("x-forwarded-proto") or request.url.scheme

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -50,6 +50,15 @@ def invalidate_public_layers() -> None:
     global _PUBLISHED_VECTOR_IDS
     _PUBLISHED_VECTOR_IDS = None
     _PMTILES_KEY_CACHE.clear()
+    # The raster side keeps the same kind of cache for its description endpoints, and the events
+    # that invalidate one invalidate the other — every caller already reaches for this function, so
+    # forwarding here is what stops the two from drifting. Imported lazily: raster.py imports from
+    # this module, so a top-level import would be circular.
+    try:
+        from .raster import invalidate_public_rasters
+        invalidate_public_rasters()
+    except ImportError:                 # pragma: no cover - only during a partial import
+        pass
     _PARQUET_PREFIX_CACHE.clear()
 
 

--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -32,6 +32,10 @@ class Instance:
         self.url = normalize_url(url)
         self.token = token or None
         self.client = Client(self.url, token=self.token)
+        # url -> parsed document, or the GeoDeployError it failed with. Per CONNECTION, so
+        # reconnecting is the way to drop it — these describe layers, and a layer's description
+        # does not change while you are looking at it. See `fetch_json`.
+        self._doc_cache: dict = {}
 
     # -- discovery ---------------------------------------------------------------------------------
 
@@ -69,24 +73,54 @@ class Instance:
                 pass
         return (self.client.catalog.public() or {}).get("portals") or []
 
-    def fetch_json(self, url: str) -> dict:
+    def fetch_json(self, url: str, cache: bool = True) -> dict:
         """GET any URL on this instance as JSON, with the token when there is one.
 
         The layer surfaces (TileJSON, WMTS, legends) are ordinary URLs rather than client methods,
         and a private layer's are behind the credential — so this carries it, and the same
         User-Agent as everything else.
+
+        CACHED BY DEFAULT, and that is a speed fix rather than a nicety. These documents describe a
+        layer, not its data: a TileJSON, a legend, a set of bounds. Opening a seven-layer portal
+        asked for a dozen of them, one after another, and every one was a blocking round trip —
+        which is a large part of what "QGIS freezes for a while" was. They are re-read when the
+        instance is reconnected, which is the only moment they can meaningfully change.
         """
         import json
         from urllib.request import Request, urlopen
+
+        if cache and url in self._doc_cache:
+            hit = self._doc_cache[url]
+            if isinstance(hit, Exception):
+                raise hit               # a 404 is an answer too; do not ask again for it
+            return hit
 
         headers = {"User-Agent": self._c_user_agent(), "Accept": "application/json"}
         if self.token:
             headers["Authorization"] = "Bearer {0}".format(self.token)
         try:
             with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
-                return json.loads(response.read().decode("utf-8"))
+                doc = json.loads(response.read().decode("utf-8"))
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
-            raise GeoDeployError("Could not read {0}: {1}".format(url, exc))
+            error = GeoDeployError("Could not read {0}: {1}".format(url, exc))
+            if cache:
+                self._doc_cache[url] = error
+            raise error
+        if cache:
+            self._doc_cache[url] = doc
+        return doc
+
+    def prefetch(self, urls) -> None:
+        """Warm the cache for several documents. Safe to call from a WORKER thread — which is the
+        point: the layers themselves must be built on the GUI thread, so the network part is done
+        before that starts rather than one blocking request at a time in the middle of it."""
+        for url in urls:
+            if not url or url in self._doc_cache:
+                continue
+            try:
+                self.fetch_json(url)
+            except GeoDeployError:
+                pass                    # already recorded in the cache; the caller degrades
 
     def fetch_text(self, url: str) -> str:
         """GET a URL on this instance as text — WMTS capabilities are XML, not JSON."""

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.3
+version=0.1.4
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,14 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.3 - A raster opened as part of a portal is drawn the way THAT portal draws it, not
+changelog=0.1.4 - Opening a portal is much faster and looks like the portal. Layers are styled
+    before they join the map instead of after (one redraw each, not two), the canvas is frozen while
+    a group is assembled (one redraw for the whole portal, not one per layer), and the documents
+    that describe a layer are fetched once and reused - in the background thread, not between
+    layers. A portal opened WITHOUT an account now uses the portal's own colours, width, outline and
+    transparency rather than each layer's default style, and no longer loses a layer when a vector
+    and a raster share an id. Polygons are drawn at the map's 45% fill, lines at its default width.
+    0.1.3 - A raster opened as part of a portal is drawn the way THAT portal draws it, not
     in the layer's default style - the portal bakes its colormap, stretch and hillshade into its own
     tile URL, and the same raster can look different in two portals. Layer opacity now travels in as
     well as out, so a half-transparent overlay opens half-transparent.

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -459,30 +459,17 @@ class GeoDeployDock(QDockWidget):
             self._say(f"QGIS could not open the {source['kind']} source for {name}.", Qgis.Critical)
             return
 
-        QgsProject.instance().addMapLayer(layer)
-        # The stored style is `{opacity, style: {...}, popup_fields}` — the plugin only ever read
-        # the inner `style`, so a layer saved at 50% arrived opaque.
-        if isinstance(row.get("default_style"), dict):
-            _set_opacity(layer, row["default_style"].get("opacity"))
+        # EVERYTHING BEFORE THE LAYER GOES ON THE MAP. Adding it first and styling it after is what
+        # made layers appear plain and then visibly change: QGIS starts rendering the moment a layer
+        # joins the project, so the whole canvas was drawn once with the default look, then again
+        # once the style landed. Two full renders per layer, and the first one wrong.
         applied = ""
+        if isinstance(row.get("default_style"), dict):
+            # The stored style is `{opacity, style: {...}, popup_fields}` — the plugin only ever
+            # read the inner `style`, so a layer saved at 50% arrived opaque.
+            _set_opacity(layer, row["default_style"].get("opacity"))
         if self.styled.isChecked() and source["kind"] != "cog":
-            style = (row.get("default_style") or {}).get("style") if row.get("default_style") else None
-            if style is None and self.instance:
-                # A public row carries no style. `layers.resolve` needs a token, so for anonymous
-                # browsing — the plugin's headline promise — it can only fail, and every public
-                # layer arrived unstyled. `/legend` is PUBLIC and is what the portal draws from.
-                try:
-                    ref = row.get("uid") or row.get("id")
-                    # `legend` is defined on the VECTOR and RASTER namespaces, not on the
-                    # kind-agnostic `layers` helper — asking the latter is an AttributeError, which
-                    # is what every unstyled layer was really hitting.
-                    kind = "raster" if (row.get("layer_type") == "raster"
-                                        or row.get("storage_backend") == "raster") else "vector"
-                    legend = self.instance.client.layers.api(kind).legend(ref)
-                    style = symbology.style_from_legend(legend)
-                except GeoDeployError as exc:
-                    symbology._log(f"Could not read the legend for {name}: {exc}")
-                    style = None
+            style = self._style_for_row(row, name)
             if style:
                 # `symbology.apply` picks the renderer from the layer's TYPE — feature layers and
                 # vector-tile layers need different ones, and choosing here by source kind is how
@@ -494,7 +481,36 @@ class GeoDeployDock(QDockWidget):
             else:
                 # Distinguish "has no style" from "has one we failed to use". The first is normal.
                 applied = " (no saved style on this layer)"
+        QgsProject.instance().addMapLayer(layer)
         self._say(f"Added {name} — {source['why']}{applied}.")
+
+    def _style_for_row(self, row, name):
+        """A layer's own saved style, from the row if it carries one or `/legend` if it does not.
+
+        A public row carries no style. `layers.resolve` needs a token, so for anonymous browsing —
+        the plugin's headline promise — it could only fail, and every public layer arrived unstyled.
+        `/legend` IS public and is what the portal draws from. Cached by `fetch_json`, so opening
+        several layers does not re-ask.
+        """
+        if isinstance(row.get("default_style"), dict):
+            style = row["default_style"].get("style")
+            if style:
+                return style
+        if not self.instance:
+            return None
+        try:
+            ref = row.get("uid") or row.get("id")
+            # `legend` is defined on the VECTOR and RASTER namespaces, not on the kind-agnostic
+            # `layers` helper — asking the latter is an AttributeError, which is what every
+            # unstyled layer was really hitting.
+            kind = "raster" if (row.get("layer_type") == "raster"
+                                or row.get("storage_backend") == "raster") else "vector"
+            legend = self.instance.fetch_json(
+                "{0}/api/data/{1}/{2}/legend".format(self.instance.url.rstrip("/"), kind, ref))
+            return symbology.style_from_legend(legend)
+        except GeoDeployError as exc:
+            symbology._log("Could not read the legend for {0}: {1}".format(name, exc))
+            return None
 
     # -- upload ------------------------------------------------------------------------------------
 
@@ -835,9 +851,29 @@ class GeoDeployDock(QDockWidget):
                         doc, symbology.style_from_legend),
                     "_anonymous": True}
 
+        def work_and_warm():
+            """The portal document, plus every per-layer document its build will need.
+
+            Layers must be CONSTRUCTED on the GUI thread, but the documents that describe them —
+            TileJSON, bounds — are ordinary HTTP. Fetching them during the build meant a dozen
+            blocking round trips one after another while QGIS was frozen. Doing it here, in the
+            worker that was already running, leaves the build with no I/O at all.
+            """
+            doc = work()
+            base = instance.url.rstrip("/")
+            urls = []
+            for cfg in (doc.get("layer_configs") or []):
+                lid = cfg.get("layer_id")
+                if lid is None:
+                    continue
+                kind = "raster" if cfg.get("layer_type") == "raster" else "vector"
+                urls.append("{0}/api/data/{1}/{2}/tilejson".format(base, kind, lid))
+            instance.prefetch(urls)
+            return doc
+
         self._busy(True)
         self._say("Opening " + str(row.get("title") or "the portal") + "...", bar=False)
-        self._run(_Job("GeoDeploy: opening portal", work), self._portal_opened)
+        self._run(_Job("GeoDeploy: opening portal", work_and_warm), self._portal_opened)
 
     def _portal_opened(self, job):
         self._busy(False)
@@ -851,6 +887,15 @@ class GeoDeployDock(QDockWidget):
             return
 
         project = QgsProject.instance()
+        # ONE REDRAW FOR THE WHOLE GROUP. QGIS re-renders the canvas every time a layer joins the
+        # project, so a seven-layer portal drew the entire map seven times — each one fetching
+        # tiles for every layer already placed. Freezing while the group is assembled is the
+        # standard way to say "tell me when I am done"; the `finally` guarantees it thaws even if
+        # one layer throws, because leaving a user's canvas frozen would be far worse than a slow
+        # open.
+        canvas = self.iface.mapCanvas() if self.iface else None
+        if canvas is not None:
+            canvas.freeze(True)
         group = project.layerTreeRoot().insertGroup(0, doc.get("title") or "GeoDeploy portal")
         # Only tag the portal id when we could actually write back to it. Tagging a read-only copy
         # would offer an "update" that is going to be refused, which is worse than not offering it.
@@ -923,7 +968,12 @@ class GeoDeployDock(QDockWidget):
         # layer_configs[0] is the TOP, and adding in the same order puts it at the top here too.
         tree = doc.get("layer_groups") or [
             {"layer_id": c.get("layer_id"), "layer_type": c.get("layer_type")} for c in configs]
-        place(tree, group)
+        try:
+            place(tree, group)
+        finally:
+            if canvas is not None:
+                canvas.freeze(False)
+                canvas.refresh()
 
         note = ""
         if missing:

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -121,9 +121,14 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
     for ml in (style_doc.get("layers") or []):
         meta = ml.get("metadata") or {}
         layer_id = meta.get("geodeploy:layer_id")
-        if layer_id is None or layer_id in seen:
+        # KEYED BY ID **AND** TYPE. Vectors and rasters are numbered in separate sequences, so a
+        # portal holding vector 1 and raster 1 — an ordinary thing — had the second one swallowed
+        # as a duplicate of the first, and the group opened missing a layer with no error anywhere.
+        # Measured on a live portal: 7 layers in, 5 out.
+        key = (layer_id, meta.get("geodeploy:type") or "vector")
+        if layer_id is None or key in seen:
             continue
-        seen.add(layer_id)
+        seen.add(key)
         legend = {"color_mode": _mode_of(meta), "field": meta.get("geodeploy:legendField"),
                   "entries": meta.get("geodeploy:legend") or [],
                   "size": _size_of(meta.get("geodeploy:sizeLegend"))}
@@ -134,7 +139,7 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
             # MapLibre omits `visibility` when a layer is shown, so absent means visible.
             "visible": ((ml.get("layout") or {}).get("visibility") or "visible") != "none",
             "opacity": meta.get("geodeploy:opacity", 1.0),
-            "style": style_from_legend(legend) or {},
+            "style": _baked_style(ml, meta, legend, style_from_legend),
             "popup_fields": [],
             # WHERE THE DATA COMES FROM, taken from the portal's own style.
             #
@@ -147,6 +152,76 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
         })
     configs.reverse()
     return configs
+
+
+def _baked_style(ml_layer: dict, meta: dict, legend: dict, style_from_legend) -> dict:
+    """The style a PUBLISHED portal actually draws a layer with.
+
+    THE LEGEND IS ONLY HALF THE STORY, and the half that is usually empty. `geodeploy:legend` lists
+    the CLASSES of a graduated or categorized layer — for a single-symbol layer, which most are, it
+    is `[]`, so building the style from it alone produced `{}` and the plugin fell back to the
+    layer's own default. Measured on a live portal: `example` is drawn `#10b981` at 45% with a
+    `#1d4ed8` outline while its default style is plain `#3b82f6`, and `shapefiles_dresden` is drawn
+    `#3b82f6` against a default of `#d1ba23`. Two layers, two wrong colours, both public — which is
+    why "the portal looks different in QGIS" had nothing to do with permissions.
+
+    Everything needed is already in the document: the MapLibre `paint` block, and the
+    `geodeploy:*` metadata that carries what paint cannot express as a single value (the marker
+    shape, the dash pattern, and — for points baked as icons — the colour and radius themselves).
+    """
+    style = dict(style_from_legend(legend) or {})
+    paint = ml_layer.get("paint") or {}
+    layer_opacity = meta.get("geodeploy:opacity")
+    try:
+        layer_opacity = float(layer_opacity) if layer_opacity is not None else 1.0
+    except (TypeError, ValueError):
+        layer_opacity = 1.0
+
+    def plain(value):
+        """A literal paint value, or None when it is an EXPRESSION.
+
+        A classified layer bakes `["step", …]` / `["match", …]` into the colour. Those classes are
+        exactly what the legend carries, so they are read from there instead of parsed twice —
+        and a list must never be handed on as if it were a colour.
+        """
+        return value if isinstance(value, (str, int, float)) else None
+
+    # Shape and dash are metadata whichever geometry this is.
+    for key, prop in (("geodeploy:marker", "marker"), ("geodeploy:lineType", "lineType")):
+        if meta.get(key):
+            style.setdefault(prop, meta[key])
+
+    kind = ml_layer.get("type")
+    if kind == "fill":
+        style.setdefault("color", plain(paint.get("fill-color")) or style.get("color"))
+        outline = plain(paint.get("fill-outline-color"))
+        if outline:
+            style.setdefault("outline_color", outline)
+        baked = plain(paint.get("fill-opacity"))
+        if baked is not None and layer_opacity:
+            # The portal bakes `opacity * fill_opacity` into one number, and the layer opacity is
+            # applied separately in QGIS — so divide it back out or it would be applied twice.
+            style.setdefault("fill_opacity", min(1.0, float(baked) / layer_opacity))
+    elif kind == "line":
+        style.setdefault("color", plain(paint.get("line-color")) or style.get("color"))
+        width = plain(paint.get("line-width"))
+        if width is not None:
+            style.setdefault("line_width", width)
+    elif kind == "circle":
+        style.setdefault("color", plain(paint.get("circle-color")) or style.get("color"))
+        radius = plain(paint.get("circle-radius"))
+        if radius is not None:
+            style.setdefault("radius", radius)
+    elif kind == "symbol":
+        # Points drawn as ICONS: the paint block holds only `icon-opacity`, because the colour and
+        # size went into the generated image. The generator records both as metadata for exactly
+        # this reason — they ARE the style's `color` and `radius`.
+        if meta.get("geodeploy:markerColor"):
+            style.setdefault("color", meta["geodeploy:markerColor"])
+        if meta.get("geodeploy:markerSize") is not None:
+            style.setdefault("radius", meta["geodeploy:markerSize"])
+
+    return {k: v for k, v in style.items() if v is not None}
 
 
 def _source_of(style_doc: dict, ml_layer: dict):

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -106,6 +106,12 @@ CSS_PX_TO_POINTS = 0.75
 #: them is what makes QGIS and the portal show the same map.
 DEFAULT_POINT_RADIUS = 5
 DEFAULT_POINT_STROKE = 1
+#: And the polygon ones. `fill-opacity: opacity * style.get("fill_opacity", 0.45)` in
+#: portal_generator — so a polygon with no stated opacity is drawn at 45% on every portal there is.
+DEFAULT_FILL_OPACITY = 0.45
+DEFAULT_FILL_OUTLINE = "#1d4ed8"
+#: A line with no stated width is 2 CSS px on the map.
+DEFAULT_LINE_WIDTH = 2
 
 
 def _set_stroke_width(layer0, width: float) -> None:
@@ -199,10 +205,9 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
             _set_stroke_width(layer0, DEFAULT_POINT_STROKE * CSS_PX_TO_POINTS)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
         _use_points(symbol, layer0)
-        if style.get("line_width"):
-            # In points now (see `_use_points`), so the width IS the width — no mm conversion, and
-            # no divide-by-four fudge that was only ever right at one screen DPI.
-            layer0.setWidth(float(style["line_width"]) * CSS_PX_TO_POINTS)
+        # Always set, defaulted to the map's `line-width: 2` — QGIS's own default is 0.26 mm, a
+        # hairline, so an unstyled line came out far thinner than the portal draws it.
+        layer0.setWidth(float(style.get("line_width") or DEFAULT_LINE_WIDTH) * CSS_PX_TO_POINTS)
         dash = (style.get("lineType") or "solid").lower()
         if dash == "dashed":
             layer0.setPenStyle(Qt.DashLine)
@@ -212,10 +217,15 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
         outline = style.get("outline_color")
         if outline == "none":
             layer0.setStrokeStyle(Qt.NoPen)
-        elif outline:
-            layer0.setStrokeColor(QColor(outline))
-        if style.get("fill_opacity") is not None:
-            symbol.setOpacity(float(style["fill_opacity"]))
+        else:
+            # The map's default outline, not QGIS's — `fill-outline-color: #1d4ed8` in
+            # portal_generator when the style names none.
+            layer0.setStrokeColor(QColor(outline or DEFAULT_FILL_OUTLINE))
+        # ALWAYS, and defaulted — the same mistake the point radius made. A polygon style rarely
+        # carries `fill_opacity`, and the map fills the gap with 0.45: every portal draws polygons
+        # translucent. Applying it only when present meant QGIS drew them SOLID, so a layer that is
+        # a soft wash in the browser arrived as a flat block of colour hiding everything under it.
+        symbol.setOpacity(float(style.get("fill_opacity", DEFAULT_FILL_OPACITY)))
     return symbol
 
 

--- a/integrations/qgis-plugin/scripts/test_published_style.py
+++ b/integrations/qgis-plugin/scripts/test_published_style.py
@@ -1,0 +1,157 @@
+"""Rebuilding a portal's layer list from its PUBLIC style.json.
+
+This is the anonymous path — no token, no API — and it was quietly wrong in two ways that both look
+like "the plugin ignores my portal":
+
+* **The style came out empty for most layers.** `geodeploy:legend` lists the CLASSES of a graduated
+  or categorized layer; for a single-symbol layer, which most are, it is `[]`. Reading only that
+  produced `{}`, and the plugin fell back to the layer's own default style — a different colour
+  from the one the portal draws. Nothing to do with permissions: measured on a public layer.
+* **A layer went missing.** De-duplication was keyed on the layer id alone, and vectors and rasters
+  are numbered separately, so a portal holding vector 1 and raster 1 lost one of them silently.
+
+The fixture below is trimmed from a real `style.json` — same keys, same nesting, same metadata
+names — so it tests the document the server actually publishes rather than an idea of it.
+"""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PKG = os.path.join(HERE, "..", "geodeploy_qgis")
+sys.path.insert(0, PKG)
+sys.path.insert(0, os.path.join(PKG, "vendor"))
+
+
+def _load(name):
+    """Import a plugin module without its QGIS-only imports."""
+    lines = open(os.path.join(PKG, name + ".py"), encoding="utf-8").read().splitlines()
+    src = "\n".join(l for l in lines
+                    if not (l.startswith("from .connection") or l.startswith("from .symbology")))
+    ns = {}
+    exec(compile(src, name, "exec"), ns)                                        # noqa: S102
+    return ns
+
+
+symbology = _load("symbology")
+portals = _load("portals")
+configs_from_published_style = portals["configs_from_published_style"]
+style_from_legend = symbology["style_from_legend"]
+
+STYLE_DOC = {
+    "sources": {
+        "vector_3": {"type": "vector", "url": "pmtiles://https://x.org/api/data/vector/3/pmtiles"},
+        "vector_4": {"type": "vector",
+                     "tiles": ["https://x.org/tiles/geodeploy_u1.dresden/{z}/{x}/{y}"]},
+        "vector_1": {"type": "vector", "tiles": ["https://x.org/tiles/geodeploy_u1.countries/{z}/{x}/{y}"]},
+        "raster_1": {"type": "raster", "tiles": ["/raster/cog/tiles/WebMercatorQuad/{z}/{x}/{y}?url=s3://b/a.tif&rescale=0,1"]},
+    },
+    # MapLibre draws later layers on top, so this list is BOTTOM-to-top.
+    "layers": [
+        {"id": "vector-3", "type": "fill", "source": "vector_3", "source-layer": "geodeploy",
+         "paint": {"fill-color": "#10b981", "fill-opacity": 0.45,
+                   "fill-outline-color": "#1d4ed8"},
+         "metadata": {"geodeploy:layer_id": 3, "geodeploy:type": "vector",
+                      "geodeploy:name": "example", "geodeploy:opacity": 1.0,
+                      "geodeploy:marker": "circle", "geodeploy:lineType": "solid",
+                      "geodeploy:legend": []}},
+        # The SAME layer baked twice — a fill plus its outline. Only one config may come out.
+        {"id": "vector-3-outline", "type": "line", "source": "vector_3", "source-layer": "geodeploy",
+         "paint": {"line-color": "#1d4ed8", "line-width": 1},
+         "metadata": {"geodeploy:layer_id": 3, "geodeploy:type": "vector"}},
+        {"id": "raster-1", "type": "raster", "source": "raster_1", "paint": {"raster-opacity": 0.6},
+         "metadata": {"geodeploy:layer_id": 1, "geodeploy:type": "raster",
+                      "geodeploy:name": "RVI_2023_2024", "geodeploy:opacity": 0.6}},
+        {"id": "vector-1", "type": "symbol", "source": "vector_1", "source-layer": "geodeploy",
+         "paint": {"icon-opacity": 1.0},
+         "metadata": {"geodeploy:layer_id": 1, "geodeploy:type": "vector",
+                      "geodeploy:name": "countries", "geodeploy:opacity": 1.0,
+                      "geodeploy:marker": "circle", "geodeploy:markerColor": "#ef4444",
+                      "geodeploy:markerSize": 1.0, "geodeploy:legend": []}},
+        {"id": "vector-4", "type": "line", "source": "vector_4", "source-layer": "geodeploy_u1.dresden",
+         "layout": {"visibility": "none"},
+         "paint": {"line-color": "#3b82f6", "line-width": 1.04, "line-opacity": 1.0},
+         "metadata": {"geodeploy:layer_id": 4, "geodeploy:type": "vector",
+                      "geodeploy:name": "shapefiles_dresden", "geodeploy:opacity": 1.0,
+                      "geodeploy:lineType": "dashed", "geodeploy:legend": []}},
+    ],
+}
+
+configs = configs_from_published_style(STYLE_DOC, style_from_legend)
+by_name = {c["name"]: c for c in configs}
+
+# ── nothing may go missing ────────────────────────────────────────────────────────────────────
+assert len(configs) == 4, [c["name"] for c in configs]
+assert "countries" in by_name and "RVI_2023_2024" in by_name, (
+    "vector 1 and raster 1 are DIFFERENT layers; keying de-duplication on the id alone drops one")
+print("de-duplication   -> 4 layers from 5 baked, and vector 1 / raster 1 both survive")
+
+# ── order is reversed: MapLibre draws bottom-to-top, a portal lists top-first ─────────────────
+assert [c["name"] for c in configs] == ["shapefiles_dresden", "countries", "RVI_2023_2024",
+                                        "example"], [c["name"] for c in configs]
+print("order            -> reversed, so the group opens the right way up")
+
+# ── a POLYGON keeps the portal's colour, outline and translucency ─────────────────────────────
+s = by_name["example"]["style"]
+assert s["color"] == "#10b981", s          # NOT the layer's default
+assert s["outline_color"] == "#1d4ed8", s
+assert s["fill_opacity"] == 0.45, s
+print("polygon          ->", json.dumps(s))
+
+# ── a LINE keeps the portal's colour and width, and its dash comes from the metadata ──────────
+s = by_name["shapefiles_dresden"]["style"]
+assert s["color"] == "#3b82f6" and s["line_width"] == 1.04 and s["lineType"] == "dashed", s
+assert by_name["shapefiles_dresden"]["visible"] is False, "layout.visibility none means hidden"
+print("line             ->", json.dumps(s))
+
+# ── POINTS are baked as icons, so colour and radius live in the metadata, not the paint ───────
+s = by_name["countries"]["style"]
+assert s["color"] == "#ef4444" and s["radius"] == 1.0, s
+print("point (icon)     ->", json.dumps(s))
+
+# ── opacity travels ───────────────────────────────────────────────────────────────────────────
+assert by_name["RVI_2023_2024"]["opacity"] == 0.6
+print("opacity          -> carried from the baked layer")
+
+# ── the layer-level opacity must not be counted twice ─────────────────────────────────────────
+# The portal bakes `opacity * fill_opacity` into one number and QGIS applies layer opacity itself,
+# so a half-opacity layer with a 0.45 fill bakes 0.225 and must come back out as 0.45.
+half = json.loads(json.dumps(STYLE_DOC))
+ml = half["layers"][0]
+ml["paint"]["fill-opacity"] = 0.225
+ml["metadata"]["geodeploy:opacity"] = 0.5
+out = {c["name"]: c for c in configs_from_published_style(half, style_from_legend)}["example"]
+assert out["opacity"] == 0.5 and abs(out["style"]["fill_opacity"] - 0.45) < 1e-9, out
+print("opacity, twice   -> divided back out, not applied twice")
+
+# ── a CATEGORIZED layer, the shape the live instance bakes ────────────────────────────────────
+cat = json.loads(json.dumps(STYLE_DOC))
+ml = cat["layers"][0]
+ml["paint"]["fill-color"] = ["match", ["get", "Type"], "Autochamber", "#8c4ee3", "#eea26b"]
+ml["metadata"]["geodeploy:legendField"] = "Type"
+ml["metadata"]["geodeploy:legend"] = [
+    {"color": "#8c4ee3", "label": "Autochamber", "value": "Autochamber"},
+    {"color": "#6cefa2", "label": "Manual chamber", "value": "Manual chamber"},
+    {"color": "#eea26b", "label": "Other", "value": None, "other": True}]
+s = {c["name"]: c for c in configs_from_published_style(cat, style_from_legend)}["example"]["style"]
+assert s.get("color_mode") == "categorized" and s.get("color_field") == "Type", s
+assert not isinstance(s.get("color"), list)
+print("categorized      ->", len(s.get("categories") or []), "categories, field", s.get("color_field"))
+
+
+# ── a CLASSIFIED layer bakes an expression; its classes come from the legend, not the paint ───
+classified = json.loads(json.dumps(STYLE_DOC))
+ml = classified["layers"][0]
+ml["paint"]["fill-color"] = ["step", ["get", "pop"], "#fee5d9", 100, "#a50f15"]
+ml["metadata"]["geodeploy:legendField"] = "pop"
+# The mode is not stated anywhere — it is read from the ENTRIES' shape (`_mode_of`): `min`/`max`
+# means graduated, `value` means categorized. Written the way the server bakes it.
+ml["metadata"]["geodeploy:legend"] = [{"color": "#fee5d9", "label": "< 100", "min": None, "max": 100},
+                                      {"color": "#a50f15", "label": "100 - 900", "min": 100, "max": 900}]
+s = {c["name"]: c for c in
+     configs_from_published_style(classified, style_from_legend)}["example"]["style"]
+assert s.get("color_mode") == "graduated" and len(s.get("classes") or []) == 2, s
+assert not isinstance(s.get("color"), list), "a MapLibre expression must never be used as a colour"
+print("classified       -> classes from the legend, expression never mistaken for a colour")
+
+print("\nALL PUBLISHED-STYLE CASES PASS")


### PR DESCRIPTION
## Speed — three causes

1. **Layers were styled after being added.** QGIS renders the moment a layer joins the project, so every layer was drawn twice and the first time was wrong. That is also why symbology looked like it "arrived afterwards". Styling now happens before `addMapLayer`.
2. **A group redrew the whole canvas once per layer.** A seven-layer portal drew the entire map seven times, re-fetching tiles for everything already placed. The canvas is now frozen for the build and thawed in a `finally`.
3. **A dozen blocking round trips on the GUI thread.** Every TileJSON, legend and bounds lookup happened mid-build while QGIS was frozen. `fetch_json` caches per connection (failures too — a 404 is an answer) and `prefetch` warms them inside the `QgsTask` that was already running, so the build does no network at all.

## Fidelity — an anonymous portal opened in the wrong colours, and lost a layer

`_baked_style` now reads the portal's own MapLibre `paint` and `geodeploy:*` metadata, not only `geodeploy:legend` — which is `[]` for a single-symbol layer, so the style came out `{}` and each layer fell back to its own default. Measured on the live instance:

| layer | portal draws | default style |
|---|---|---|
| `example` (public) | `#10b981` @ 45%, outline `#1d4ed8` | `#3b82f6` |
| `shapefiles_dresden` | `#3b82f6`, width 1.04 | `#d1ba23` |
| `countries` | `#ef4444`, radius 1.0 | `#3b82f6` |

Nothing to do with permissions — `example` is public.

**De-duplication is keyed by (id, type).** Vectors and rasters are numbered separately, so a portal holding vector 1 and raster 1 silently dropped one: 7 baked layers in, 5 configs out.

**Polygon and line defaults.** `fill_opacity` 0.45 and `line_width` 2 — the map applies them when a style omits them, which most do; QGIS was filling the gap with opaque and hairline instead. That is the solid dark yellow where the browser showed a translucent wash.

## Server

`/api/data/raster/{ref}/tilejson` and `/wmts` required `is_public`, so a raster public only through a published portal served its **tiles** (200) while its own metadata 404'd — the `Could not read the raster's bounds: HTTP Error 404` in the log. `_describable` mirrors `vector._publicly_readable`.

Deliberately **not** applied to `/cog` or `/export`: those hand over the pixels, and being shown in a portal is a licence to look at a picture, not to download the source data.

Plugin 0.1.4. New test `test_published_style.py` in CI, built from a real `style.json` shape.
