### PR TITLE
A vector-tile style is bound to one geometry, so stop guessing it

### DIFF
--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,20 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17e (**polygons drew as a dot per vertex, or not at all.** A `QgsVectorTileBasicRendererStyle`
+is bound to ONE geometry type and QGIS honours that literally: a marker symbol over line data draws
+a marker at every vertex (a road network as a carpet of dots — the reported screenshot), a fill
+symbol over point data draws nothing. `apply_to_vector_tiles` defaulted the unknown case to POINT,
+and the unknown case was the common one: `_row_for` matches on `id`, but the public index puts the
+UID there while portal configs carry numeric ids, so `layer_row` is **always None** on the anonymous
+path. Now `configs_from_published_style` carries `geometry_type`, taken from the **MapLibre layer
+type** (`_geometry_of`) rather than `geodeploy:geometry` — the source of a 3D point layer says
+"point" while its `pillars` tiles hold polygons — and `place` passes it through even when the row is
+missing. Genuinely unknown geometry gets a style per type rather than a guess.
+Also: `_vector_tiles(prefer_uri=True)` for portal sources, so a portal drawing from `pillars` is not
+silently redirected to the layer's own TileJSON; `_baked_style` reads `fill-extrusion-color`;
+`fetch_text` is cached like `fetch_json`. Verified across all six live portals: 25 layers, every one
+resolving geometry, source and colour.)
 2026-08-17c (**a portal's raster was drawn in the layer's DEFAULT style.** A raster is coloured by
 the server, and a portal bakes its colormap/stretch/band/hillshade into its OWN tile URL — proven on
 the live instance, where one `Degfert_DEM_restr.tif` appears as `&colormap_name=terrain` in one

--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -122,18 +122,34 @@ class Instance:
             except GeoDeployError:
                 pass                    # already recorded in the cache; the caller degrades
 
-    def fetch_text(self, url: str) -> str:
-        """GET a URL on this instance as text — WMTS capabilities are XML, not JSON."""
+    def fetch_text(self, url: str, cache: bool = True) -> str:
+        """GET a URL on this instance as text — WMTS capabilities are XML, not JSON.
+
+        Cached like `fetch_json`, and for the same reason: this is read on the GUI thread every time
+        a raster is added, and a capabilities document describes the raster rather than its pixels.
+        """
         from urllib.request import Request, urlopen
 
+        key = "text:" + url
+        if cache and key in self._doc_cache:
+            hit = self._doc_cache[key]
+            if isinstance(hit, Exception):
+                raise hit
+            return hit
         headers = {"User-Agent": self._c_user_agent(), "Accept": "application/xml, text/xml, */*"}
         if self.token:
             headers["Authorization"] = "Bearer {0}".format(self.token)
         try:
             with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
-                return response.read().decode("utf-8", "replace")
+                body = response.read().decode("utf-8", "replace")
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
-            raise GeoDeployError("Could not read {0}: {1}".format(url, exc))
+            error = GeoDeployError("Could not read {0}: {1}".format(url, exc))
+            if cache:
+                self._doc_cache[key] = error
+            raise error
+        if cache:
+            self._doc_cache[key] = body
+        return body
 
     def published_style(self, slug: str) -> dict:
         """A published portal's own style.json — served to anyone, no credential involved.

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.4
+version=0.1.5
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,13 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.4 - Opening a portal is much faster and looks like the portal. Layers are styled
+changelog=0.1.5 - Fixes layers drawn with the wrong kind of symbol. A vector-tile style is bound to
+    ONE geometry type, and the plugin was falling back to "point" whenever it could not tell - so
+    polygons and lines arrived as a dot at every vertex, or did not draw at all. The geometry is now
+    read from the portal's own published style (and from how the layer is DRAWN, so 3D layers work
+    too); where it is genuinely unknown, every geometry type gets a symbol instead of one being
+    guessed. A portal's own tiles are also no longer swapped for the layer's when the two differ.
+    0.1.4 - Opening a portal is much faster and looks like the portal. Layers are styled
     before they join the map instead of after (one redraw each, not two), the canvas is frozen while
     a group is assembled (one redraw for the whole portal, not one per layer), and the documents
     that describe a layer are fetched once and reused - in the background thread, not between

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -635,18 +635,24 @@ class GeoDeployDock(QDockWidget):
                     {"tilejson_url": f"{base}/api/data/vector/{ref}/tilejson"}, name) \
                     if base and ref else (None, {})
                 if layer is not None:
-                    layer.setCustomProperty(symbology.P_SOURCE_LAYER,
-                                            doc.get("_source_layer") or "")
+                    layer.setCustomProperty(
+                        symbology.P_SOURCE_LAYER,
+                        src.get("source_layer") or doc.get("_source_layer") or "")
                     self._set_tile_extent(layer, doc.get("bounds"))
                 else:
                     # An instance too old to publish that TileJSON: the archive still draws, slowly.
                     layer = QgsVectorLayer("/vsicurl/" + url, name, "ogr")
             elif kind == "vector-tiles":
                 layer, doc = self._vector_tiles({"uri": url, "tilejson_url": (
-                    f"{base}/api/data/vector/{ref}/tilejson" if base and ref else None)}, name)
+                    f"{base}/api/data/vector/{ref}/tilejson" if base and ref else None)},
+                    name, prefer_uri=True)
                 if layer is not None:
-                    layer.setCustomProperty(symbology.P_SOURCE_LAYER,
-                                            doc.get("_source_layer") or "")
+                    # THE PORTAL'S source-layer first. It names the layer inside the very tiles this
+                    # URL serves, and the two can differ: Martin publishes `<schema>.<table>` while
+                    # a 3D point layer is drawn from a `pillars` function source entirely.
+                    layer.setCustomProperty(
+                        symbology.P_SOURCE_LAYER,
+                        src.get("source_layer") or doc.get("_source_layer") or "")
                     self._set_tile_extent(layer, doc.get("bounds"))
             else:
                 return None
@@ -724,7 +730,7 @@ class GeoDeployDock(QDockWidget):
             symbology._log("Could not read the raster's WMTS: {0}".format(exc))
             return None
 
-    def _vector_tiles(self, source, name):
+    def _vector_tiles(self, source, name, prefer_uri: bool = False):
         """`(layer, tilejson)` for a vector-tile source, described by the server rather than guessed.
 
         THE SLOWNESS WAS HERE, and it was not the tiles' fault. A vector-tile layer built from a
@@ -748,7 +754,13 @@ class GeoDeployDock(QDockWidget):
                 symbology._log("Could not read the TileJSON for {0}: {1}".format(name, exc))
                 doc = {}
         tiles = (doc or {}).get("tiles") or []
-        template = tiles[0] if tiles else source.get("uri")
+        # `prefer_uri` is for a source the PORTAL named. The layer's TileJSON describes the layer's
+        # own tiles, and a portal does not always draw from those: a 3D point layer is served by a
+        # `pillars` function that buffers the points into polygons, so following the TileJSON there
+        # would quietly swap the portal's tiles for different ones. The TileJSON is still read — for
+        # the zoom range and the bounds, which the bare template has no room for.
+        template = (source.get("uri") or (tiles[0] if tiles else None)) if prefer_uri else (
+            tiles[0] if tiles else source.get("uri"))
         if not template:
             return None, {}
         uri = _xyz_uri(template, (doc or {}).get("minzoom"), (doc or {}).get("maxzoom"))
@@ -961,7 +973,16 @@ class GeoDeployDock(QDockWidget):
                     # THE PORTAL'S style wins over the layer's default here — that is what opening
                     # a portal means. Through the dispatcher, so a tile layer gets the tile
                     # renderer instead of silently keeping the colour it was born with.
-                    symbology.apply(layer, style, layer_row or {})
+                    #
+                    # The GEOMETRY has to come with it. A portal may show a layer that is not in
+                    # the public listing, and `layer_row` is then None — so the renderer was left
+                    # guessing, guessed "point", and drew polygons as a dot per vertex. The
+                    # published style records the geometry; prefer it, since it describes the very
+                    # tiles being drawn.
+                    row_for_style = dict(layer_row or {})
+                    if cfg.get("geometry_type"):
+                        row_for_style["geometry_type"] = cfg["geometry_type"]
+                    symbology.apply(layer, style, row_for_style)
                 added += 1
 
         # A portal with no folders is a flat list — the configs themselves, in order.

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -136,6 +136,11 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
             "layer_id": layer_id,
             "layer_type": meta.get("geodeploy:type") or "vector",
             "name": meta.get("geodeploy:name"),
+            # POINT / LINE / POLYGON, and it matters more than it looks. A vector-tile renderer
+            # takes one symbol PER GEOMETRY TYPE, so getting it wrong does not mean a wrong colour
+            # — it means a polygon drawn with a marker symbol, i.e. a dot at every vertex, or
+            # nothing at all. The published style records it and the plugin was not reading it.
+            "geometry_type": _geometry_of(ml, meta),
             # MapLibre omits `visibility` when a layer is shown, so absent means visible.
             "visible": ((ml.get("layout") or {}).get("visibility") or "visible") != "none",
             "opacity": meta.get("geodeploy:opacity", 1.0),
@@ -152,6 +157,22 @@ def configs_from_published_style(style_doc: dict, style_from_legend) -> list[dic
         })
     configs.reverse()
     return configs
+
+
+#: What is actually IN the tiles, by the MapLibre layer type that draws them. This is the authority,
+#: not `geodeploy:geometry` — which describes the SOURCE. A 3D point layer is drawn as
+#: `fill-extrusion` from a `pillars` function source that serves POLYGONS (the points, buffered), so
+#: the source says "point" while the tiles hold polygons; trusting the source there draws nothing.
+_GEOMETRY_BY_ML_TYPE = {
+    "fill": "polygon", "fill-extrusion": "polygon",
+    "line": "line",
+    "circle": "point", "symbol": "point", "heatmap": "point",
+}
+
+
+def _geometry_of(ml_layer: dict, meta: dict) -> str | None:
+    """The geometry these tiles hold, preferring how they are DRAWN over what the source says."""
+    return _GEOMETRY_BY_ML_TYPE.get(ml_layer.get("type")) or meta.get("geodeploy:geometry")
 
 
 def _baked_style(ml_layer: dict, meta: dict, legend: dict, style_from_legend) -> dict:
@@ -192,7 +213,13 @@ def _baked_style(ml_layer: dict, meta: dict, legend: dict, style_from_legend) ->
             style.setdefault(prop, meta[key])
 
     kind = ml_layer.get("type")
-    if kind == "fill":
+    if kind == "fill-extrusion":
+        # A 3D layer. QGIS draws it flat, which is honest — the colour is the part that carries.
+        style.setdefault("color", plain(paint.get("fill-extrusion-color")) or style.get("color"))
+        baked = plain(paint.get("fill-extrusion-opacity"))
+        if baked is not None and layer_opacity:
+            style.setdefault("fill_opacity", min(1.0, float(baked) / layer_opacity))
+    elif kind == "fill":
         style.setdefault("color", plain(paint.get("fill-color")) or style.get("color"))
         outline = plain(paint.get("fill-outline-color"))
         if outline:

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -418,13 +418,25 @@ def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None,
         (row.get("default_style") or {}).get("style")
         if isinstance(row.get("default_style"), dict) else {}) or {}
 
+    # WHICH GEOMETRY, and never a guess. A tile renderer's style is bound to ONE geometry type, and
+    # QGIS honours that binding literally: give a line layer a point style and it draws a marker at
+    # every vertex — a road network arriving as a carpet of dots — and give a point layer a fill
+    # style and it draws nothing at all. Defaulting the unknown case to "point" is what produced
+    # both. When the geometry is genuinely unknown, every type gets a style instead, so whatever the
+    # tiles hold is drawn with a symbol that suits it; a tile layer may legitimately carry more than
+    # one geometry anyway.
     geom = (row.get("geometry_type") or "").lower()
     if "polygon" in geom:
-        geometry_type = QgsWkbTypes.PolygonGeometry
+        geometry_types = [QgsWkbTypes.PolygonGeometry]
     elif "line" in geom:
-        geometry_type = QgsWkbTypes.LineGeometry
+        geometry_types = [QgsWkbTypes.LineGeometry]
+    elif "point" in geom:
+        geometry_types = [QgsWkbTypes.PointGeometry]
     else:
-        geometry_type = QgsWkbTypes.PointGeometry
+        geometry_types = [QgsWkbTypes.PolygonGeometry, QgsWkbTypes.LineGeometry,
+                          QgsWkbTypes.PointGeometry]
+        if geom:
+            _log("Unrecognised geometry {0!r}; styling every geometry type.".format(geom))
 
     model = None
     try:
@@ -434,18 +446,24 @@ def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None,
         model = None
 
     def _style(name, colour, expression):
-        # THE SAME symbol builder the feature path uses — marker shape, radius, line width, dash,
-        # fill opacity and data-defined size all included. A second implementation here is how the
-        # two surfaces would start drawing the same layer differently.
-        symbol = _symbol_of(geometry_type, colour, style)
-        if symbol is None:
-            return None
-        entry = QgsVectorTileBasicRendererStyle(name, source_layer or "", geometry_type)
-        entry.setSymbol(symbol)
-        entry.setEnabled(True)
-        if expression:
-            entry.setFilterExpression(expression)
-        return entry
+        """One renderer entry per geometry type this layer may hold — usually exactly one."""
+        out = []
+        for geometry_type in geometry_types:
+            # THE SAME symbol builder the feature path uses — marker shape, radius, line width,
+            # dash, fill opacity and data-defined size all included. A second implementation here
+            # is how the two surfaces would start drawing the same layer differently.
+            symbol = _symbol_of(geometry_type, colour, style)
+            if symbol is None:
+                continue
+            entry = QgsVectorTileBasicRendererStyle(
+                name if len(geometry_types) == 1 else "{0}-{1}".format(name, geometry_type),
+                source_layer or "", geometry_type)
+            entry.setSymbol(symbol)
+            entry.setEnabled(True)
+            if expression:
+                entry.setFilterExpression(expression)
+            out.append(entry)
+        return out
 
     styles = []
     try:
@@ -462,26 +480,20 @@ def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None,
                     # data falls through every filter and disappears.
                     op = "<=" if i == len(model.classes) - 1 else "<"
                     parts.append("{0} {1} {2}".format(field, op, hi))
-                entry = _style("class-{0}".format(i), cls.get("color"), " AND ".join(parts) or None)
-                if entry:
-                    styles.append(entry)
+                styles.extend(_style("class-{0}".format(i), cls.get("color"),
+                                     " AND ".join(parts) or None))
         elif model is not None and model.mode == "categorized" and model.field and model.categories:
             for i, cat in enumerate(model.categories):
                 value = cat.get("value")
                 literal = ("'" + str(value).replace("'", "''") + "'"
                            if not isinstance(value, (int, float)) else str(value))
-                entry = _style("cat-{0}".format(i), cat.get("color"),
-                               '"{0}" = {1}'.format(model.field, literal))
-                if entry:
-                    styles.append(entry)
-            # Everything not listed, drawn in the same "other" colour the map uses.
-            other = _style("other", model.other_color or "#9ca3af", None)
-            if other:
-                styles.insert(0, other)      # first = drawn underneath the named categories
+                styles.extend(_style("cat-{0}".format(i), cat.get("color"),
+                                     '"{0}" = {1}'.format(model.field, literal)))
+            # Everything not listed, drawn in the same "other" colour the map uses. First in the
+            # list = drawn underneath the named categories.
+            styles[:0] = _style("other", model.other_color or "#9ca3af", None)
         if not styles:
-            single = _style("geodeploy", (style or {}).get("color") or "#3b82f6", None)
-            if single:
-                styles.append(single)
+            styles.extend(_style("geodeploy", (style or {}).get("color") or "#3b82f6", None))
         if not styles:
             return False
 

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -303,10 +303,35 @@ out = styles_for({"geometry_type": "Polygon"},
 assert len(out) == 1 and out[0].symbol.color == "#654321"
 print("no classes     -> falls back to one symbol")
 
-# An unknown geometry name is treated as points rather than dropping the layer's styling.
+# ── the geometry type is a BINDING, not a hint ────────────────────────────────────────────────
+# A tile renderer style only draws features of its own geometry type, and QGIS is literal about it:
+# a point style over line data draws a marker at every vertex (a road network as a carpet of dots),
+# and a fill style over point data draws nothing. Defaulting the unknown case to "point" produced
+# both. Unknown now means "style every type" — a tile layer can legitimately hold more than one.
 out = styles_for({"geometry_type": None}, {"color": "#123456"})
-assert out[0].geometry_type == QgsWkbTypes.PointGeometry
-print("unknown geom   -> points")
+assert sorted(s.geometry_type for s in out) == [QgsWkbTypes.PointGeometry,
+                                                QgsWkbTypes.LineGeometry,
+                                                QgsWkbTypes.PolygonGeometry], [s.geometry_type for s in out]
+assert len({s.name for s in out}) == 3, "each entry needs its own name"
+print("unknown geom   -> one style per geometry type, so nothing is mis-drawn")
+
+# A geometry that IS known binds to exactly that type and no other.
+for name, expected in (("MultiPolygon", QgsWkbTypes.PolygonGeometry),
+                       ("LineString", QgsWkbTypes.LineGeometry),
+                       ("point", QgsWkbTypes.PointGeometry),
+                       ("MULTIPOINT", QgsWkbTypes.PointGeometry)):
+    out = styles_for({"geometry_type": name}, {"color": "#123456"})
+    assert [s.geometry_type for s in out] == [expected], (name, [s.geometry_type for s in out])
+print("known geom     -> bound to exactly that type")
+
+# Classified + unknown geometry: every class still gets every type, and the filters survive.
+out = styles_for({"geometry_type": ""},
+                 {"color_mode": "categorized", "color_field": "k",
+                  "categories": [{"value": "a", "color": "#111111"},
+                                 {"value": "b", "color": "#222222"}]})
+assert len(out) == 9, len(out)          # (2 categories + other) x 3 geometry types
+assert sum(1 for s in out if s.filter == '"k" = ' + "'a'") == 3
+print("classified     -> classes x geometry types, filters intact")
 
 # The row's OWN stored style is used when the caller passes none — the add path relies on this.
 layer = TileLayer()


### PR DESCRIPTION
## Polygons drew as a dot per vertex, or not at all

`QgsVectorTileBasicRendererStyle` binds a symbol to **one** geometry type, and QGIS honours that literally: a marker symbol over line data draws a marker at every vertex — a road network as a carpet of dots, which is the reported screenshot — and a fill symbol over point data draws nothing at all.

`apply_to_vector_tiles` defaulted the unknown case to **point**.

And the unknown case was the common one: `_row_for` matches on `id`, but the public index puts the **UID** there while a portal's configs carry **numeric** ids — so on the anonymous path `layer_row` is *always* `None` and the renderer was *always* guessing.

## The fix

`configs_from_published_style` now carries `geometry_type`, taken from the **MapLibre layer type** rather than `geodeploy:geometry`. That distinction matters: a 3D point layer's source says `point` while the `pillars` tiles it is actually drawn from hold **polygons**. `place` passes it through even when the listing row is missing, and genuinely unknown geometry gets one style per type instead of a guess — a tile layer can legitimately hold more than one.

## Two more found in the same documents

- **`_vector_tiles(prefer_uri=True)` for portal sources.** The layer's TileJSON describes the *layer's* tiles, and a portal does not always draw from those; following it silently swapped the `pillars` tiles for the plain table. The TileJSON is still read — for the zoom range and bounds.
- **`fill-extrusion-color`** is read, and the portal's own `source-layer` is preferred over the TileJSON's (`pillars` vs `geodeploy_u1.<table>`).

`fetch_text` is now cached like `fetch_json` — it is read on the GUI thread for every raster added.

## Verified across all six live portals

25 layers, every one resolving a geometry, a source and a colour — including the `pillars` layer, which now resolves to `polygon` / `sl=pillars` where it previously resolved to `point` and drew nothing.

## Not a plugin bug

Two rasters in *Web map* are served with `bidx=1` and **no `rescale`**, and TiTiler returns effectively blank tiles for them — 206 and 514 bytes at z12 dead centre of their own bounds, against 27 KB for the hillshade beside them. Same URL the browser uses, so they are blank there too. They need a rescale set in the portal.

Plugin 0.1.5.
