### PR TITLE
A portal opens the same way with and without a token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: The plugin picks the fast source, and degrades when it is absent
         run: python integrations/qgis-plugin/scripts/test_sources.py
 
-      - name: An anonymous portal is rebuilt with the PORTAL's styling
+      - name: A portal opens the same way with and without a token
         # The style.json path has no token and no API behind it, so nothing else catches a portal
         # that opens in the layers' default colours or quietly loses a layer to a clashing id.
         run: python integrations/qgis-plugin/scripts/test_published_style.py

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,21 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17f (**the two portal paths were not the same path, and every 0.1.5 fix covered only one.**
+`PortalOut.LayerConfig` is `{layer_id, layer_type, visible, opacity, style, popup_fields}` — no
+`source`, no `geometry_type`, no `name`. Everything read from the published style.json therefore
+applied to the ANONYMOUS path alone: with a token, a portal's rasters still opened in the layer's
+default colours (the complaint "fixed" in 0.1.3), geometry still depended on a `_row_for` lookup, and
+a layer that failed was reported by its numeric id ("1 could not be opened (9)"). New
+`portals.enrich_from_published` merges `source`/`geometry_type`/`name` in from style.json for a
+PUBLISHED portal, adding keys only — the API's style, visibility and opacity are authoritative and
+untouched — and degrading to the API document when style.json cannot be read. An unpublished portal
+has nothing to merge, which is honest: its rasters are not served under any styling yet.
+`place` now prefers the portal's source for EVERY layer type, not just rasters: a 3D point layer is
+drawn from a `pillars` function whose tiles hold polygons, and nothing in the layer's own listing
+entry points there. Also fixed a latent `AttributeError` — `portals.py` called `_log`, which it does
+not define (`_note` now does, lazily). Tests: the authenticated-parity block in
+`scripts/test_published_style.py`.)
 2026-08-17e (**polygons drew as a dot per vertex, or not at all.** A `QgsVectorTileBasicRendererStyle`
 is bound to ONE geometry type and QGIS honours that literally: a marker symbol over line data draws
 a marker at every vertex (a road network as a carpet of dots — the reported screenshot), a fill

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.5
+version=0.1.6
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,11 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.5 - Fixes layers drawn with the wrong kind of symbol. A vector-tile style is bound to
+changelog=0.1.6 - A portal now opens the same way whether or not you are signed in. The API's portal
+    document does not carry a layer's source, geometry or name - only the published style does - so
+    every fix in 0.1.5 covered the signed-out path alone: with a token, rasters still opened in the
+    layer's default colours and 3D layers were drawn from the wrong tiles. The two are now merged.
+    0.1.5 - Fixes layers drawn with the wrong kind of symbol. A vector-tile style is bound to
     ONE geometry type, and the plugin was falling back to "point" whenever it could not tell - so
     polygons and lines arrived as a dot at every vertex, or did not draw at all. The geometry is now
     read from the portal's own published style (and from how the layer is DRAWN, so 3D layers work

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -849,7 +849,8 @@ class GeoDeployDock(QDockWidget):
             # With a token, ask the API — it is authoritative and covers unpublished portals.
             if instance.token and ref is not None:
                 try:
-                    return instance.client.portals.get(ref)
+                    return portal_sync.enrich_from_published(
+                        instance.client.portals.get(ref), instance, symbology.style_from_legend)
                 except GeoDeployError:
                     pass                # fall through: a published portal is readable anyway
             # Without one, read what the portal PUBLISHES. Looking at a public portal should never
@@ -936,15 +937,19 @@ class GeoDeployDock(QDockWidget):
                     continue
                 label = str(cfg.get("name") or cfg.get("layer_id"))
                 layer_row = self._row_for(cfg.get("layer_id"), cfg.get("layer_type"))
-                is_raster = cfg.get("layer_type") == "raster"
                 layer = None
-                if is_raster and (cfg.get("source") or {}).get("url"):
-                    # THE PORTAL'S OWN TILES. A raster is styled by the server, and the portal bakes
-                    # its colormap, stretch, band choice and hillshade into the tile URL — so the
-                    # SAME raster reads `&colormap_name=terrain` in one portal, a bare `&rescale=`
-                    # in another and `&algorithm=hillshade&expression=b1*5.0` in a third. Building
-                    # it from the layer's own listing entry instead gave everyone the layer's
-                    # DEFAULT style, which is not what any of those portals shows.
+                if (cfg.get("source") or {}).get("url"):
+                    # THE PORTAL'S OWN SOURCE, for every layer type, because that is what "open the
+                    # portal" means.
+                    #
+                    # For a RASTER it is the styling: the server colours these, and the portal bakes
+                    # its colormap, stretch, band choice and hillshade into the tile URL — the same
+                    # raster reads `&colormap_name=terrain` in one portal, a bare `&rescale=` in
+                    # another and `&algorithm=hillshade&expression=b1*5.0` in a third. For a VECTOR
+                    # it is which tiles: a 3D point layer is drawn from a `pillars` function that
+                    # buffers the points into polygons, and nothing in the layer's own listing entry
+                    # points there. Either way, going through the layer's entry instead draws
+                    # something the portal does not show.
                     layer = self._layer_from_portal_source(cfg, label)
                 if layer is None and layer_row is not None:
                     source = sources.describe(layer_row,

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -22,6 +22,16 @@ from __future__ import annotations
 
 from .connection import GeoDeployError
 
+
+def _note(message: str) -> None:
+    """Say something in the QGIS log. Imported lazily because `symbology` imports nothing from here
+    but this module must not require QGIS to be importable at all — the tests load it standalone."""
+    try:
+        from .symbology import _log
+        _log(message)
+    except Exception:                   # noqa: BLE001 - a log line is never worth an exception
+        pass
+
 # Namespaced so nothing else in a QGIS project collides with them.
 P_LAYER_ID = "geodeploy/layer_id"
 P_LAYER_TYPE = "geodeploy/layer_type"
@@ -453,4 +463,49 @@ def push(client, group, configs, publish: bool = True, new_title: str | None = N
         group.setCustomProperty(P_PORTAL_TITLE, doc.get("title") or new_title or title or "")
     except Exception:                   # noqa: BLE001 - a tag is not worth failing a publish over
         pass
+    return doc
+
+
+def enrich_from_published(doc: dict, instance, style_from_legend) -> dict:
+    """Fill in what the API's `layer_configs` do not carry, from the portal's own published style.
+
+    THE ASYMMETRY THAT CAUSED A BUG. `PortalOut.LayerConfig` is `{layer_id, layer_type, visible,
+    opacity, style, popup_fields}` — no `source`, no `geometry_type`, no `name`. The published
+    style.json carries all three, because it has to: it IS the drawing instructions.
+
+    Without `source`, the group builder had nothing portal-specific to build a RASTER from and fell
+    back to the layer's own listing entry — so a portal drawing a DEM as `colormap_name=terrain`
+    opened in the layer's default grey, exactly the complaint that was fixed for the anonymous path
+    and not for this one. Without `geometry_type` it depended on the listing row matching, and
+    without `name` a layer that failed to open was reported by its numeric id.
+
+    The API's own values always win. This only ADDS keys, so the portal's authoritative styling and
+    visibility are untouched — and an unpublished portal simply has nothing to merge, which is
+    honest: its rasters are not being served under any styling yet.
+    """
+    if not doc.get("published") or not doc.get("slug"):
+        return doc
+    try:
+        baked = configs_from_published_style(
+            instance.published_style(doc["slug"]), style_from_legend)
+    except Exception as exc:            # noqa: BLE001 - the API document is still perfectly usable
+        _note("Could not read the published style for extra layer detail: {0}".format(exc))
+        return doc
+
+    by_key = {}
+    for cfg in baked:
+        try:
+            by_key[(int(cfg["layer_id"]), str(cfg.get("layer_type") or "vector"))] = cfg
+        except (TypeError, ValueError, KeyError):
+            continue
+    for cfg in (doc.get("layer_configs") or []):
+        try:
+            match = by_key.get((int(cfg.get("layer_id")), str(cfg.get("layer_type") or "vector")))
+        except (TypeError, ValueError):
+            continue
+        if not match:
+            continue
+        for key in ("source", "geometry_type", "name"):
+            if cfg.get(key) is None and match.get(key) is not None:
+                cfg[key] = match[key]
     return doc

--- a/integrations/qgis-plugin/scripts/test_published_style.py
+++ b/integrations/qgis-plugin/scripts/test_published_style.py
@@ -155,3 +155,76 @@ assert not isinstance(s.get("color"), list), "a MapLibre expression must never b
 print("classified       -> classes from the legend, expression never mistaken for a colour")
 
 print("\nALL PUBLISHED-STYLE CASES PASS")
+
+# ── the AUTHENTICATED document, and the asymmetry that bit it ─────────────────────────────────
+# `PortalOut.LayerConfig` is {layer_id, layer_type, visible, opacity, style, popup_fields}: no
+# `source`, no `geometry_type`, no `name`. Every fix that read those from the published style
+# therefore covered the anonymous path only — a portal opened WITH a token still drew its rasters in
+# the layer's default style, and still had to guess geometry from a listing lookup. `enrich_from_
+# published` merges the missing keys in, and must never touch the API's own values.
+enrich_from_published = portals["enrich_from_published"]
+
+
+class FakeInstance:
+    def __init__(self, doc, fail=False):
+        self._doc, self.fail, self.calls = doc, fail, 0
+
+    def published_style(self, slug):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("style.json is unreachable")
+        return self._doc
+
+
+API_DOC = {
+    "id": 13, "slug": "abc", "title": "Web map", "published": True,
+    "layer_configs": [
+        # A raster whose PORTAL styling is a terrain colormap; the API config states the style but
+        # gives no source, which is what left the plugin building it from the layer's default.
+        {"layer_id": 1, "layer_type": "raster", "visible": True, "opacity": 0.6,
+         "style": {"colormap": "terrain", "rescale": "264.9,298.33"}, "popup_fields": []},
+        # A vector the portal draws differently from its default.
+        {"layer_id": 3, "layer_type": "vector", "visible": True, "opacity": 1.0,
+         "style": {"color": "#10b981", "fill_opacity": 0.45}, "popup_fields": []},
+    ],
+}
+
+inst = FakeInstance(STYLE_DOC)
+out = enrich_from_published(json.loads(json.dumps(API_DOC)), inst, style_from_legend)
+by_id = {(c["layer_id"], c["layer_type"]): c for c in out["layer_configs"]}
+
+raster = by_id[(1, "raster")]
+assert raster["source"]["kind"] == "raster-xyz", raster
+assert "rescale=0,1" in raster["source"]["url"], "the PORTAL's tile template, styling and all"
+assert raster["opacity"] == 0.6, "the API's own opacity must survive"
+assert raster["style"] == {"colormap": "terrain", "rescale": "264.9,298.33"}, "style untouched"
+print("authed raster    -> gains the portal's source, keeps the API's style and opacity")
+
+vector = by_id[(3, "vector")]
+assert vector["geometry_type"] == "polygon", vector
+assert vector["source"]["kind"] == "pmtiles", vector
+assert vector["name"] == "example", "a failed layer is named, not numbered"
+# The API's style is authoritative for vectors and must NOT be replaced by the baked one.
+assert vector["style"] == {"color": "#10b981", "fill_opacity": 0.45}, vector
+print("authed vector    -> gains geometry/source/name, style left alone")
+
+# An UNPUBLISHED portal has no style.json to read, and must not be asked for one.
+unpub = enrich_from_published(dict(json.loads(json.dumps(API_DOC)), published=False),
+                              FakeInstance(STYLE_DOC), style_from_legend)
+assert unpub["layer_configs"][0].get("source") is None
+print("unpublished      -> nothing merged, nothing fetched")
+
+# An unreachable style.json must degrade, not raise — the API document is perfectly usable.
+degraded = enrich_from_published(json.loads(json.dumps(API_DOC)),
+                                 FakeInstance(STYLE_DOC, fail=True), style_from_legend)
+assert len(degraded["layer_configs"]) == 2
+print("unreachable      -> degrades to the API document")
+
+# A layer the published style does not mention (added since publishing) is left as it is.
+extra = json.loads(json.dumps(API_DOC))
+extra["layer_configs"].append({"layer_id": 99, "layer_type": "vector", "style": {}})
+out = enrich_from_published(extra, FakeInstance(STYLE_DOC), style_from_legend)
+assert out["layer_configs"][-1].get("geometry_type") is None
+print("unknown layer    -> untouched")
+
+print("\nALL AUTHENTICATED-PARITY CASES PASS")


### PR DESCRIPTION
Asked whether the 0.1.5 fixes hold with a token, the answer was **no** — and the reason is structural, not incidental.

## The asymmetry

`PortalOut.LayerConfig` is:

```python
{layer_id, layer_type, visible, opacity, style, popup_fields}
```

No `source`. No `geometry_type`. No `name`. Only the published `style.json` carries those, because it *is* the drawing instructions. So every fix that read them covered the **anonymous path alone**. With a token:

- **A portal's rasters still opened in the layer's default colours** — the complaint nominally fixed in 0.1.3, still live here, because without `source` there was nothing portal-specific to build from.
- **Geometry still depended on `_row_for` matching**, so a layer the listing didn't cover fell back to a guess — the dot-per-vertex bug, by a different route.
- **A failed layer was reported by its numeric id.** That is what `1 could not be opened (9)` was.

## The fix

`portals.enrich_from_published` merges `source` / `geometry_type` / `name` in from the published style for a **published** portal. It only *adds* keys — the API's `style`, `visible` and `opacity` stay authoritative, since for vectors they are the portal's real styling. It degrades to the API document when `style.json` can't be read, and an unpublished portal has nothing to merge, which is honest: its rasters aren't being served under any styling yet.

`place` now prefers the portal's source for **every** layer type, not just rasters. A 3D point layer is drawn from a `pillars` function whose tiles hold **polygons**; nothing in the layer's own listing entry points there, so building from it drew the wrong geometry from the wrong tiles.

## Also

A latent `AttributeError`: `portals.py` called `_log`, which it does not define. It would have fired precisely when something else had already gone wrong — i.e. it would have replaced a useful message with a crash. `_note` now does it, lazily.

## Tests

Six new cases pinning the authenticated shape: the raster gains the portal's source while keeping the API's style and opacity; the vector gains geometry/source/name with its style untouched; an unpublished portal fetches nothing; an unreachable `style.json` degrades; a layer added since publishing is left alone.

Plugin 0.1.6.
