### PR TITLE
Open in GeoDeploy, and a portal raster inherits the layer's stretch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         # is CONSTRUCTED. This builds the dock and checks every signal target exists.
         run: python integrations/qgis-plugin/scripts/smoke.py
 
-      - name: Vector-tile symbology really classifies
+      - name: Vector-tile symbology classifies, and round-trips back out
         # A tile layer that arrives in the right colour and nothing else looks styled and is not.
         # QGIS is not installable here, so this stubs the tile renderer and asserts on the filter
         # expressions handed to it — including the two edges that silently drop features, an open

--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -311,6 +311,14 @@ deliberately NOT visibility-filtered (published portals depend on them).
 - No rate limiting beyond nginx; no pagination on list endpoints (fine at current scale).
 
 ## Last updated
+2026-08-17c (`public.py`: new **`GET /api/public/layers/{kind}/{ref}`** — ONE public layer in the
+shape the layer page reads, so a public layer has a shareable address (the QGIS plugin's "Open in
+GeoDeploy", and the new public UI route `/layers/:kind/:id`). Same readability rule as the display
+endpoints — `vector._publicly_readable` / `raster._describable`, i.e. shared OR drawn by a published
+portal — and governed by the same `_require_enabled` switch as the index, so turning the anonymous
+index off does not leave every layer individually addressable. Adds `default_style`, `columns` and
+`tile_status` to what the index carries (the page draws the layer and lists its fields); adds nothing
+about who uploaded it or where it is stored.)
 2026-08-17 (`data/vector.py`: **`GET /{ref}/tiles/{z}/{x}/{y}`** — public XYZ vector tiles for a tiled
 GeoParquet layer, read a tile at a time from its PMTiles archive via `services/pmtiles_reader`. Same
 public terms as `/pmtiles` and Martin's `/tiles/` (a published portal is unauthenticated). **204, not

--- a/api/geodeploy/routers/public.py
+++ b/api/geodeploy/routers/public.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..database import get_db
 from ..models import Portal, RasterLayer, SetupConfig, VectorLayer
 from ..services import share_links
+from .common import by_ref
 
 router = APIRouter(prefix="/public", tags=["public"])
 
@@ -78,6 +79,57 @@ async def public_index(request: Request, db: AsyncSession = Depends(get_db)) -> 
             "ogc_features": base + "/api/ogc",
         },
     }
+
+
+@router.get("/layers/{kind}/{layer_ref}")
+async def public_layer(kind: str, layer_ref: str, request: Request,
+                       db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """ONE public layer, in the shape the layer page reads — so a public layer has a shareable page.
+
+    The index above lists layers; nothing let an anonymous visitor look at one. That is what the
+    plugin's "Open in GeoDeploy" needs: a public layer should open for anybody, and a private one
+    should ask them to sign in — the same rule the rest of the anonymous surface follows.
+
+    Deliberately the SAME readability rule as the display endpoints (`_publicly_readable`): a layer
+    that is shared, or drawn by a published portal. It adds `default_style`, `columns` and
+    `tile_status` to what the index carries, because the page draws the layer and lists its fields;
+    it adds nothing about who uploaded it or where it is stored.
+    """
+    await _require_enabled(db)
+    base = _base_url(request)
+    if kind == "raster":
+        from .data.raster import _describable
+        row = (await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
+               ).scalar_one_or_none()
+        if not await _describable(row, db):
+            raise HTTPException(404, "No public layer at this address.")
+        out = _raster_out(row, base)
+        out.update({"uid": row.uid, "status": row.status, "band_count": row.band_count,
+                    "default_style": _style(row), "file_size": row.file_size,
+                    "width": getattr(row, "width", None), "height": getattr(row, "height", None),
+                    "nodata_value": getattr(row, "nodata_value", None)})
+        return out
+    if kind == "vector":
+        from .data.vector import _publicly_readable
+        row = (await db.execute(select(VectorLayer).where(by_ref(VectorLayer, layer_ref)))
+               ).scalar_one_or_none()
+        if not row or row.status != "ready" or not await _publicly_readable(row, db):
+            raise HTTPException(404, "No public layer at this address.")
+        out = _vector_out(row, base)
+        columns = []
+        if row.columns:
+            try:
+                columns = json.loads(row.columns)
+            except (ValueError, TypeError):
+                columns = []
+        out.update({"uid": row.uid, "status": row.status, "columns": columns,
+                    "storage_backend": getattr(row, "storage_backend", "postgis"),
+                    "tile_status": getattr(row, "tile_status", None),
+                    "schema_name": row.schema_name, "table_name": row.table_name,
+                    "file_size": row.file_size,
+                    "default_style": json.loads(row.default_style) if row.default_style else None})
+        return out
+    raise HTTPException(404, "Unknown layer kind.")
 
 
 @router.get("/portals")

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -131,6 +131,14 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   permalink it serves, never a substitute for the bbox queries.
 
 ## Last updated
+2026-08-17b (`portal_generator`: **a portal's raster with no `rescale` now inherits the layer's.**
+TiTiler needs a stretch for anything not already 0-255, and without one a float DEM or index raster
+comes back transparent. Measured on a live portal: two layers configured `bidx=1` with no rescale
+returned 206- and 514-byte tiles at the centre of their own bounds against 27 kB for the hillshade
+beside them — blank in the browser AND in QGIS, while the same layers opened standalone looked right,
+because standalone they use their default style, which has one. User-confirmed from both surfaces. A
+portal still keeps whatever stretch it states; it falls back only when it states none. An 8-bit RGB
+image has none in either place and is unaffected. **Takes effect on republish** — style.json is baked.)
 2026-08-17 (**new `pmtiles_reader.py` — one tile out of an archive, so tiled layers can be served as
 ordinary XYZ.** PMTiles v3 read-only, written by hand rather than pulled in as a dependency (fixed
 127-byte header, varint directories, a Hilbert curve, all frozen by the spec). Every read is an HTTP

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -253,12 +253,26 @@ def generate_style(layer_configs: list[dict], vector_layers: list, raster_layers
             layers_info.append(_layer_info(layer, "raster"))
             source_id = f"raster_{layer.id}"
             rstyle = cfg.get("style", {})
+            # A PORTAL WITH NO STRETCH FALLS BACK TO THE LAYER'S OWN.
+            #
+            # TiTiler needs a `rescale` for any raster whose values are not already 0-255: without
+            # one a float DEM or an index raster comes back essentially transparent. Measured on a
+            # live portal — two layers configured `bidx=1` with no rescale returned 206- and
+            # 514-byte tiles at the centre of their own bounds, against 27 kB for the hillshade
+            # beside them. Blank in the browser and blank in QGIS, while the SAME layer opened on its
+            # own looked right, because on its own it is drawn with its default style, which has one.
+            #
+            # So the portal keeps whatever it states, and states nothing only when the author never
+            # touched the stretch — in which case the layer's own is the honest answer, not a blank
+            # tile. An 8-bit RGB image has no rescale in either place and is unaffected.
+            dstyle = json.loads(layer.default_style) if layer.default_style else {}
+            rescale = rstyle.get("rescale") or dstyle.get("rescale")
             sources[source_id] = {
                 "type": "raster",
                 "tiles": [raster_tile_url(
                     layer.s3_key,
                     colormap=rstyle.get("colormap"),
-                    rescale=rstyle.get("rescale"),
+                    rescale=rescale,
                     algorithm=rstyle.get("algorithm"),
                     zfactor=rstyle.get("zfactor"),
                     bidx=rstyle.get("bidx"),

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -63,6 +63,12 @@ async def seeded(db):
                        s3_key="rasters/1/x/dem.tif", status="ready", is_public=True,
                        visibility="public", band_count=1, crs="EPSG:3006"))
     await db.commit()
+    # The published-portal id sets are MODULE-LEVEL caches, invalidated in production by the
+    # publish/share/delete paths. Nothing invalidates them between tests, so a set computed from
+    # another module's fixtures leaks in and makes a private layer here look portal-published —
+    # which is exactly how `test_a_private_layer_is_404_not_a_hint` saw a 200. Reset to this DB.
+    from geodeploy.routers.data.vector import invalidate_public_layers
+    invalidate_public_layers()
     yield db
 
 

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -210,3 +210,77 @@ class TestAdminToggleEndpoint:
                                  headers=headers)).json()
         assert rows["total"] >= 1
         assert rows["items"][0]["detail"] == {"enabled": False}
+
+
+class TestOnePublicLayer:
+    """`GET /api/public/layers/{kind}/{ref}` — the page behind the plugin's "Open in GeoDeploy".
+
+    The index says WHAT is public; this says what one of them IS, so a public layer has a shareable
+    address. Which makes its exposure rule the thing to pin: it must serve exactly what the display
+    endpoints already serve to anyone (shared, or drawn by a published portal) and nothing more.
+    """
+
+    async def test_a_shared_vector_is_served_with_what_the_page_needs(self, client, seeded):
+        body = (await client.get("/api/public/layers/vector/aaaaaaaaaaaa")).json()
+        assert body["name"] == "Roads"
+        assert body["uid"] == "aaaaaaaaaaaa"
+        assert body["status"] == "ready"
+        assert body["geometry_type"] == "linestring"        # the map needs it to pick a symbol
+        assert body["feature_count"] == 12
+        assert body["bbox"] == [11.0, 55.0, 24.0, 69.0]
+        assert body["crs"] == "EPSG:4326"
+        assert "columns" in body and "default_style" in body
+        assert body["links"], "the share links are the point of the page"
+
+    async def test_a_shared_raster_is_served(self, client, seeded):
+        body = (await client.get("/api/public/layers/raster/eeeeeeeeeeee")).json()
+        assert body["name"] == "Elevation" and body["band_count"] == 1
+        assert body["uid"] == "eeeeeeeeeeee" and body["status"] == "ready"
+
+    async def test_a_private_layer_is_404_not_a_hint(self, client, seeded):
+        # 'Internal' is organization-visibility. A signed-out visitor must not learn it exists, and
+        # the page turns this into "sign in and look again" rather than "no such layer".
+        r = await client.get("/api/public/layers/vector/cccccccccccc")
+        assert r.status_code == 404
+        assert "Internal" not in r.text
+
+    async def test_a_layer_that_is_not_ready_is_404(self, client, seeded):
+        assert (await client.get("/api/public/layers/vector/dddddddddddd")).status_code == 404
+
+    async def test_a_layer_shown_by_a_published_portal_resolves(self, client, seeded, db):
+        # The rule that matters most, and the one the raster endpoints used to get wrong: being
+        # drawn by a public portal is enough. Portal 1 draws vector 1; make that layer non-shared
+        # and it must STILL resolve, because the portal is published and public.
+        from geodeploy.routers.data.vector import invalidate_public_layers
+        layer = await db.get(VectorLayer, 1)
+        layer.is_public, layer.visibility = False, "organization"
+        await db.commit()
+        invalidate_public_layers()
+        assert (await client.get("/api/public/layers/vector/aaaaaaaaaaaa")).status_code == 200
+        # …and a layer no portal draws is still refused.
+        assert (await client.get("/api/public/layers/vector/cccccccccccc")).status_code == 404
+
+    async def test_by_integer_id_too_for_older_links(self, client, seeded):
+        assert (await client.get("/api/public/layers/vector/1")).status_code == 200
+
+    async def test_an_unknown_kind_is_refused(self, client, seeded):
+        assert (await client.get("/api/public/layers/nonsense/1")).status_code == 404
+
+    async def test_it_needs_no_credentials(self, client, seeded):
+        r = await client.get("/api/public/layers/vector/aaaaaaaaaaaa")
+        assert r.status_code == 200
+        assert "authorization" not in {k.lower() for k in r.request.headers}
+
+    async def test_the_index_switch_governs_it_too(self, client, seeded, db):
+        # If an operator turns the anonymous index off, this must go with it — otherwise the switch
+        # only hides the list while every layer stays individually addressable.
+        row = await db.get(SetupConfig, 1)
+        if row is None:
+            db.add(SetupConfig(id=1, public_index_enabled=False))
+        else:
+            row.public_index_enabled = False
+        await db.commit()
+        # `index_enabled` reads the row it is handed, so there is no cache to clear — the next
+        # request sees the new value.
+        r = await client.get("/api/public/layers/vector/aaaaaaaaaaaa")
+        assert r.status_code == 404, r.status_code

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,13 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17g (new **"Open in GeoDeploy"** button — `open_in_browser` opens `/layers/<kind>/<uid>`, the
+instance's own page for one layer, in the desktop browser; for a portal it opens the portal. The dock
+shows a layer's geometry and symbology, and the page shows what it cannot: metadata, field list,
+extent, sharing state, and every ready-made link for other tools. The address is PUBLIC — see
+`routers/public.py::public_layer` and the new UI route — so a shared layer opens for anyone and a
+private one becomes a sign-in prompt on the instance, where the visitor may well have access. That is
+why the button needs no token to be useful. `_open_portal` now shares the one `_open_url` helper.)
 2026-08-17f (**the two portal paths were not the same path, and every 0.1.5 fix covered only one.**
 `PortalOut.LayerConfig` is `{layer_id, layer_type, visible, opacity, style, popup_fields}` — no
 `source`, no `geometry_type`, no `name`. Everything read from the published style.json therefore

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,25 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17h (**pushing a restyle from a portal group sent nothing, and for rasters it DELETED the
+portal's styling.** Two halves of one mistake: a portal's layers open as the surfaces that draw like
+the portal, and neither is what QGIS can read a style back out of.
+*Vectors:* `from_qgis` reads FEATURE renderers, and a portal group's vectors are `QgsVectorTileLayer`
+— so it returned `{}` and the restyle never left QGIS. New `style_from_vector_tiles` is the inverse of
+`apply_to_vector_tiles`: each renderer entry carries a symbol and the FILTER the class was written
+with, so `"k" = 'a'` reads back as a category and `"pop" >= 100 AND "pop" < 1000` as a class
+(`_CAT_FILTER`/`_parse_range`). A filter this did not write, or two fields in one classification,
+degrades to a single symbol rather than being half-parsed into somebody else's classification.
+*Rasters:* portal tiles are a picture — QGIS models them as `QgsSingleBandColorDataRenderer`,
+"Singleband color data", with no bands to stretch — so there is genuinely nothing to read.
+`plan_push` now KEEPS the portal's existing style whenever the QGIS side reads as empty, for vectors
+too: pushing `{}` replaced a portal's colormap with nothing, so an attempted restyle silently
+destroyed the styling it meant to change. The diff dialog reports these as "Style kept as the portal
+has it" with the way to actually restyle a raster (open the GeoTIFF, restyle, Save styling).
+Also: the size conversions did not invert — `_symbol_of` writes `radius * 2 * 0.75` while the reader
+used `size / 2` and `width * 4` (a leftover from millimetres), so a radius of 5 round-tripped to 3.75
+and a line width of 2 to 6. One shared `_style_from_symbol` now divides by the same constant the
+writer multiplies by, and `test_tile_symbology` round-trips every mode to keep it honest.)
 2026-08-17g (new **"Open in GeoDeploy"** button — `open_in_browser` opens `/layers/<kind>/<uid>`, the
 instance's own page for one layer, in the desktop browser; for a portal it opens the portal. The dock
 shows a layer's geometry and symbology, and the page shows what it cannot: metadata, field list,

--- a/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
@@ -37,6 +37,13 @@ def summarise(plan: dict) -> str:
 
     section("Unchanged", plan.get("unchanged") or [])
     section("Restyled", plan.get("restyled") or [])
+    # Said out loud, because the alternative is a silent no-op the user reads as a failed restyle.
+    # A portal's raster is a server-rendered picture in QGIS — "Singleband color data", with nothing
+    # to change — so its styling cannot be read back out. The portal keeps what it had.
+    section("Style kept as the portal has it — QGIS's version could not be read "
+            "(a raster opened as portal tiles has no bands to restyle; tick “Prefer the real data "
+            "over the styled view” to open the GeoTIFF itself, restyle that, and use “Save styling "
+            "to GeoDeploy”)", plan.get("kept") or [])
     section("Added — already on the instance", plan.get("added") or [])
     section("New — not on the instance yet", plan.get("uploads") or [])
     section("Removed from the portal", plan.get("removed") or [])
@@ -61,7 +68,7 @@ def confirm(parent, portal_title: str, plan: dict, creating: bool):
 
     uploads_n = len(plan.get("uploads") or [])
     existing_n = (len(plan.get("unchanged") or []) + len(plan.get("restyled") or [])
-                  + len(plan.get("added") or []))
+                  + len(plan.get("kept") or []) + len(plan.get("added") or []))
     if creating and uploads_n and not existing_n:
         # The "start in QGIS, end with a URL" case. Everything here is a local file, so the whole
         # group is about to be UPLOADED before the portal can exist — that is a much bigger action

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.6
+version=0.1.7
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,10 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.6 - A portal now opens the same way whether or not you are signed in. The API's portal
+changelog=0.1.7 - New "Open in GeoDeploy" button: opens the selected layer's page on the instance
+    in your browser - map, metadata, fields, extent and every share link. Works without an account
+    for a public layer; a private one asks you to sign in there.
+    0.1.6 - A portal now opens the same way whether or not you are signed in. The API's portal
     document does not carry a layer's source, geometry or name - only the published style does - so
     every fix in 0.1.5 covered the signed-out path alone: with a token, rasters still opened in the
     layer's default colours and 3D layers were drawn from the wrong tiles. The two are now merged.

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.7
+version=0.1.8
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,15 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.7 - New "Open in GeoDeploy" button: opens the selected layer's page on the instance
+changelog=0.1.8 - Restyling a layer inside a portal group and pushing it back now works. A portal's
+    layers open as TILES, and QGIS renders those through a different renderer than a normal vector
+    layer - so the styling was read from the wrong place and nothing was sent. It is now read back
+    properly, classes and all. A raster opened from portal tiles has no bands to restyle ("Singleband
+    color data"), so its portal styling is now LEFT ALONE instead of being replaced with nothing -
+    which used to wipe the colormap. To restyle a raster, tick "Prefer the real data over the styled
+    view", restyle that, and use "Save styling to GeoDeploy". Also fixes marker size and line width
+    changing slightly every time a layer was pushed back.
+    0.1.7 - New "Open in GeoDeploy" button: opens the selected layer's page on the instance
     in your browser - map, metadata, fields, extent and every share link. Works without an account
     for a public layer; a private one asks you to sign in there.
     0.1.6 - A portal now opens the same way whether or not you are signed in. The API's portal

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -156,6 +156,14 @@ class GeoDeployDock(QDockWidget):
         self.add_btn = QPushButton("Add to map")
         self.add_btn.clicked.connect(self.add_selected)
         outer.addWidget(self.add_btn)
+
+        self.open_web_btn = QPushButton("Open in GeoDeploy")
+        self.open_web_btn.setToolTip(
+            "Open the selected layer's page on the instance, in your browser — the map, the "
+            "metadata, the fields and every share link. A public layer opens for anyone; a private "
+            "one asks you to sign in there.")
+        self.open_web_btn.clicked.connect(self.open_in_browser)
+        outer.addWidget(self.open_web_btn)
         self.tree.itemSelectionChanged.connect(self._on_selection_changed)
 
         # -- portals ----------------------------------------------------------------------------
@@ -438,7 +446,10 @@ class GeoDeployDock(QDockWidget):
     def _on_selection_changed(self):
         """A portal cannot be added to the map, so the button says what it WILL do instead."""
         row = self._selected_row() or {}
-        self.add_btn.setText("Open portal in browser" if row.get("_portal") else "Add to map")
+        is_portal = bool(row.get("_portal"))
+        self.add_btn.setText("Open portal in browser" if is_portal else "Add to map")
+        self.open_web_btn.setText("Open portal in GeoDeploy" if is_portal
+                                  else "Open layer in GeoDeploy")
 
     def add_selected(self):
         row = self._selected_row()
@@ -1148,6 +1159,45 @@ class GeoDeployDock(QDockWidget):
                   base + "/p/" + str(doc.get("slug")) + detail)
         self.refresh_layers()
 
+    def open_in_browser(self):
+        """Open the selected layer's (or portal's) page on the instance.
+
+        The plugin shows a layer's geometry and its symbology; the instance's own page shows what it
+        cannot — the metadata, the field list, the extent, the sharing state and every ready-made
+        link for other tools. Rather than describe all that in a dock, point at it.
+
+        `/layers/<kind>/<uid>` is the PUBLIC address for one layer: anyone may open a shared layer,
+        and a private one turns into a sign-in prompt on the instance, where the visitor may well
+        have access. That is the same rule the rest of the anonymous surface follows, and it is why
+        this does not need a token to be useful.
+        """
+        row = self._selected_row()
+        if not row:
+            self._say("Pick a layer or a portal first.", Qgis.Warning)
+            return
+        if row.get("_portal"):
+            self._open_portal(row)
+            return
+        base = (row.get("_base") or (self.instance.url if self.instance else "")).rstrip("/")
+        ref = row.get("uid") or row.get("id")
+        if not base or ref is None:
+            self._say("That layer has no address on the instance.", Qgis.Warning)
+            return
+        kind = "raster" if (row.get("layer_type") == "raster"
+                            or row.get("kind") == "raster"
+                            or row.get("storage_backend") == "raster") else "vector"
+        self._open_url("{0}/layers/{1}/{2}".format(base, kind, ref))
+
+    def _open_url(self, url):
+        """Hand a URL to the desktop browser, and never leave the user without the address."""
+        try:
+            from qgis.PyQt.QtCore import QUrl
+            from qgis.PyQt.QtGui import QDesktopServices
+            QDesktopServices.openUrl(QUrl(url))
+            self._say("Opened {0} in your browser.".format(url))
+        except Exception as exc:        # noqa: BLE001 - still give them the address
+            self._say("Open it at {0} ({1}).".format(url, exc), Qgis.Warning)
+
     def _open_portal(self, row):
         """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
         # The instance publishes the portal's OWN url; `/p/<slug>` was a guess, and it lands on
@@ -1161,13 +1211,7 @@ class GeoDeployDock(QDockWidget):
                 self._say("That portal has no address yet — publish it first.", Qgis.Warning)
                 return
             url = f"{base}/portals/{slug}/"
-        try:
-            from qgis.PyQt.QtCore import QUrl
-            from qgis.PyQt.QtGui import QDesktopServices
-            QDesktopServices.openUrl(QUrl(url))
-            self._say(f"Opened {url} in your browser.")
-        except Exception as exc:        # noqa: BLE001 - still give them the address
-            self._say(f"Open it at {url} ({exc}).", Qgis.Warning)
+        self._open_url(url)
 
     def save_style(self):
         """Push the selected layer's QGIS styling back as its GeoDeploy default style.

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -324,13 +324,16 @@ def plan_push(group, style_for, current_configs) -> dict:
     * `added`     — in the group, already on the instance, not yet on the portal;
     * `uploads`   — in the group but NOT on the instance: local files, with nothing to reference
                     until they are uploaded. `(name, qgis_layer)` so the caller can send them;
-    * `removed`   — on the portal, no longer in the group.
+    * `removed`   — on the portal, no longer in the group;
+    * `kept`      — on the portal, and its QGIS styling could not be read, so the portal's own is
+                    left exactly as it was. Named so the dialog can say that out loud instead of
+                    reporting the layer as "unchanged", which would be true only by accident.
     """
     before = {}
     for cfg in (current_configs or []):
         before[(int(cfg.get("layer_id")), str(cfg.get("layer_type")))] = cfg
 
-    configs, uploads, unchanged, restyled, added = [], [], [], [], []
+    configs, uploads, unchanged, restyled, added, kept = [], [], [], [], [], []
     seen = set()
 
     def walk(node):
@@ -356,13 +359,29 @@ def plan_push(group, style_for, current_configs) -> dict:
                 continue
             layer_id, layer_type = identity
             seen.add((layer_id, layer_type))
+            was = before.get((layer_id, layer_type))
             style = style_for(qgis_layer, layer_type) or {}
+            if not style and (was or {}).get("style"):
+                # AN UNREADABLE STYLE MUST NOT ERASE THE PORTAL'S.
+                #
+                # A portal's raster is opened as server-rendered tiles — a picture — because that is
+                # the only way it looks like the portal. QGIS calls that "Singleband color data" and
+                # offers nothing to change: there are no bands to stretch, only RGBA. So
+                # `raster_from_qgis` has nothing to translate and returns {}, and pushing that
+                # REPLACED the portal's colormap and stretch with nothing. The raster then rendered
+                # unstretched, i.e. usually blank — a restyle attempt that silently destroyed the
+                # styling it was meant to change.
+                #
+                # Keeping what the portal already had is the only safe reading of "I could not tell".
+                # It applies to vectors too: a renderer this plugin cannot translate is not an
+                # instruction to clear the portal's styling.
+                style = was["style"]
+                kept.append(qgis_layer.name())
             entry = {"layer_id": layer_id, "layer_type": layer_type,
                      "visible": bool(child.isVisible()), "opacity": _opacity_of(qgis_layer),
                      "style": style, "popup_fields": []}
             configs.append(entry)
             tree.append({"layer_id": layer_id, "layer_type": layer_type})
-            was = before.get((layer_id, layer_type))
             if was is None:
                 added.append(qgis_layer.name())
             elif _style_differs(was, entry):
@@ -387,7 +406,7 @@ def plan_push(group, style_for, current_configs) -> dict:
 
     return {"configs": configs, "uploads": uploads, "unchanged": unchanged,
             "restyled": restyled, "added": added, "removed": removed, "rename": rename,
-            "tree": tree}
+            "tree": tree, "kept": kept}
 
 
 def _style_differs(before: dict, after: dict) -> bool:

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -19,6 +19,8 @@ right colour, because a layer drawn plainly is recoverable and a layer that refu
 """
 from __future__ import annotations
 
+import re
+
 from .connection import GeoDeployError  # noqa: F401  (re-exported for callers)
 
 try:                                    # pragma: no cover - only present inside QGIS
@@ -529,6 +531,17 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
     if not QGIS or qgis_layer is None:
         return {}
     renderer = qgis_layer.renderer() if hasattr(qgis_layer, "renderer") else None
+    # A PICTURE, NOT A RASTER. A portal's raster arrives as server-rendered tiles, which QGIS models
+    # as one band of RGBA — "Singleband color data" in the Symbology tab, with no render type to
+    # choose and nothing to stretch. There is genuinely no styling to read back, so say so plainly:
+    # silence here reads as "the push lost my changes", and pushing the empty result would REPLACE
+    # the portal's colormap with nothing (see portals.plan_push, which now refuses to).
+    if type(renderer).__name__ == "QgsSingleBandColorDataRenderer":
+        _log("This raster is drawn from the portal's own tiles, so QGIS holds it as colour, not as "
+             "values — there is no band styling to send back. To restyle it, add the layer with "
+             "'Prefer the real data over the styled view' (that opens the GeoTIFF), restyle that, "
+             "and use 'Save styling to GeoDeploy'.")
+        return {}
     if renderer is None:
         return {}
     style = {}
@@ -758,6 +771,120 @@ def _ramp_name(renderer):
         return (None, False)
 
 
+#: Filters `apply_to_vector_tiles` writes, read back. `"field" = 'value'` is a category; a pair of
+#: comparisons on one field is a class. Anchored so a hand-written filter this cannot understand
+#: falls through to a single symbol rather than being half-parsed into a wrong class.
+_CAT_FILTER = re.compile(
+    r"""^"(?P<field>[^"]+)"\s*=\s*(?P<value>'(?:[^']|'')*'|-?[0-9.]+)$""")
+_RANGE_PART = re.compile(
+    r"""^"(?P<field>[^"]+)"\s*(?P<op><=|<|>=|>)\s*(?P<value>-?[0-9.eE+]+)$""")
+
+
+def _unquote(literal: str):
+    """A filter literal back to a Python value, undoing the doubled quotes an escape needed."""
+    if literal.startswith("'") and literal.endswith("'"):
+        return literal[1:-1].replace("''", "'")
+    try:
+        number = float(literal)
+    except ValueError:
+        return literal
+    return int(number) if number == int(number) else number
+
+
+def _parse_range(expression: str):
+    """`("field", lo, hi)` for a class filter, or None. Open edges come back as None."""
+    parts = [p.strip() for p in re.split(r"\s+AND\s+", expression.strip(), flags=re.IGNORECASE)]
+    field, lo, hi = None, None, None
+    for part in parts:
+        m = _RANGE_PART.match(part)
+        if not m:
+            return None
+        if field is not None and m.group("field") != field:
+            return None                 # two fields is not a class this plugin wrote
+        field = m.group("field")
+        value = float(m.group("value"))
+        if m.group("op") in (">=", ">"):
+            lo = value
+        else:
+            hi = value
+    if field is None or (lo is None and hi is None):
+        return None
+    return field, lo, hi
+
+
+def style_from_vector_tiles(tile_layer) -> dict:
+    """The GeoDeploy style for a vector-TILE layer — the inverse of `apply_to_vector_tiles`.
+
+    WHY THIS IS NEEDED AT ALL. A portal's vector layers open as tiles, because that is what draws
+    fast and matches the portal. QGIS renders those through `QgsVectorTileBasicRenderer`, which is
+    not a feature renderer — so `from_qgis`, which reads `QgsSingleSymbolRenderer` and friends, found
+    nothing and returned `{}`. Restyling a layer in a portal group and pushing it therefore sent no
+    style at all: the change looked applied in QGIS and never arrived.
+
+    Each renderer entry carries a symbol and a FILTER, which is exactly how the classes were written
+    out, so they read back the same way: `"k" = 'a'` is a category, `"pop" >= 100 AND "pop" < 1000`
+    is a class. Anything this cannot recognise degrades to a single symbol in the first colour rather
+    than being guessed at — an approximation of somebody's classification is worse than none.
+    """
+    if not QGIS or tile_layer is None:
+        return {}
+    renderer = tile_layer.renderer() if hasattr(tile_layer, "renderer") else None
+    entries = list(renderer.styles()) if hasattr(renderer, "styles") else []
+    if not entries:
+        return {}
+
+    # One class may have been written once per geometry type (see `apply_to_vector_tiles`), so the
+    # FILTER identifies a class, not the entry. Keep the first of each.
+    seen, unique = set(), []
+    for entry in entries:
+        if hasattr(entry, "isEnabled") and not entry.isEnabled():
+            continue
+        expression = (entry.filterExpression() or "").strip()
+        if expression in seen:
+            continue
+        seen.add(expression)
+        unique.append((expression, entry))
+    if not unique:
+        return {}
+
+    visual = _style_from_symbol(unique[0][1].symbol()) if unique[0][1].symbol() else {}
+
+    categories, classes, field, other = [], [], None, None
+    for expression, entry in unique:
+        symbol = entry.symbol()
+        colour = _hex(symbol.color()) if symbol is not None else None
+        if not expression:
+            other = colour              # the unfiltered entry is the catch-all
+            continue
+        cat = _CAT_FILTER.match(expression)
+        if cat:
+            if field not in (None, cat.group("field")):
+                return dict(visual, color_mode="single")
+            field = cat.group("field")
+            categories.append({"value": _unquote(cat.group("value")), "color": colour})
+            continue
+        rng = _parse_range(expression)
+        if rng:
+            if field not in (None, rng[0]):
+                return dict(visual, color_mode="single")
+            field = rng[0]
+            classes.append({"min": rng[1], "max": rng[2], "color": colour})
+            continue
+        # A filter nobody here wrote: do not pretend to understand it.
+        return dict(visual, color_mode="single")
+
+    if classes and not categories:
+        classes.sort(key=lambda c: (c["min"] is not None, c["min"] if c["min"] is not None else 0))
+        return dict(visual, color_mode="graduated", color_field=field,
+                    classes=classes, classes_n=len(classes))
+    if categories and not classes:
+        style = dict(visual, color_mode="categorized", color_field=field, categories=categories)
+        if other:
+            style["other_color"] = other
+        return style
+    return dict(visual, color_mode="single")
+
+
 def from_qgis(qgis_layer) -> dict:
     """The GeoDeploy style dict for a QGIS layer's current renderer.
 
@@ -766,6 +893,15 @@ def from_qgis(qgis_layer) -> dict:
     """
     if not QGIS or qgis_layer is None:
         return {}
+    # A VECTOR-TILE LAYER IS NOT A FEATURE LAYER, and this is where forgetting that cost a whole
+    # feature: everything below reads feature renderers, so a portal group's layers — which are all
+    # tiles — returned {} and their restyling never reached the instance.
+    try:
+        from qgis.core import QgsVectorTileLayer
+        if isinstance(qgis_layer, QgsVectorTileLayer):
+            return style_from_vector_tiles(qgis_layer)
+    except ImportError:                 # pragma: no cover - older QGIS has no vector tiles
+        pass
     renderer = qgis_layer.renderer() if hasattr(qgis_layer, "renderer") else None
     if renderer is None:
         return {}
@@ -805,16 +941,34 @@ def from_qgis(qgis_layer) -> dict:
             symbols = renderer.symbols(None)
             symbol = symbols[0] if symbols else None
         if symbol is not None:
-            style = {"color_mode": "single", "color": _hex(symbol.color())}
-            layer0 = symbol.symbolLayer(0) if symbol.symbolLayerCount() else None
-            if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
-                style["radius"] = round(float(symbol.size()) / 2.0, 2)
-            elif isinstance(layer0, QgsSimpleLineSymbolLayer):
-                style["line_width"] = round(float(layer0.width()) * 4.0, 2)
-                pen = layer0.penStyle()
-                style["lineType"] = ("dashed" if pen == Qt.DashLine
-                                     else "dotted" if pen == Qt.DotLine else "solid")
-            return style
+            return dict({"color_mode": "single"}, **_style_from_symbol(symbol))
     except Exception:                   # noqa: BLE001 - never block an upload over styling
         return {}
     return {}
+
+
+def _style_from_symbol(symbol) -> dict:
+    """Colour, size and dash from ONE QGIS symbol — the inverse of `_symbol_of`.
+
+    THE CONVERSIONS HAVE TO INVERT, and two of them did not. `_symbol_of` writes a marker's size as
+    `radius * 2 * CSS_PX_TO_POINTS` and a line's width as `line_width * CSS_PX_TO_POINTS`; this read
+    them back as `size / 2` and `width * 4`, left over from when sizes were in millimetres. A radius
+    of 5 round-tripped to 3.75 and a line width of 2 to 6 — so simply opening a layer and pushing it
+    back changed how it draws. Dividing by the same constant the writer multiplies by is the whole
+    fix, and `test_tile_symbology` now round-trips to keep it that way.
+    """
+    style = {"color": _hex(symbol.color())}
+    layer0 = symbol.symbolLayer(0) if symbol.symbolLayerCount() else None
+    if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
+        style["radius"] = round(float(symbol.size()) / 2.0 / CSS_PX_TO_POINTS, 2)
+    elif isinstance(layer0, QgsSimpleLineSymbolLayer):
+        style["line_width"] = round(float(layer0.width()) / CSS_PX_TO_POINTS, 2)
+        pen = layer0.penStyle()
+        style["lineType"] = ("dashed" if pen == Qt.DashLine
+                             else "dotted" if pen == Qt.DotLine else "solid")
+    elif isinstance(layer0, QgsSimpleFillSymbolLayer):
+        try:
+            style["fill_opacity"] = round(float(symbol.opacity()), 3)
+        except Exception:               # noqa: BLE001 - not every build exposes it
+            pass
+    return style

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -11,6 +11,7 @@ asserts on what would have been handed to QGIS: one style per class, the right c
 that selects exactly that class — including the two edge cases that silently lose features, an open
 outer bound and an inclusive top break.
 """
+import json
 import sys
 import types
 
@@ -46,13 +47,16 @@ class _SymbolLayer:
     """
 
     def __init__(self):
-        self.width = None
+        self._width = None
         self.stroke = None
         self.stroke_width = None
         self.pen = None
 
     def setWidth(self, w):
-        self.width = w
+        self._width = w
+
+    def width(self):                    # a METHOD in QGIS
+        return self._width
 
     def setStrokeWidth(self, w):
         # A marker's OUTLINE width — a different setter from setWidth, which is a line's own width.
@@ -67,6 +71,9 @@ class _SymbolLayer:
 
     def setPenStyle(self, s):
         self.pen = s
+
+    def penStyle(self):
+        return self.pen if self.pen is not None else 1   # 1 = Qt.SolidLine
 
     def setDataDefinedProperty(self, key, prop):
         self.data_defined = prop
@@ -100,19 +107,30 @@ _LAYER_FOR = {0: QgsSimpleMarkerSymbolLayer, 1: QgsSimpleLineSymbolLayer,
 class _Symbol:
     def __init__(self, geometry_type):
         self.geometry_type = geometry_type
-        self.color = None
-        self.size = None
-        self.opacity = None
+        self._color = _QColor("#000000")
+        self._size = None
+        self._opacity = 1.0
         self._layer = _LAYER_FOR[geometry_type]()
 
     def setColor(self, c):
-        self.color = c.name() if hasattr(c, "name") else c
+        self._color = c if hasattr(c, "name") else _QColor(c)
+
+    # A METHOD, as in QGIS — the read-back path calls `symbol.color().name()`, so a plain string
+    # attribute here would have made the round-trip test pass against an API that does not exist.
+    def color(self):
+        return self._color
 
     def setSize(self, s):
-        self.size = s
+        self._size = s
+
+    def size(self):                     # a METHOD in QGIS, like color()
+        return self._size
 
     def setOpacity(self, o):
-        self.opacity = o
+        self._opacity = o
+
+    def opacity(self):
+        return self._opacity
 
     def setDataDefinedSize(self, p):
         self.data_defined = p
@@ -135,12 +153,9 @@ class QgsVectorTileBasicRendererStyle(_Stub):
         self.name = name
         self.source_layer = source_layer
         self.geometry_type = geometry_type
-        self.symbol = None
+        self._symbol = None
         self.filter = ""
         self.enabled = False
-
-    def setSymbol(self, s):
-        self.symbol = s
 
     def setEnabled(self, v):
         self.enabled = v
@@ -148,13 +163,30 @@ class QgsVectorTileBasicRendererStyle(_Stub):
     def setFilterExpression(self, e):
         self.filter = e
 
+    def filterExpression(self):
+        return self.filter
+
+    def isEnabled(self):
+        return self.enabled
+
+    def symbol(self):
+        return self._symbol
+
+    def setSymbol(self, s):             # noqa: F811 - replaces the simple setter above
+        self._symbol = s
+
 
 class QgsVectorTileBasicRenderer(_Stub):
     def __init__(self):
-        self.styles = []
+        self._styles = []
 
     def setStyles(self, styles):
-        self.styles = styles
+        self._styles = styles
+
+    # QGIS exposes the list as a METHOD; the read-back path calls it, so the stub must too or the
+    # round-trip test would pass against an API that does not exist.
+    def styles(self):
+        return self._styles
 
 
 for name in ("QgsCategorizedSymbolRenderer", "QgsGraduatedSymbolRenderer", "QgsRendererCategory",
@@ -208,7 +240,7 @@ def styles_for(row, style, source_layer="geodeploy"):
     ok = apply_to_vector_tiles(layer, row, source_layer, style)
     assert ok, "apply_to_vector_tiles refused the style"
     assert layer.repainted, "the layer was never repainted, so nothing would redraw"
-    return layer.renderer.styles
+    return layer.renderer.styles()
 
 
 # ── graduated ────────────────────────────────────────────────────────────────────────────────
@@ -223,7 +255,7 @@ style = {
 }
 out = styles_for(row, style)
 assert len(out) == 3, out
-assert [s.symbol.color for s in out] == ["#fee5d9", "#fb6a4a", "#a50f15"]
+assert [s.symbol().color().name() for s in out] == ["#fee5d9", "#fb6a4a", "#a50f15"]
 assert all(s.geometry_type == QgsWkbTypes.PolygonGeometry for s in out)
 assert all(s.source_layer == "geodeploy" and s.enabled for s in out)
 # An open LOWER edge must not become `>= None` — that class has to keep drawing everything below it.
@@ -232,7 +264,7 @@ assert out[1].filter == '"pop" >= 100 AND "pop" < 1000', out[1].filter
 # The TOP break is inclusive, or the single largest value in the layer matches nothing and vanishes.
 assert out[2].filter == '"pop" >= 1000 AND "pop" <= 9000', out[2].filter
 # The outline travelled through the shared symbol builder, not a tile-only copy of it.
-assert out[0].symbol.symbolLayer(0).stroke.name() == "#333333"
+assert out[0].symbol().symbolLayer(0).stroke.name() == "#333333"
 print("graduated      -> 3 filtered styles, open low edge and inclusive top break")
 
 # ── categorized ──────────────────────────────────────────────────────────────────────────────
@@ -248,14 +280,14 @@ style = {
 }
 out = styles_for(row, style)
 # "Other" first so the named categories draw ON TOP of it, matching the map's fallback colour.
-assert out[0].name == "other" and out[0].filter == "" and out[0].symbol.color == "#cccccc"
+assert out[0].name == "other" and out[0].filter == "" and out[0].symbol().color().name() == "#cccccc"
 assert [s.filter for s in out[1:]] == ['"surface" = \'paved\'',
                                        '"surface" = \'unpaved\'',
                                        '"surface" = \'O\'\'Hare\''], [s.filter for s in out[1:]]
 assert all(s.geometry_type == QgsWkbTypes.LineGeometry for s in out)
 # A quote in a value must be ESCAPED, not concatenated into a broken expression.
 assert out[3].filter.count("''") == 1
-assert out[1].symbol.symbolLayer(0).width == 2 * 0.75, "line width lost the CSS-px→pt conversion"
+assert out[1].symbol().symbolLayer(0).width() == 2 * 0.75, "line width lost the CSS-px→pt conversion"
 print("categorized    -> other + 3 filtered styles, quote escaped, width converted")
 
 # Numeric category values must NOT be quoted, or the filter never matches an integer column.
@@ -272,35 +304,35 @@ print("numeric values -> unquoted literals")
 # is dark grey, which at that size covers the fill entirely and turns every point black whatever
 # colour was asked for. Both symptoms, one screenshot, one cause.
 out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6"})
-assert out[0].symbol.color == "#3b82f6"
-assert out[0].symbol.size == 5 * 2 * 0.75, ("a point with no radius must take the PORTAL's default "
+assert out[0].symbol().color().name() == "#3b82f6"
+assert out[0].symbol().size() == 5 * 2 * 0.75, ("a point with no radius must take the PORTAL's default "
                                             "(circle-radius 5), not QGIS's number under our unit")
-stroke = out[0].symbol.symbolLayer(0)
+stroke = out[0].symbol().symbolLayer(0)
 assert stroke.stroke.name() == "#ffffff", "the map draws circle-stroke-color #ffffff"
 assert stroke.stroke_width == 1 * 0.75, "…at circle-stroke-width 1"
 print("styleless point -> portal defaults: radius 5, white 1px stroke")
 
 # An explicit outline still wins over the default.
 out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6", "outline_color": "#000000"})
-assert out[0].symbol.symbolLayer(0).stroke.name() == "#000000"
+assert out[0].symbol().symbolLayer(0).stroke.name() == "#000000"
 # …and "none" still means none.
 out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6", "outline_color": "none"})
-assert out[0].symbol.symbolLayer(0).pen == 0, "outline_color 'none' must set NoPen"
+assert out[0].symbol().symbolLayer(0).pen == 0, "outline_color 'none' must set NoPen"
 print("point outline   -> explicit colour wins, 'none' means none")
 
 
 # ── single symbol, and the degrade paths ─────────────────────────────────────────────────────
 out = styles_for({"geometry_type": "Point"}, {"color": "#3388ff", "radius": 6, "marker": "square"})
 assert len(out) == 1 and out[0].filter == ""
-assert out[0].symbol.color == "#3388ff"
-assert out[0].symbol.size == 6 * 2 * 0.75, "point radius lost the diameter/points conversion"
+assert out[0].symbol().color().name() == "#3388ff"
+assert out[0].symbol().size() == 6 * 2 * 0.75, "point radius lost the diameter/points conversion"
 print("single symbol  -> one unfiltered style, radius converted")
 
 # A graduated style with NO classes must still draw — in its base colour, not refuse.
 out = styles_for({"geometry_type": "Polygon"},
                  {"color_mode": "graduated", "color_field": "pop", "classes": [],
                   "color": "#654321"})
-assert len(out) == 1 and out[0].symbol.color == "#654321"
+assert len(out) == 1 and out[0].symbol().color().name() == "#654321"
 print("no classes     -> falls back to one symbol")
 
 # ── the geometry type is a BINDING, not a hint ────────────────────────────────────────────────
@@ -340,7 +372,113 @@ assert apply_to_vector_tiles(
             "default_style": {"style": {"color_mode": "categorized", "color_field": "k",
                                         "categories": [{"value": "a", "color": "#abcdef"}]}}},
     "geodeploy")
-assert any(s.filter == '"k" = \'a\'' for s in layer.renderer.styles)
+assert any(s.filter == '"k" = \'a\'' for s in layer.renderer.styles())
 print("row default    -> read from default_style when no style is passed")
 
 print("\nALL VECTOR-TILE SYMBOLOGY CASES PASS")
+
+
+# ── ROUND TRIP: apply a style to tiles, read it back, and get the same style ──────────────────
+# The bug this catches is the one that made "restyle a portal group and push it" do nothing at all:
+# `from_qgis` reads FEATURE renderers, and a portal's vector layers are TILE layers, so it returned
+# {} and the push sent no style. Reading the tile renderer back is the fix; a round trip is the only
+# test that proves the two directions actually agree, and it immediately caught two conversions that
+# did not invert (a radius of 5 came back 3.75, a line width of 2 came back 6).
+style_from_vector_tiles = ns["style_from_vector_tiles"]
+
+
+class Renderer:
+    def __init__(self, styles):
+        self._s = styles
+
+    def styles(self):
+        return self._s
+
+
+class TileLayerWith:
+    def __init__(self, styles):
+        self._r = Renderer(styles)
+
+    def renderer(self):
+        return self._r
+
+
+def round_trip(row, style):
+    applied = styles_for(row, style)
+    return style_from_vector_tiles(TileLayerWith(applied))
+
+
+out = round_trip({"geometry_type": "point"}, {"color": "#3388ff", "radius": 6, "marker": "square"})
+assert out["color_mode"] == "single" and out["color"] == "#3388ff", out
+assert out["radius"] == 6, ("a radius must survive the trip, not shrink by CSS_PX_TO_POINTS", out)
+print("round trip point     ->", json.dumps(out))
+
+out = round_trip({"geometry_type": "LineString"},
+                 {"color": "#d1ba23", "line_width": 2, "lineType": "dashed"})
+assert out["color"] == "#d1ba23" and out["line_width"] == 2, out
+assert out["lineType"] == "dashed", out
+print("round trip line      ->", json.dumps(out))
+
+out = round_trip({"geometry_type": "MultiPolygon"},
+                 {"color_mode": "graduated", "color_field": "pop",
+                  "classes": [{"min": None, "max": 100, "color": "#fee5d9"},
+                              {"min": 100, "max": 1000, "color": "#fb6a4a"},
+                              {"min": 1000, "max": 9000, "color": "#a50f15"}]})
+assert out["color_mode"] == "graduated" and out["color_field"] == "pop", out
+assert [c["color"] for c in out["classes"]] == ["#fee5d9", "#fb6a4a", "#a50f15"], out
+assert out["classes"][0]["min"] is None, "an open lower edge must come back open"
+assert out["classes"][2]["max"] == 9000, out
+print("round trip graduated ->", len(out["classes"]), "classes, edges intact")
+
+out = round_trip({"geometry_type": "LineString"},
+                 {"color_mode": "categorized", "color_field": "surface",
+                  "categories": [{"value": "paved", "color": "#1f78b4"},
+                                 {"value": "O'Hare", "color": "#33a02c"}],
+                  "other_color": "#cccccc"})
+assert out["color_mode"] == "categorized" and out["color_field"] == "surface", out
+assert [c["value"] for c in out["categories"]] == ["paved", "O'Hare"], out
+assert out["other_color"] == "#cccccc", out
+print("round trip category  -> values and the escaped quote survive")
+
+out = round_trip({"geometry_type": "Point"},
+                 {"color_mode": "categorized", "color_field": "zone",
+                  "categories": [{"value": 1, "color": "#f00000"},
+                                 {"value": 2, "color": "#00f000"}]})
+assert [c["value"] for c in out["categories"]] == [1, 2], ("numbers must not come back as text", out)
+print("round trip numeric   -> stays numeric")
+
+# A filter nobody here wrote must NOT be half-parsed into a wrong classification.
+hand = styles_for({"geometry_type": "Polygon"}, {"color": "#123456"})
+hand[0].setFilterExpression('"a" > 1 OR "b" < 2')
+out = style_from_vector_tiles(TileLayerWith(hand))
+assert out["color_mode"] == "single" and out["color"] == "#123456", out
+print("foreign filter       -> degrades to one symbol, not a wrong class")
+
+# Two DIFFERENT fields is not a classification this wrote either. Needs two real categories: with
+# only one, repointing it is indistinguishable from a legitimate classification on that other field,
+# which is why the first version of this case failed — the premise was wrong, not the reader.
+two = styles_for({"geometry_type": "Polygon"},
+                 {"color_mode": "categorized", "color_field": "k",
+                  "categories": [{"value": "a", "color": "#111111"},
+                                 {"value": "b", "color": "#222222"}]})
+assert len(two) == 3, ("other + two categories", [e.name for e in two])
+two[-1].setFilterExpression('"other" = \'z\'')
+out = style_from_vector_tiles(TileLayerWith(two))
+assert out["color_mode"] == "single", out
+print("two fields           -> degrades to one symbol")
+
+# A classification on ONE field with several categories is of course kept.
+ok = styles_for({"geometry_type": "Polygon"},
+                {"color_mode": "categorized", "color_field": "k",
+                 "categories": [{"value": "a", "color": "#111111"},
+                                {"value": "b", "color": "#222222"}]})
+out = style_from_vector_tiles(TileLayerWith(ok))
+assert out["color_mode"] == "categorized" and len(out["categories"]) == 2, out
+print("two categories       -> kept")
+
+# Nothing to read is {} — "use the default" — never a half-built style.
+assert style_from_vector_tiles(TileLayerWith([])) == {}
+assert style_from_vector_tiles(None) == {}
+print("nothing to read      -> {}")
+
+print("\nALL ROUND-TRIP CASES PASS")

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -299,6 +299,13 @@ export const listBasemaps = () => api.get('/basemaps')
 export const getServiceHealth = () => api.get('/admin/health')
 export const getStorageStats = () => api.get('/admin/storage-stats')
 
+// ONE public layer, for the public layer page (`/layers/:kind/:id`). Goes through `api` so the
+// baseURL and the auth header are the same as everywhere else — a signed-in visitor simply gets the
+// same answer, and a signed-out one gets it too, because the endpoint itself is anonymous. Only
+// layers that are shared or drawn by a published portal resolve; anything else 404s, and the page
+// turns that into an invitation to sign in.
+export const getPublicLayer = (kind, ref) => api.get(`/public/layers/${kind}/${ref}`)
+
 // Whether this instance publishes GET /api/public — the anonymous list of its public portals and
 // public layers that a browse client (or the QGIS plugin) reads. Discoverability, not access:
 // everything it lists is already reachable by link.

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -10,6 +10,14 @@ const routes = [
   { path: '/reset-password', component: () => import('@/views/ResetPassword.vue'), meta: { public: true } },
   { path: '/portal-gate', component: () => import('@/views/PortalGate.vue'), meta: { public: true } },
   { path: '/sso-callback', component: () => import('@/views/SsoCallback.vue'), meta: { public: true } },
+  // A PUBLIC layer page. Outside the app shell on purpose: it is a shareable address for one
+  // dataset, reachable by anyone the layer is shared with, and it must not depend on a session.
+  // `/data/:kind/:id` inside the app is the same component and stays the signed-in route; this one
+  // loads the layer from `/api/public/layers/...`, which serves only what is actually public — so a
+  // private layer 404s here and the page sends the visitor to sign in, where they may well be able
+  // to see it.
+  { path: '/layers/:kind(vector|raster|external)/:id',
+    component: () => import('@/views/LayerPage.vue'), meta: { public: true } },
   {
     path: '/',
     component: () => import('@/views/Layout.vue'),

--- a/ui/src/stores/auth.js
+++ b/ui/src/stores/auth.js
@@ -11,6 +11,9 @@ export const useAuthStore = defineStore('auth', () => {
   const isAdmin = computed(() => ['admin', 'owner'].includes(role.value))
   const isOwner = computed(() => role.value === 'owner')
   const canEdit = computed(() => ['editor', 'admin', 'owner'].includes(role.value))
+  // Is anybody signed in? Named because `auth.user` reads as "the user" even when it is null, and a
+  // page that serves signed-out visitors has to ask the question explicitly.
+  const isAuthenticated = computed(() => !!user.value)
 
   async function fetchMe() {
     const { data } = await getMe()
@@ -38,5 +41,6 @@ export const useAuthStore = defineStore('auth', () => {
     if (token) localStorage.setItem('geodeploy_token', token)
   }
 
-  return { user, role, isAdmin, isOwner, canEdit, fetchMe, loginUser, logout, setToken }
+  return { user, role, isAdmin, isOwner, canEdit, isAuthenticated,
+           fetchMe, loginUser, logout, setToken }
 })

--- a/ui/src/views/LayerPage.vue
+++ b/ui/src/views/LayerPage.vue
@@ -21,9 +21,14 @@
     <!-- Header ------------------------------------------------------------------------------ -->
     <div v-if="layer" class="min-w-0">
       <div>
-        <RouterLink to="/data"
+        <RouterLink v-if="auth.isAuthenticated" to="/data"
           class="text-xs text-muted-foreground/70 hover:text-foreground inline-flex items-center gap-1">
           <span aria-hidden="true">←</span> My Data
+        </RouterLink>
+        <!-- Signed out, "My Data" is not somewhere this visitor can go. -->
+        <RouterLink v-else to="/login"
+          class="text-xs text-muted-foreground/70 hover:text-foreground inline-flex items-center gap-1">
+          Sign in <span aria-hidden="true">→</span>
         </RouterLink>
         <div class="flex items-center gap-2 mt-1">
           <LegendSwatch :geom="swatchGeom" :color="swatch" :marker="markerShape"
@@ -187,7 +192,8 @@
 
     <!-- Not found / still loading. Below the map, which stays mounted. -->
     <div v-if="!layer" class="card p-8 text-center text-muted-foreground">
-      <p v-if="dataStore.loading" class="text-sm">Loading…</p>
+      <p v-if="publicError" class="text-sm">{{ publicError }}</p>
+      <p v-else-if="dataStore.loading" class="text-sm">Loading…</p>
       <template v-else>
         <p class="text-sm">That layer is not here any more.</p>
         <RouterLink to="/data" class="btn-secondary mt-4 inline-flex">Back to My Data</RouterLink>
@@ -298,6 +304,7 @@ import { buildMapStyle, lonLatBbox } from '@/lib/mapStyle'
 import { registerMarkerImages, setMarkerSpecs } from '@/lib/markerImage'
 import { DEFAULT_BASEMAP } from '@/lib/basemaps'
 import { legendEntries, representativeColor } from '@/lib/symbology'
+import { getPublicLayer } from '@/api'
 import StyleModal from '@/components/data/StyleModal.vue'
 import SharingModal from '@/components/data/SharingModal.vue'
 import ShareLinksModal from '@/components/data/ShareLinksModal.vue'
@@ -333,6 +340,12 @@ const isRaster = computed(() => kind.value === 'raster'
   || (isExternal.value && layer.value?.kind === 'raster'))
 const isVector = computed(() => !isRaster.value && !isExternal.value)
 
+// Set only on the PUBLIC route, when the layer could not come from the store — see `onMounted`.
+const publicLayer = ref(null)
+const publicError = ref('')
+// `/layers/...` is the shareable public address; `/data/...` is the same page inside the app.
+const isPublicRoute = computed(() => route.path.startsWith('/layers/'))
+
 const layer = computed(() => {
   // The URL carries the UID: integer ids are per-kind sequences that renumber on a restore, so a
   // bookmarked /data/vector/12 could come back pointing at a different layer. An integer is still
@@ -340,7 +353,8 @@ const layer = computed(() => {
   const ref_ = String(route.params.id || '')
   const list = kind.value === 'external' ? dataStore.externalSources
     : (kind.value === 'raster' ? dataStore.rasterLayers : dataStore.vectorLayers)
-  return list.find(l => l.uid === ref_) || list.find(l => String(l.id) === ref_) || null
+  return list.find(l => l.uid === ref_) || list.find(l => String(l.id) === ref_)
+    || publicLayer.value || null
 })
 const ready = computed(() => isExternal.value || layer.value?.status === 'ready')
 
@@ -547,7 +561,36 @@ function renderMap() {
 }
 
 onMounted(async () => {
-  if (!dataStore.vectorLayers.length && !dataStore.rasterLayers.length) await dataStore.refresh()
+  // The router skips its auth check on a `public: true` route, so nobody has asked who this is yet.
+  // Ask now, and ignore a failure: a signed-in visitor following a public link should still get the
+  // full page with its edit actions, and a signed-out one is exactly who this route is for.
+  if (isPublicRoute.value && !auth.user) {
+    try { await auth.fetchMe() } catch { /* signed out, which is fine here */ }
+  }
+  // SIGNED IN: the store is the source, and it carries everything the actions need.
+  if (auth.isAuthenticated && !isPublicRoute.value) {
+    if (!dataStore.vectorLayers.length && !dataStore.rasterLayers.length) await dataStore.refresh()
+    return
+  }
+  // A signed-in visitor arriving by the PUBLIC link still gets the full page — try the store first
+  // so the edit actions light up, and fall back to the public endpoint if it has nothing.
+  if (auth.isAuthenticated) {
+    try {
+      if (!dataStore.vectorLayers.length && !dataStore.rasterLayers.length) await dataStore.refresh()
+    } catch { /* not fatal here: the public endpoint below serves anyone */ }
+    if (layer.value) return
+  }
+  try {
+    const { data } = await getPublicLayer(kind.value === 'raster' ? 'raster' : 'vector',
+                                          String(route.params.id || ''))
+    publicLayer.value = data
+  } catch (e) {
+    // 404 means "not public", which for a signed-out visitor is usually "sign in and look again"
+    // rather than "does not exist" — so say that instead of showing an empty page.
+    publicError.value = e.response?.status === 404
+      ? 'This layer is not shared publicly. Sign in to see whether you have access to it.'
+      : (e.response?.data?.detail || 'Could not load this layer.')
+  }
 })
 // The map is created on mount by the composable, so wait for it AND for the layer to arrive.
 watch([loaded, layer, styleForMap], () => renderMap(), { deep: true, immediate: true })

--- a/ui/src/views/README.md
+++ b/ui/src/views/README.md
@@ -63,6 +63,15 @@ Page-level route components. All except SetupWizard/Login render inside `Layout.
 - Raster layer `bbox` from the API is in source CRS (not lon/lat) — using it directly for `fitToBbox` can throw "Invalid LngLat" (see tasks/raster notes). Prefer zooming via vector bounds or TiTiler TileJSON.
 
 ## Last updated
+2026-08-17b (**`LayerPage.vue` now serves a PUBLIC route as well.** New `/layers/:kind/:id` sits
+OUTSIDE the app shell with `meta: { public: true }` — a shareable address for one dataset that must
+not depend on a session — while `/data/:kind/:id` inside the app is unchanged. On the public route
+the page resolves the session anyway (the router skips its auth check there, so nobody has asked yet)
+so a signed-in visitor following a public link still gets the edit actions; otherwise it loads from
+`GET /api/public/layers/{kind}/{ref}`. A 404 there means "not shared publicly", which the page turns
+into an invitation to sign in rather than an empty screen. The back link becomes "Sign in" when there
+is no session, since My Data is not somewhere that visitor can go. New `auth.isAuthenticated` — the
+store exposed only `user`, and code was already reading a property that did not exist.)
 2026-08-17 (`LayerPage.vue` + `components/data/VectorRow.vue` share the tiling control's icon and
 wording: new `TilesIcon` in `views/icons.js` (the four-square grid My Data always used — the page had
 reached for `LayersIcon`, so one action wore two symbols) and new **`lib/tiling.js`** holding


### PR DESCRIPTION
## The two blank rasters — never the plugin

TiTiler needs a `rescale` for anything not already 0–255; without one a float DEM or index raster comes back transparent. Measured on the live portal:

| layer | portal params | tile at z12, centre of its own bounds |
|---|---|---|
| `RVI_2023_2024` | `bidx=1` | **206 bytes** — blank |
| `FINAL_MICROTOPO3-SLU202237` | `bidx=1` | **514 bytes** — blank |
| `Degfert_DEM` | `bidx=1&algorithm=hillshade&expression=b1*5.0` | 27 kB |

Blank in the browser and blank in QGIS — confirmed from both surfaces. The same layers opened *standalone* looked right, because standalone they use their default style, which has a stretch.

`portal_generator` now falls back to the layer's stretch when the portal states none. It keeps whatever the portal does state, and an 8-bit RGB image has none in either place and is unaffected. **Takes effect on republish** — `style.json` is baked, so recreating a portal by hand is not necessary.

Checked against every live portal raster: this rescues exactly the two reported, leaves the hillshade (correctly stretch-free) and the external basemap alone.

## Open in GeoDeploy

The dock shows a layer's geometry and symbology. The instance's page shows what it cannot — metadata, field list, extent, sharing state, and every ready-made link for other tools. Rather than reproduce that in a dock, point at it.

The address is **public**, because the requirement was that it work for anyone on a public layer:

- **api** — `GET /api/public/layers/{kind}/{ref}` returns one layer in the shape the page reads. Same readability rule as the display endpoints (shared, **or** drawn by a published portal), and behind the same `_require_enabled` switch as the index — otherwise turning the anonymous index off would only hide the *list* while leaving every layer individually addressable.
- **ui** — `/layers/:kind/:id` renders `LayerPage` outside the app shell, public. `/data/:kind/:id` inside the app is unchanged. The public route resolves the session anyway (the router skips its auth check there), so a signed-in visitor following a public link keeps the edit actions; a 404 becomes *"this layer is not shared publicly — sign in to see whether you have access"* rather than an empty page.
- **qgis** — the button; for a portal it opens the portal.

## Also

`auth.isAuthenticated` is new. The store exposed only `user`, and code was already reading a property that did not exist — silently falsy, so it would have "worked" while always taking the signed-out branch.

10 new API tests pin the endpoint's exposure rule, including the one the raster routes previously got wrong: a layer drawn by a published portal resolves even when it is not itself shared.

Plugin 0.1.7.
