### PR TITLE
Make the public layer page usable, and give the portal button its own job

### DIFF
--- a/api/geodeploy/routers/public.py
+++ b/api/geodeploy/routers/public.py
@@ -104,10 +104,24 @@ async def public_layer(kind: str, layer_ref: str, request: Request,
         if not await _describable(row, db):
             raise HTTPException(404, "No public layer at this address.")
         out = _raster_out(row, base)
+        ds = _style(row) or {}
         out.update({"uid": row.uid, "status": row.status, "band_count": row.band_count,
-                    "default_style": _style(row), "file_size": row.file_size,
+                    "default_style": ds, "file_size": row.file_size,
                     "width": getattr(row, "width", None), "height": getattr(row, "height", None),
                     "nodata_value": getattr(row, "nodata_value", None)})
+        # THE MAP NEEDS THIS. `lib/mapStyle.js` skips any raster without a `tile_url` — so without
+        # it the public page rendered a raster's metadata beside an empty map. Built exactly as the
+        # authenticated row builds it (`raster._raster_out` in routers/data/raster.py), from the
+        # layer's default style, so the public page draws what My Data draws.
+        out["catalog"] = base + "/api/stac"
+        from ...services.titiler import get_tile_url as raster_tile_url
+        if row.status == "ready" and row.s3_key:
+            out["tile_url"] = raster_tile_url(
+                row.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),
+                algorithm=ds.get("algorithm"), zfactor=ds.get("zfactor"), bidx=ds.get("bidx"),
+                color_classes=ds.get("color_classes"),
+                colormap_reverse=bool(ds.get("colormap_reverse")),
+                band_count=row.band_count)
         return out
     if kind == "vector":
         from .data.vector import _publicly_readable
@@ -122,6 +136,7 @@ async def public_layer(kind: str, layer_ref: str, request: Request,
                 columns = json.loads(row.columns)
             except (ValueError, TypeError):
                 columns = []
+        out["catalog"] = base + "/api/stac"
         out.update({"uid": row.uid, "status": row.status, "columns": columns,
                     "storage_backend": getattr(row, "storage_backend", "postgis"),
                     "tile_status": getattr(row, "tile_status", None),

--- a/api/geodeploy/routers/public.py
+++ b/api/geodeploy/routers/public.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..database import get_db
 from ..models import Portal, RasterLayer, SetupConfig, VectorLayer
 from ..services import share_links
+from ..services.titiler import get_tile_url as raster_tile_url
 from .common import by_ref
 
 router = APIRouter(prefix="/public", tags=["public"])
@@ -114,7 +115,6 @@ async def public_layer(kind: str, layer_ref: str, request: Request,
         # authenticated row builds it (`raster._raster_out` in routers/data/raster.py), from the
         # layer's default style, so the public page draws what My Data draws.
         out["catalog"] = base + "/api/stac"
-        from ...services.titiler import get_tile_url as raster_tile_url
         if row.status == "ready" and row.s3_key:
             out["tile_url"] = raster_tile_url(
                 row.s3_key, colormap=ds.get("colormap"), rescale=ds.get("rescale"),

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -237,11 +237,20 @@ class TestOnePublicLayer:
         assert body["crs"] == "EPSG:4326"
         assert "columns" in body and "default_style" in body
         assert body["links"], "the share links are the point of the page"
+        # The page shows the links panel WITHOUT calling the authed /links route, so the list and the
+        # catalog address both have to be here — otherwise a signed-out visitor gets a 401 in a panel
+        # whose contents were already available.
+        assert body["catalog"].endswith("/api/stac")
 
     async def test_a_shared_raster_is_served(self, client, seeded):
         body = (await client.get("/api/public/layers/raster/eeeeeeeeeeee")).json()
         assert body["name"] == "Elevation" and body["band_count"] == 1
         assert body["uid"] == "eeeeeeeeeeee" and body["status"] == "ready"
+        # WITHOUT THIS THE MAP IS EMPTY: `lib/mapStyle.js` skips a raster that has no `tile_url`, so
+        # the page would have shown the metadata beside a blank canvas.
+        assert "/raster/cog/tiles/" in body["tile_url"], body.get("tile_url")
+        assert "dem.tif" in body["tile_url"]
+        assert body["catalog"].endswith("/api/stac")
 
     async def test_a_private_layer_is_404_not_a_hint(self, client, seeded):
         # 'Internal' is organization-visibility. A signed-out visitor must not learn it exists, and

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,24 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17i (**the public layer page actually works now, and the portal button does something
+different from the button next to it.**
+*Page:* the public row was missing two things the page needs — a raster's `tile_url` (`lib/mapStyle.js`
+skips a raster without one, so the page showed metadata beside an empty map) and the `links`/`catalog`
+the Share-links panel shows. `ShareLinksModal` now uses `props.layer.links` when the row carries them
+instead of calling the `data:read`-scoped `/links` route, which answered 401 for a signed-out visitor
+looking at links that were already loaded. `mapStyle` no longer demands `pmtiles_key` to draw a tiled
+GeoParquet layer: the tiling task sets it with `tile_status`, the URL is built from the layer id, and
+a public row deliberately carries no storage keys. Every write action on the page is behind
+`auth.canEdit`, so signed out there is nothing to press.
+*Portal button:* `open_in_browser` opens `/portals/<id>/edit` for a portal — "Add to map" already
+offers the published page, so two buttons doing that was one too many. It needs a session and the
+numeric id, and an anonymous listing has neither, so it is DISABLED with the reason rather than
+falling back to view mode. New `_apply_auth_ui` does the same for push-group / upload / save-styling:
+disabled until a token is connected, each keeping its own explanation under the "needs a token" note.
+*Test doubles:* `scripts/smoke.py`'s `_Any` returned itself from every method, so `toolTip() + "…"`
+and `selectedItems()[0]` failed where real Qt would not. It now returns the right TYPE for named
+string and list getters — the stub's job is to be faithful, not merely permissive.)
 2026-08-17h (**pushing a restyle from a portal group sent nothing, and for rasters it DELETED the
 portal's styling.** Two halves of one mistake: a portal's layers open as the surfaces that draw like
 the portal, and neither is what QGIS can read a style back out of.

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.8
+version=0.1.9
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,12 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.8 - Restyling a layer inside a portal group and pushing it back now works. A portal's
+changelog=0.1.9 - "Open in GeoDeploy" now opens a PORTAL in the editor rather than repeating what
+    "Open portal in browser" already does, and the actions that need a token (push a group, upload,
+    save styling, edit a portal) are disabled with the reason in their tooltip until you connect with
+    one. A public layer's page opens for anyone, with the map, the extent and the share links, and
+    without any of the buttons that would need an account.
+    0.1.8 - Restyling a layer inside a portal group and pushing it back now works. A portal's
     layers open as TILES, and QGIS renders those through a different renderer than a normal vector
     layer - so the styling was read from the wrong place and nothing was sent. It is now read back
     properly, classes and all. A raster opened from portal tiles has no bands to restyle ("Singleband

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -197,6 +197,12 @@ class GeoDeployDock(QDockWidget):
         self.save_style_btn.clicked.connect(self.save_style)
         outer.addWidget(self.save_style_btn)
 
+        # The actions that genuinely need a credential, each with the explanation it already carries.
+        self._write_actions = [(b, b.toolTip()) for b in
+                               (self.push_group_btn, self.upload_btn, self.save_style_btn)]
+        # The dock opens NOT connected, so they start unavailable and say why.
+        self._apply_auth_ui()
+
         self.push_style = QCheckBox("Send its styling too")
         self.push_style.setChecked(True)
         self.push_style.setToolTip(
@@ -230,6 +236,26 @@ class GeoDeployDock(QDockWidget):
         # fine for the one message that explains why the thing you asked for did not happen.
         duration = 0 if level in (Qgis.Warning, Qgis.Critical) else 6
         bar_widget.pushMessage(PLUGIN_NAME, text, level=level, duration=duration)
+
+    def _apply_auth_ui(self):
+        """Enable the write actions only when there is a token to make them work.
+
+        They used to be permanently enabled and to answer a click with "this needs a token", which
+        is a worse way to say the same thing: the dock's whole promise is that anonymous browsing is
+        a first-class mode, so the parts that genuinely need a credential should look unavailable
+        rather than broken. The tooltip carries the reason, since a disabled button with no
+        explanation is its own kind of dead end.
+        """
+        signed_in = bool(self.instance and self.instance.token)
+        for button, own in self._write_actions:
+            button.setEnabled(signed_in)
+            # `own` is the button's real explanation, captured when the dock was built — kept in a
+            # plain list rather than a Qt property, which hands back a QVariant and would need
+            # coercing at every use.
+            button.setToolTip(own if signed_in else
+                              "Needs a token with write access — paste one above and connect "
+                              "again.\n\n" + own)
+        self._on_selection_changed()
 
     def _install_auth(self):
         """Attach the token to QGIS's OWN requests for this instance's host.
@@ -354,6 +380,7 @@ class GeoDeployDock(QDockWidget):
         # Before any layer is added: an OAPIF layer is fetched by QGIS itself, so the token has to
         # be on QGIS's requests, not only on ours.
         self._install_auth()
+        self._apply_auth_ui()
         who = f"signed in as {info.get('user')}" if info.get("authenticated") else "not signed in"
         extra = ("" if info.get("index_available")
                  else " — this instance does not publish an index, so only what your token can see "
@@ -447,9 +474,24 @@ class GeoDeployDock(QDockWidget):
         """A portal cannot be added to the map, so the button says what it WILL do instead."""
         row = self._selected_row() or {}
         is_portal = bool(row.get("_portal"))
+        signed_in = bool(self.instance and self.instance.token)
         self.add_btn.setText("Open portal in browser" if is_portal else "Add to map")
-        self.open_web_btn.setText("Open portal in GeoDeploy" if is_portal
-                                  else "Open layer in GeoDeploy")
+        if is_portal:
+            self.open_web_btn.setText("Edit portal in GeoDeploy")
+            # Editing is an authenticated action, so the button reflects that rather than offering
+            # something it will refuse.
+            can_edit = signed_in and row.get("id") is not None
+            self.open_web_btn.setEnabled(can_edit)
+            self.open_web_btn.setToolTip(
+                "Open this portal in GeoDeploy's editor." if can_edit
+                else "Editing a portal needs a token with write access — use “Open portal in "
+                     "browser” to see the published page.")
+        else:
+            self.open_web_btn.setText("Open layer in GeoDeploy")
+            self.open_web_btn.setEnabled(True)
+            self.open_web_btn.setToolTip(
+                "Open the layer's page on the instance — the map, the metadata, the fields and "
+                "every share link. A public layer opens for anyone.")
 
     def add_selected(self):
         row = self._selected_row()
@@ -1176,7 +1218,17 @@ class GeoDeployDock(QDockWidget):
             self._say("Pick a layer or a portal first.", Qgis.Warning)
             return
         if row.get("_portal"):
-            self._open_portal(row)
+            # A PORTAL OPENS IN THE EDITOR, not in view mode — "Add to map" already offers the
+            # published page, and two buttons doing the same thing is one button too many. Editing
+            # needs a session and the portal's numeric id, and an anonymous listing has neither, so
+            # the button is disabled in that case rather than opening something else instead.
+            base = (row.get("_base") or (self.instance.url if self.instance else "")).rstrip("/")
+            portal_id = row.get("id")
+            if not (self.instance and self.instance.token) or portal_id is None:
+                self._say("Editing a portal needs a token with write access. Without one, use "
+                          "“Open portal in browser” to see the published page.", Qgis.Warning)
+                return
+            self._open_url("{0}/portals/{1}/edit".format(base, portal_id))
             return
         base = (row.get("_base") or (self.instance.url if self.instance else "")).rstrip("/")
         ref = row.get("uid") or row.get("id")

--- a/integrations/qgis-plugin/scripts/smoke.py
+++ b/integrations/qgis-plugin/scripts/smoke.py
@@ -40,6 +40,18 @@ def _stub_qgis():
         def __getattr__(cls, name):
             return _Any()
 
+    #: Qt getters that return a STRING. `_Any` accepting everything is what makes this stub small,
+    #: but a method whose result is concatenated has to hand back the right TYPE or the stub fails
+    #: where real Qt would not — which it did, on `button.toolTip() + "…"`. Named rather than
+    #: guessed, so the stub stays honest about what it is pretending to be.
+    _STRING_GETTERS = {"toolTip", "text", "name", "windowTitle", "styleSheet", "placeholderText",
+                       "currentText", "objectName", "whatsThis", "statusTip"}
+    #: …and the ones that return a LIST. Same reasoning: `selectedItems()` is empty on a fresh dock,
+    #: and code that says `items[0] if items else None` is correct against Qt and crashed against a
+    #: stub that answered with a truthy object.
+    _LIST_GETTERS = {"selectedItems", "selectedLayers", "selectedNodes", "children", "styles",
+                     "symbolLayers", "ranges", "categories", "classes"}
+
     class _Any(metaclass=_AnyMeta):
         """Accepts anything: construction, attributes, calls, and signal connections."""
 
@@ -47,6 +59,10 @@ def _stub_qgis():
             pass
 
         def __getattr__(self, name):
+            if name in _STRING_GETTERS:
+                return lambda *a, **k: ""
+            if name in _LIST_GETTERS:
+                return lambda *a, **k: []
             return _Any()
 
         def __call__(self, *a, **k):

--- a/ui/src/components/data/ShareLinksModal.vue
+++ b/ui/src/components/data/ShareLinksModal.vue
@@ -88,6 +88,19 @@ const error = ref('')
 const copied = ref('')
 
 onMounted(async () => {
+  // ALREADY HAVE THEM? Use them. The public layer page loads a layer from `/api/public/layers/...`,
+  // which carries the same `links` list — built by the same `services/share_links.py`. The fetch
+  // below needs `data:read`, so on that page it answered 401 and a signed-out visitor got "Could
+  // not load the links" for a layer whose links were already on screen's worth of data away.
+  if ((props.layer.links || []).length) {
+    links.value = props.layer.links
+    // A layer reachable through the public endpoint is public by definition, so the panel does not
+    // prompt to share it first.
+    isPublic.value = true
+    loaded.value = true
+    loading.value = false
+    return
+  }
   try {
     const fn = props.layerType === 'raster' ? getRasterLinks : getVectorLinks
     const { data } = await fn(props.layer.id)

--- a/ui/src/lib/mapStyle.js
+++ b/ui/src/lib/mapStyle.js
@@ -72,7 +72,13 @@ export function buildMapStyle({ configs = [], layers = [], rasters = [], sources
         // (rendered outside this MapLibre style — see refreshDeck), so EXCLUDE the layer here and
         // just keep its bbox for zoom-to-all. FALLBACK: a layer explicitly tiled (ready PMTiles)
         // renders via the pmtiles:// vector source instead.
-        if (!(layer.tile_status === 'ready' && layer.pmtiles_key)) { expandBounds(layer.bbox); continue }
+        // `tile_status === 'ready'` is the whole test. The tiling task sets it together with
+        // `pmtiles_key`, so also requiring the key added nothing — and it meant the PUBLIC layer
+        // page could not draw a tiled layer at all, because a public row deliberately carries no
+        // storage keys: the URL below is built from the layer's id, and the endpoint resolves the
+        // key server-side. Asking for a key we do not need in order to build a URL that does not
+        // use it is how a public page ended up with an empty map.
+        if (layer.tile_status !== 'ready') { expandBounds(layer.bbox); continue }
         style.sources[srcId] = { type: 'vector', url: `pmtiles://${location.origin}/api/data/vector/${layer.id}/pmtiles` }
         sourceLayer = 'geodeploy'
       } else {


### PR DESCRIPTION
The public route and endpoint landed in #58. Checking them properly — rather than assuming — found the page would have been half-broken for a signed-out visitor.

## What was wrong

**A raster's map was empty.** `lib/mapStyle.js` skips any raster without `tile_url`, and the public row didn't carry one. It's now built exactly as the authenticated row builds it, from the layer's default style, so the public page draws what My Data draws.

**The Share links panel 401'd.** It called the `data:read`-scoped `/links` route even though the public row already carries the same list, built by the same `share_links.py`. It now uses what it was given. `catalog` is included too, so the panel is complete.

**A tiled GeoParquet layer wouldn't draw.** `mapStyle` also required `pmtiles_key`, and a public row deliberately carries no storage keys. The key was never needed: the tiling task sets it together with `tile_status`, and the pmtiles URL is built from the layer id. Asking for a key in order to build a URL that doesn't use it is how the map ended up empty.

Every action on the page is already behind `auth.canEdit`, so signed out you get the map, the extent, the metadata, the fields and the share links — and none of the buttons. That is exactly the split requested.

## The portal button now has its own job

"Open in GeoDeploy" opened the published page for a portal — which is what "Open portal in browser" beside it already did. It now opens `/portals/<id>/edit`.

Editing needs a session *and* the portal's numeric id, and an anonymous listing has neither, so the button is **disabled with the reason in its tooltip** rather than quietly falling back to view mode.

New `_apply_auth_ui` extends that to the other credentialed actions — push group, upload, save styling — which were permanently enabled and answered a click with "this needs a token". The dock's promise is that anonymous browsing is first-class, so the parts that genuinely need a credential should *look* unavailable rather than broken.

## The test double was lying

`smoke.py`'s `_Any` returned itself from every method, so `toolTip() + "…"` and `selectedItems()[0] if items else None` both failed where real Qt would not — permissive about existence, wrong about types. It now returns the right type for named string and list getters, which is why it caught both of these before you did.

Plugin 0.1.9.
