### PR TITLE
A restyled point layer read back as the polygon entry, so nothing was pushed

### DIFF
--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,23 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17j (**a restyled POINT layer pushed back as no change at all.** QGIS's own vector-tile
+symbology editor keeps one UNFILTERED style per geometry type — Polygons, Lines, Points — and
+`style_from_vector_tiles` de-duplicated on the FILTER alone, so only the first survived: a user who
+changed the point marker had the POLYGON entry read back, a colour they never touched and equal to the
+old default. `_style_differs` therefore saw nothing, "Push group to portal" published nothing, and
+"Save styling to GeoDeploy" stored the style it already had. Reproduced exactly with a stand-in for
+QGIS's editor output before changing anything.
+Fixed by recording the geometry ON the layer when the plugin builds it (`P_GEOMETRY`, set in
+`_build_layer` and both portal-source paths — a tile layer cannot be asked what it holds) and reading
+back only the entries for that geometry. With no geometry recorded and entries that disagree it now
+returns `{}` rather than guessing, which `plan_push` turns into "keep what the portal has" — a guess
+here would silently publish a colour nobody picked. `_style_from_symbol` also stopped losing a whole
+style to one unreadable number: a missing marker size now costs the radius, not the colour.
+**The stub was hiding it twice:** `QgsVectorTileBasicRendererStyle` exposed `geometry_type` as an
+attribute where QGIS has `geometryType()`, so the new geometry filter matched every entry and the test
+passed against the bug. Same lesson as `smoke.py` — a double has to be faithful about TYPES and about
+whether something is a method, not merely permissive.)
 2026-08-17i (**the public layer page actually works now, and the portal button does something
 different from the button next to it.**
 *Page:* the public row was missing two things the page needs — a raster's `tile_url` (`lib/mapStyle.js`

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.9
+version=0.1.10
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,12 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.9 - "Open in GeoDeploy" now opens a PORTAL in the editor rather than repeating what
+changelog=0.1.10 - Restyling a POINT layer and pushing it back now registers. QGIS's vector-tile
+    symbology editor keeps one style per geometry type - polygons, lines, points - and the plugin read
+    the first of them, so a changed marker came back as the untouched polygon colour: identical to the
+    old style, so "Push group to portal" saw no change and "Save styling to GeoDeploy" appeared to do
+    nothing. The layer's geometry is now recorded when it is added and used to pick the right one.
+    0.1.9 - "Open in GeoDeploy" now opens a PORTAL in the editor rather than repeating what
     "Open portal in browser" already does, and the actions that need a token (push a group, upload,
     save styling, edit a portal) are disabled with the reason in their tooltip until you connect with
     one. A public layer's page opens for anyone, with the map, the extent and the share links, and

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -605,6 +605,9 @@ class GeoDeployDock(QDockWidget):
             # portal's style" — does not have to rediscover it.
             layer.setCustomProperty(symbology.P_SOURCE_LAYER,
                                     doc.get("_source_layer") or source.get("source_layer") or "")
+            # Recorded for the way BACK: a tile layer cannot be asked what geometry it holds, and
+            # that answer decides which renderer entry is the user's when the style is read out.
+            layer.setCustomProperty(symbology.P_GEOMETRY, row.get("geometry_type") or "")
             # Classified symbology DOES survive here: a tile renderer takes one style per class
             # with a filter, which is the same shape the map's step/match expressions have.
             symbology.apply(layer, (row.get("default_style") or {}).get("style")
@@ -691,6 +694,8 @@ class GeoDeployDock(QDockWidget):
                     layer.setCustomProperty(
                         symbology.P_SOURCE_LAYER,
                         src.get("source_layer") or doc.get("_source_layer") or "")
+                    layer.setCustomProperty(symbology.P_GEOMETRY,
+                                            cfg.get("geometry_type") or "")
                     self._set_tile_extent(layer, doc.get("bounds"))
                 else:
                     # An instance too old to publish that TileJSON: the archive still draws, slowly.
@@ -706,6 +711,8 @@ class GeoDeployDock(QDockWidget):
                     layer.setCustomProperty(
                         symbology.P_SOURCE_LAYER,
                         src.get("source_layer") or doc.get("_source_layer") or "")
+                    layer.setCustomProperty(symbology.P_GEOMETRY,
+                                            cfg.get("geometry_type") or "")
                     self._set_tile_extent(layer, doc.get("bounds"))
             else:
                 return None

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -302,6 +302,12 @@ def _log(message: str) -> None:
 #: written once, on the layer, rather than threaded through every caller that might restyle later.
 P_SOURCE_LAYER = "geodeploy/source_layer"
 
+#: And the layer's GEOMETRY, recorded for the way back out. A tile layer cannot be asked what it
+#: holds, and the answer decides which renderer entry is the user's: QGIS's own vector-tile editor
+#: keeps one UNFILTERED style per geometry type, so reading "the first one" read a polygon symbol on
+#: a point layer — the wrong colour, identical to the old default, so an edit registered as no change.
+P_GEOMETRY = "geodeploy/geometry"
+
 
 def apply(qgis_layer, style: dict, row: dict | None = None) -> bool:
     """Style ANY GeoDeploy layer — feature or vector tile — the way GeoDeploy draws it.
@@ -833,12 +839,46 @@ def style_from_vector_tiles(tile_layer) -> dict:
     if not entries:
         return {}
 
-    # One class may have been written once per geometry type (see `apply_to_vector_tiles`), so the
-    # FILTER identifies a class, not the entry. Keep the first of each.
+    # ONLY THE ENTRIES FOR THIS LAYER'S GEOMETRY.
+    #
+    # QGIS's own vector-tile symbology editor keeps one style per geometry type — Polygons, Lines,
+    # Points — all UNFILTERED. Reading them all and keeping the first meant a POINT layer's colour
+    # was read off the polygon entry: a colour the user had not touched, equal to the old default, so
+    # editing a point layer and pushing it registered as "no change" and published nothing. The
+    # geometry is recorded on the layer when the plugin builds it, precisely because the layer itself
+    # cannot be asked.
+    wanted = None
+    try:
+        recorded = (tile_layer.customProperty(P_GEOMETRY) or "")
+        recorded = str(recorded).lower()
+        from qgis.core import QgsWkbTypes
+        if "polygon" in recorded:
+            wanted = QgsWkbTypes.PolygonGeometry
+        elif "line" in recorded:
+            wanted = QgsWkbTypes.LineGeometry
+        elif "point" in recorded:
+            wanted = QgsWkbTypes.PointGeometry
+    except Exception:                   # noqa: BLE001 - fall through to every entry
+        wanted = None
+
+    enabled = [e for e in entries if not hasattr(e, "isEnabled") or e.isEnabled()]
+    if wanted is not None:
+        matching = [e for e in enabled
+                    if not hasattr(e, "geometryType") or e.geometryType() == wanted]
+        if matching:
+            enabled = matching
+    elif len({e.geometryType() for e in enabled if hasattr(e, "geometryType")}) > 1:
+        # No geometry recorded and the entries disagree: any choice would be a guess, and a guess
+        # here silently sends somebody a colour they never picked. Say so and send nothing, which
+        # `plan_push` turns into "keep what the portal already has".
+        _log("This tile layer has styles for several geometry types and no recorded geometry, so "
+             "which one is the layer's cannot be told — leaving its saved style alone.")
+        return {}
+
+    # One class may have been written once per geometry type (see `apply_to_vector_tiles`), so within
+    # one geometry the FILTER identifies a class. Keep the first of each.
     seen, unique = set(), []
-    for entry in entries:
-        if hasattr(entry, "isEnabled") and not entry.isEnabled():
-            continue
+    for entry in enabled:
         expression = (entry.filterExpression() or "").strip()
         if expression in seen:
             continue
@@ -959,16 +999,30 @@ def _style_from_symbol(symbol) -> dict:
     """
     style = {"color": _hex(symbol.color())}
     layer0 = symbol.symbolLayer(0) if symbol.symbolLayerCount() else None
+
+    def number(getter):
+        """A finite float from a Qt getter, or None. A missing size must not cost the COLOUR too —
+        losing a whole style over one unreadable number is the wrong trade, and it is the kind of
+        thing that differs between QGIS builds."""
+        try:
+            value = float(getter())
+        except (TypeError, ValueError):
+            return None
+        return value if value == value and value not in (float("inf"), float("-inf")) else None
+
     if isinstance(layer0, QgsSimpleMarkerSymbolLayer):
-        style["radius"] = round(float(symbol.size()) / 2.0 / CSS_PX_TO_POINTS, 2)
+        size = number(symbol.size)
+        if size is not None:
+            style["radius"] = round(size / 2.0 / CSS_PX_TO_POINTS, 2)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
-        style["line_width"] = round(float(layer0.width()) / CSS_PX_TO_POINTS, 2)
+        width = number(layer0.width)
+        if width is not None:
+            style["line_width"] = round(width / CSS_PX_TO_POINTS, 2)
         pen = layer0.penStyle()
         style["lineType"] = ("dashed" if pen == Qt.DashLine
                              else "dotted" if pen == Qt.DotLine else "solid")
     elif isinstance(layer0, QgsSimpleFillSymbolLayer):
-        try:
-            style["fill_opacity"] = round(float(symbol.opacity()), 3)
-        except Exception:               # noqa: BLE001 - not every build exposes it
-            pass
+        opacity = number(symbol.opacity)
+        if opacity is not None:
+            style["fill_opacity"] = round(opacity, 3)
     return style

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -166,6 +166,12 @@ class QgsVectorTileBasicRendererStyle(_Stub):
     def filterExpression(self):
         return self.filter
 
+    # A METHOD in QGIS. Exposed only as an attribute here at first, which made the reader's
+    # geometry filter — `if not hasattr(e, "geometryType")` — match every entry and hide the very
+    # bug this file was written to pin.
+    def geometryType(self):
+        return self.geometry_type
+
     def isEnabled(self):
         return self.enabled
 
@@ -396,16 +402,22 @@ class Renderer:
 
 
 class TileLayerWith:
-    def __init__(self, styles):
+    def __init__(self, styles, geometry=None):
         self._r = Renderer(styles)
+        self._props = {ns["P_GEOMETRY"]: geometry or ""}
 
     def renderer(self):
         return self._r
 
+    def customProperty(self, key, default=None):
+        return self._props.get(key, default)
+
 
 def round_trip(row, style):
     applied = styles_for(row, style)
-    return style_from_vector_tiles(TileLayerWith(applied))
+    # The plugin records the geometry on the layer when it builds one; the reader needs it to know
+    # which renderer entry is the layer's. See P_GEOMETRY.
+    return style_from_vector_tiles(TileLayerWith(applied, row.get("geometry_type")))
 
 
 out = round_trip({"geometry_type": "point"}, {"color": "#3388ff", "radius": 6, "marker": "square"})
@@ -482,3 +494,62 @@ assert style_from_vector_tiles(None) == {}
 print("nothing to read      -> {}")
 
 print("\nALL ROUND-TRIP CASES PASS")
+
+
+# ── THE REPORTED BUG: an edit to a POINT layer read back as the polygon entry ──────────────────
+# QGIS's own vector-tile symbology editor keeps one UNFILTERED style per geometry type. De-duplicating
+# on the filter alone therefore kept only the FIRST — so a user who changed the point marker had the
+# POLYGON colour read back: a colour they never touched, equal to the old default, so "push group to
+# portal" saw no change and published nothing, and "Save styling to GeoDeploy" appeared to do nothing.
+def qgis_editor_styles(colours):
+    """What QGIS leaves behind after editing a vector tile layer: one style per geometry, no filters."""
+    out = []
+    for geom, colour in ((QgsWkbTypes.PolygonGeometry, colours[0]),
+                         (QgsWkbTypes.LineGeometry, colours[1]),
+                         (QgsWkbTypes.PointGeometry, colours[2])):
+        entry = QgsVectorTileBasicRendererStyle("s", "", geom)
+        symbol = QgsSymbol.defaultSymbol(geom)
+        symbol.setColor(_QColor(colour))
+        entry.setSymbol(symbol)
+        entry.setEnabled(True)
+        entry.setFilterExpression("")
+        out.append(entry)
+    return out
+
+
+edited = qgis_editor_styles(["#aaaaaa", "#bbbbbb", "#ff0000"])
+out = style_from_vector_tiles(TileLayerWith(edited, "point"))
+assert out["color"] == "#ff0000", ("the POINT entry is the layer's; #aaaaaa is the polygon one", out)
+assert "fill_opacity" not in out, ("a point style must not pick up a fill's opacity", out)
+print("qgis-edited point  -> reads the point entry, not the first one")
+
+out = style_from_vector_tiles(TileLayerWith(edited, "MultiPolygon"))
+assert out["color"] == "#aaaaaa", out
+out = style_from_vector_tiles(TileLayerWith(edited, "LineString"))
+assert out["color"] == "#bbbbbb", out
+print("qgis-edited others -> line and polygon read their own entries")
+
+# No geometry recorded and the entries disagree: guessing would send a colour nobody picked, so it
+# sends nothing — which `plan_push` turns into "keep whatever the portal already has".
+assert style_from_vector_tiles(TileLayerWith(edited, None)) == {}
+print("geometry unknown   -> {} rather than a guess")
+
+# One unfiltered entry and no recorded geometry is unambiguous, so it still reads.
+one = qgis_editor_styles(["#aaaaaa", "#bbbbbb", "#ff0000"])[2:]
+assert style_from_vector_tiles(TileLayerWith(one, None))["color"] == "#ff0000"
+print("single entry       -> still read without a recorded geometry")
+
+# A classified POINT layer edited in QGIS keeps its filters; the geometry filter must not drop them.
+mixed = qgis_editor_styles(["#aaaaaa", "#bbbbbb", "#ff0000"])
+for value, colour in (("a", "#111111"), ("b", "#222222")):
+    e = QgsVectorTileBasicRendererStyle("c", "", QgsWkbTypes.PointGeometry)
+    sym = QgsSymbol.defaultSymbol(QgsWkbTypes.PointGeometry)
+    sym.setColor(_QColor(colour))
+    e.setSymbol(sym); e.setEnabled(True); e.setFilterExpression('"k" = \'%s\'' % value)
+    mixed.append(e)
+out = style_from_vector_tiles(TileLayerWith(mixed, "point"))
+assert out["color_mode"] == "categorized" and len(out["categories"]) == 2, out
+assert out["other_color"] == "#ff0000", ("the unfiltered POINT entry is the catch-all", out)
+print("classified point   -> categories kept, point catch-all used")
+
+print("\nALL GEOMETRY-SELECTION CASES PASS")


### PR DESCRIPTION
Reported as *"push group to portal doesn't detect symbology change for my point vector data"* and *"save styling still comes back as the old default style"*. Reproduced before changing anything, with a stand-in for what QGIS's vector-tile symbology editor actually leaves behind:

```
what the reader gets from a QGIS-edited POINT layer:
    {"color": "#aaaaaa", "fill_opacity": 1.0, "color_mode": "single"}
    the user changed the MARKER to #ff0000
```

## One cause, both symptoms

QGIS's vector-tile editor keeps one **unfiltered** style per geometry type — Polygons, Lines, Points — and `style_from_vector_tiles` de-duplicated on the **filter** alone, so only the first survived. Change the point marker and you got the *polygon* entry back: a colour you never touched, equal to the layer's old style.

So `_style_differs` saw no difference → the push published nothing. And saving the style stored the one it already had. Exactly the two things reported.

## The fix

A tile layer can't be asked what geometry it holds, so the plugin now **records it when it builds one** (`P_GEOMETRY`, set in `_build_layer` and both portal-source paths) and reads back only the entries for that geometry.

Where no geometry is recorded *and* the entries disagree, it returns `{}` instead of guessing — `plan_push` turns that into "keep what the portal already has", because a guess here silently publishes a colour nobody picked.

`_style_from_symbol` also stopped losing a whole style to one unreadable number: a missing marker size now costs the radius, not the colour.

## The test double hid this twice

`QgsVectorTileBasicRendererStyle` exposed `geometry_type` as an **attribute** where QGIS has `geometryType()`. My new geometry filter has a `not hasattr(...)` fallback, so it matched every entry and the test passed *against the bug it was written to catch*. Fixed, and the same lesson as `smoke.py` earlier today: a double has to be faithful about types and about what is a method, not merely permissive.

Six new cases pin it — the edited point, line and polygon each reading their own entry; unknown geometry returning nothing rather than a guess; a single unambiguous entry still working; and a classified point layer keeping its categories with the unfiltered point entry as the catch-all.

Plugin 0.1.10.
