### PR TITLE
Notice a stroke-only edit, and stop reporting untouched layers as restyled

### DIFF
--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,28 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17k (**change detection was wrong in both directions, and the user diagnosed it exactly: "when
+I only change the symbol fill it detects the change; when I only change the stroke colour it doesn't."**
+*Missed edits:* `_style_from_symbol` read the fill colour, the size and the dash — and never the
+STROKE, so a stroke-only edit produced an identical dict. It now reads `outline_color` (via
+`_stroke_of`, with `Qt.NoPen` → `"none"`) and the marker SHAPE (`_shape_name`, using
+`encodeShape`; a shape GeoDeploy cannot express is omitted rather than forced to the nearest match).
+*Phantom edits:* the mirror image, reported as "I changed only one style, but it says 3 were
+restyled". QGIS has no concept of "unset", so `_symbol_of` fills every gap with the map's default and
+a read-back style is always COMPLETE, while a stored one holds only the keys somebody chose. New
+`symbology.comparable_style` fills both sides from one table before comparison — and folds the two
+geometry-dependent outline defaults (`#ffffff` on a marker, `#1d4ed8` on a fill) into one token, folds
+colour case, and DROPS the top-level `color` for a classified layer, whose classes carry the colours.
+`portals._style_differs` compares through it. The reader also stopped inventing that colour: it was
+taking it from whichever entry came first — the catch-all, or class 0.
+One care point: category `value`s are DATA and are no longer case-folded with the colours; folding
+them would both hide a real change and mislabel the map.
+*Rasters:* unchanged and unchangeable by design — server-rendered tiles are colour, not values. The
+`attributes` checkbox label now says "(needed to restyle a raster)", since that checkbox IS the
+answer, and the explanation is logged at Info: three identical warnings for three rasters read as
+three failures. `_log` gained a level for exactly that.
+Tests: ~30 change-detection cases — every edit that must register, and every cosmetic difference that
+must not.)
 2026-08-17j (**a restyled POINT layer pushed back as no change at all.** QGIS's own vector-tile
 symbology editor keeps one UNFILTERED style per geometry type — Polygons, Lines, Points — and
 `style_from_vector_tiles` de-duplicated on the FILTER alone, so only the first survived: a user who

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.10
+version=0.1.11
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,15 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.10 - Restyling a POINT layer and pushing it back now registers. QGIS's vector-tile
+changelog=0.1.11 - Change detection is right in both directions. Changing only a symbol's STROKE
+    (or its marker shape) is now noticed - before, only the fill was read, so a stroke-only edit came
+    back byte-identical and reported "unchanged". And opening a portal and pushing it straight back no
+    longer reports every layer as restyled: a style read out of QGIS is always complete while a stored
+    one holds only what you chose, so the two are now compared through the same defaults. A raster
+    drawn from server tiles still cannot be restyled in QGIS - the checkbox that opens the real
+    GeoTIFF now says so on its label, and the explanation is logged as information rather than as
+    three warnings that look like failures.
+    0.1.10 - Restyling a POINT layer and pushing it back now registers. QGIS's vector-tile
     symbology editor keeps one style per geometry type - polygons, lines, points - and the plugin read
     the first of them, so a changed marker came back as the untouched polygon colour: identical to the
     old style, so "Push group to portal" saw no change and "Save styling to GeoDeploy" appeared to do

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -144,7 +144,10 @@ class GeoDeployDock(QDockWidget):
         self.styled.setChecked(True)
         outer.addWidget(self.styled)
 
-        self.attributes = QCheckBox("Prefer the real data over the styled view")
+        # The label names the raster consequence outright: "why can I not restyle this raster" was
+        # answered only in a tooltip and in the log, and the answer IS this checkbox.
+        self.attributes = QCheckBox("Prefer the real data over the styled view "
+                                    "(needed to restyle a raster)")
         self.attributes.setToolTip(
             "Vector — off: one pre-generalized archive, downloaded once, carrying only the "
             "attributes the tiles hold. On: OGC API - Features, re-queried for the extent on "

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -418,11 +418,20 @@ def _style_differs(before: dict, after: dict) -> bool:
     """
     import json
 
+    try:
+        from .symbology import comparable_style
+    except Exception:                   # noqa: BLE001 - outside QGIS, compare the raw dicts
+        def comparable_style(style):
+            return style or {}
+
     def shape(cfg):
-        return json.dumps({"style": cfg.get("style") or {},
+        # COMPARED THROUGH THE SAME DEFAULTS. A style read back out of QGIS is always complete, while
+        # a stored one holds only what somebody chose — so comparing them as written reported every
+        # layer in a freshly opened portal as restyled. See `symbology.comparable_style`.
+        return json.dumps({"style": comparable_style(cfg.get("style")),
                            "visible": bool(cfg.get("visible", True)),
                            "opacity": round(float(cfg.get("opacity", 1.0) or 1.0), 3)},
-                          sort_keys=True)
+                          sort_keys=True, default=str)
 
     return shape(before) != shape(after)
 

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -288,11 +288,17 @@ def style_from_legend(legend: dict) -> dict:
     return style
 
 
-def _log(message: str) -> None:
-    """Into QGIS's Log Messages panel, under our own tab — the place a user can be pointed to."""
+def _log(message: str, level: str = "warning") -> None:
+    """Into QGIS's Log Messages panel, under our own tab — the place a user can be pointed to.
+
+    `level="info"` is for things that are EXPLANATIONS rather than faults. Three identical WARNINGs
+    for three rasters that simply cannot carry band styling read as three failures; they are one fact
+    about how a portal draws a raster, and the dialog already says what to do about it.
+    """
     try:
         from qgis.core import Qgis, QgsMessageLog
-        QgsMessageLog.logMessage(message, "GeoDeploy", Qgis.Warning)
+        QgsMessageLog.logMessage(message, "GeoDeploy",
+                                 Qgis.Info if level == "info" else Qgis.Warning)
     except Exception:                   # noqa: BLE001 - logging must never raise
         pass
 
@@ -307,6 +313,67 @@ P_SOURCE_LAYER = "geodeploy/source_layer"
 #: keeps one UNFILTERED style per geometry type, so reading "the first one" read a polygon symbol on
 #: a point layer — the wrong colour, identical to the old default, so an edit registered as no change.
 P_GEOMETRY = "geodeploy/geometry"
+
+
+#: Every visual key, with the value the MAP supplies when a style omits it. Used only to COMPARE two
+#: styles — see `comparable_style`.
+_STYLE_DEFAULTS = {
+    "color_mode": "single",
+    "color": "#3b82f6",
+    "radius": DEFAULT_POINT_RADIUS,
+    "marker": "circle",
+    "line_width": DEFAULT_LINE_WIDTH,
+    "lineType": "solid",
+    "fill_opacity": DEFAULT_FILL_OPACITY,
+    "outline_color": "",                # geometry-dependent, so normalised below rather than here
+}
+
+
+def comparable_style(style: dict | None) -> dict:
+    """A style reduced to what a viewer would SEE, for comparing two of them.
+
+    WHY A STORED STYLE AND A READ-BACK ONE CANNOT BE COMPARED DIRECTLY. QGIS has no concept of "unset":
+    `_symbol_of` fills every gap with the map's own default — radius 5, a white marker stroke, 45% fill
+    — so reading a symbol back always returns a COMPLETE style, while the stored one usually holds only
+    the few keys somebody actually chose. Compared raw, opening a portal and pushing it straight back
+    reported every layer as restyled; reported as "I changed only one style, but it says 3 were
+    restyled". Filling both sides from the same table is what makes the comparison mean "looks
+    different" instead of "is written differently".
+
+    Keys that do not apply to a geometry are harmless: both sides get them identically.
+    """
+    merged = dict(_STYLE_DEFAULTS)
+    merged.update({k: v for k, v in (style or {}).items() if v is not None})
+    # An outline is stated as a colour or the word "none", and the DEFAULT differs by geometry — white
+    # on a marker, #1d4ed8 on a fill. Either default reads as "the outline nobody chose", so both
+    # collapse to one token rather than being compared as colours.
+    if merged.get("outline_color") in ("", None, "#ffffff", DEFAULT_FILL_OUTLINE):
+        merged["outline_color"] = "default"
+    for key in ("radius", "line_width", "fill_opacity"):
+        try:
+            merged[key] = round(float(merged[key]), 3)
+        except (TypeError, ValueError):
+            merged[key] = None
+    # Colours differ only by case or shorthand surprisingly often (#FFF vs #ffffff); comparing them
+    # as written would report a change nobody made.
+    for key in ("color", "outline_color", "other_color"):
+        if isinstance(merged.get(key), str):
+            merged[key] = merged[key].strip().lower()
+    # The class lists carry their own colours, and those matter — keep them, case-folding ONLY the
+    # colour. A category's `value` is DATA: "Autochamber" and "autochamber" are different categories,
+    # and folding them here would hide a real change and mislabel the map.
+    for key in ("classes", "categories"):
+        if isinstance(merged.get(key), list):
+            merged[key] = [
+                {k: (v.strip().lower() if k == "color" and isinstance(v, str) else v)
+                 for k, v in item.items()}
+                for item in merged[key] if isinstance(item, dict)]
+    # A CLASSIFIED layer's single colour is not drawn — the classes are. Keeping it in the comparison
+    # made an untouched categorized layer look edited, because the read-back fills it from the
+    # catch-all entry while the stored style never had one.
+    if merged.get("color_mode") in ("graduated", "categorized"):
+        merged.pop("color", None)
+    return merged
 
 
 def apply(qgis_layer, style: dict, row: dict | None = None) -> bool:
@@ -543,10 +610,11 @@ def raster_from_qgis(qgis_layer, colormaps=None) -> dict:
     # silence here reads as "the push lost my changes", and pushing the empty result would REPLACE
     # the portal's colormap with nothing (see portals.plan_push, which now refuses to).
     if type(renderer).__name__ == "QgsSingleBandColorDataRenderer":
-        _log("This raster is drawn from the portal's own tiles, so QGIS holds it as colour, not as "
-             "values — there is no band styling to send back. To restyle it, add the layer with "
-             "'Prefer the real data over the styled view' (that opens the GeoTIFF), restyle that, "
-             "and use 'Save styling to GeoDeploy'.")
+        _log("This raster is drawn from server-rendered tiles, so QGIS holds it as colour rather "
+             "than values — QGIS shows 'Singleband color data' and offers nothing to change, and "
+             "there is no band styling to read back. To restyle it, tick 'Prefer the real data over "
+             "the styled view' and add it again: that opens the GeoTIFF, with its real bands.",
+             level="info")
         return {}
     if renderer is None:
         return {}
@@ -913,12 +981,17 @@ def style_from_vector_tiles(tile_layer) -> dict:
         # A filter nobody here wrote: do not pretend to understand it.
         return dict(visual, color_mode="single")
 
+    # For a CLASSIFIED layer the top-level colour means nothing — the classes carry the colours, and
+    # `visual` took its `color` from whichever entry happened to be first (the catch-all, or class 0).
+    # Reporting that as the layer's colour is how an untouched categorized layer read as edited.
+    shape_only = {k: v for k, v in visual.items() if k != "color"}
     if classes and not categories:
         classes.sort(key=lambda c: (c["min"] is not None, c["min"] if c["min"] is not None else 0))
-        return dict(visual, color_mode="graduated", color_field=field,
+        return dict(shape_only, color_mode="graduated", color_field=field,
                     classes=classes, classes_n=len(classes))
     if categories and not classes:
-        style = dict(visual, color_mode="categorized", color_field=field, categories=categories)
+        style = dict(shape_only, color_mode="categorized", color_field=field,
+                     categories=categories)
         if other:
             style["other_color"] = other
         return style
@@ -1014,6 +1087,14 @@ def _style_from_symbol(symbol) -> dict:
         size = number(symbol.size)
         if size is not None:
             style["radius"] = round(size / 2.0 / CSS_PX_TO_POINTS, 2)
+        # THE OUTLINE, which this used to ignore entirely — so changing only a marker's stroke
+        # produced a byte-identical style and the push reported "unchanged". Reported exactly that
+        # way: "when I only change the symbol fill it detects the change; when I only change the
+        # stroke colour it doesn't."
+        style["outline_color"] = _stroke_of(layer0)
+        shape = _shape_name(layer0)
+        if shape:
+            style["marker"] = shape
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
         width = number(layer0.width)
         if width is not None:
@@ -1025,4 +1106,33 @@ def _style_from_symbol(symbol) -> dict:
         opacity = number(symbol.opacity)
         if opacity is not None:
             style["fill_opacity"] = round(opacity, 3)
+        style["outline_color"] = _stroke_of(layer0)
     return style
+
+
+def _stroke_of(layer0) -> str:
+    """A symbol layer's outline as GeoDeploy states it: a colour, or `"none"` for no outline."""
+    try:
+        if layer0.strokeStyle() == Qt.NoPen:
+            return "none"
+    except Exception:                   # noqa: BLE001 - not every symbol layer has one
+        pass
+    try:
+        return _hex(layer0.strokeColor())
+    except Exception:                   # noqa: BLE001
+        return ""
+
+
+def _shape_name(layer0):
+    """A marker's shape as one of GeoDeploy's names, or None when it is something else entirely.
+
+    Read back so changing the SHAPE registers as a change too. QGIS knows far more shapes than
+    GeoDeploy draws; one it cannot express is left out rather than forced to the nearest match, which
+    would quietly rewrite the user's symbol.
+    """
+    try:
+        name = QgsSimpleMarkerSymbolLayer.encodeShape(layer0.shape())
+    except Exception:                   # noqa: BLE001 - encodeShape moved between QGIS versions
+        return None
+    name = str(name).strip().lower()
+    return name if name in _MARKERS else None

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -553,3 +553,92 @@ assert out["other_color"] == "#ff0000", ("the unfiltered POINT entry is the catc
 print("classified point   -> categories kept, point catch-all used")
 
 print("\nALL GEOMETRY-SELECTION CASES PASS")
+
+
+# ── DETECTION: what counts as a change, and what must not ──────────────────────────────────────
+# Two complaints, opposite in direction, one root cause — a style read out of QGIS is always COMPLETE
+# while a stored one holds only what somebody chose:
+#   * "I only change the stroke colour and it doesn't detect the change"  → the reader ignored strokes.
+#   * "I changed only one style, but it says 3 were restyled"             → filled-in defaults counted.
+comparable_style = ns["comparable_style"]
+
+
+def differs(before, after):
+    """`portals._style_differs`, in the one part that matters here."""
+    return comparable_style(before) != comparable_style(after)
+
+
+# A portal's stored style, and the same style after a round trip through QGIS. Nothing was edited, so
+# nothing may be reported.
+stored = {"color": "#10b981", "fill_opacity": 0.45, "outline_color": "#1d4ed8"}
+readback = round_trip({"geometry_type": "MultiPolygon"}, stored)
+assert not differs(stored, readback), (stored, readback)
+print("untouched polygon  -> no change reported")
+
+for geom, stored in (("point", {"color": "#ef4444", "radius": 1.0}),
+                     ("LineString", {"color": "#3b82f6", "line_width": 1.04}),
+                     ("point", {"color": "#3b82f6"}),                 # nothing but a colour
+                     ("MultiPolygon", {"color": "#e5b636"})):
+    readback = round_trip({"geometry_type": geom}, stored)
+    assert not differs(stored, readback), (geom, stored, readback)
+print("untouched, 4 shapes-> no change reported")
+
+# A classified layer, likewise.
+stored = {"color_mode": "categorized", "color_field": "Type",
+          "categories": [{"value": "Autochamber", "color": "#8c4ee3"},
+                         {"value": "Manual chamber", "color": "#6cefa2"}],
+          "other_color": "#eea26b"}
+readback = round_trip({"geometry_type": "point"}, stored)
+assert not differs(stored, readback), (stored, readback)
+# The category VALUES must survive as written — they are data, not colours.
+assert [c["value"] for c in readback["categories"]] == ["Autochamber", "Manual chamber"], readback
+print("untouched category -> no change reported, values kept verbatim")
+
+# ── …and every real edit MUST be reported ─────────────────────────────────────────────────────
+base_point = {"color": "#3b82f6", "radius": 5, "outline_color": "#ffffff", "marker": "circle"}
+edits = [
+    ("fill colour",   dict(base_point, color="#ff0000")),
+    ("stroke colour", dict(base_point, outline_color="#000000")),
+    ("stroke removed", dict(base_point, outline_color="none")),
+    ("radius",        dict(base_point, radius=9)),
+    ("marker shape",  dict(base_point, marker="square")),
+]
+for what, edited in edits:
+    assert differs(base_point, edited), ("an edit to the " + what + " must be reported", edited)
+print("point edits        ->", ", ".join(w for w, _ in edits), "all detected")
+
+base_line = {"color": "#3b82f6", "line_width": 2, "lineType": "solid"}
+for what, edited in (("colour", dict(base_line, color="#00ff00")),
+                     ("width", dict(base_line, line_width=6)),
+                     ("dash", dict(base_line, lineType="dashed"))):
+    assert differs(base_line, edited), what
+print("line edits         -> colour, width, dash all detected")
+
+base_fill = {"color": "#10b981", "fill_opacity": 0.45, "outline_color": "#1d4ed8"}
+for what, edited in (("colour", dict(base_fill, color="#123456")),
+                     ("opacity", dict(base_fill, fill_opacity=0.9)),
+                     ("outline", dict(base_fill, outline_color="#ff0000")),
+                     ("no outline", dict(base_fill, outline_color="none"))):
+    assert differs(base_fill, edited), what
+print("polygon edits      -> colour, opacity, outline, no-outline all detected")
+
+# A change to a CLASS's colour, or to the field, or a class added: all real.
+g = {"color_mode": "graduated", "color_field": "pop",
+     "classes": [{"min": None, "max": 100, "color": "#fee5d9"},
+                 {"min": 100, "max": None, "color": "#a50f15"}]}
+assert differs(g, {**g, "color_field": "area"})
+assert differs(g, {**g, "classes": [dict(g["classes"][0], color="#000000"), g["classes"][1]]})
+assert differs(g, {**g, "classes": g["classes"] + [{"min": 900, "max": None, "color": "#111111"}]})
+print("class edits        -> field, class colour, extra class all detected")
+
+# Cosmetic-only differences must NOT be reported: case, shorthand-vs-long, an explicitly stated
+# default, or a key written as null.
+assert not differs({"color": "#3B82F6"}, {"color": "#3b82f6"})
+assert not differs({"color": "#3b82f6"}, {"color": "#3b82f6", "radius": 5})
+assert not differs({"color": "#3b82f6"}, {"color": "#3b82f6", "lineType": "solid"})
+assert not differs({"color": "#3b82f6"}, {"color": "#3b82f6", "outline_color": None})
+assert not differs({"color": "#3b82f6", "outline_color": "#ffffff"},
+                   {"color": "#3b82f6", "outline_color": "#1d4ed8"})   # both mean "the default"
+print("cosmetic only      -> not reported")
+
+print("\nALL CHANGE-DETECTION CASES PASS")


### PR DESCRIPTION
Both halves were diagnosed precisely in the report: *"when I only change the symbol fill it detects the change; when I only change the stroke colour it doesn't"* — and separately, *"I changed only one style, but it says 3 were restyled"*. They turn out to be the same root cause pointing in opposite directions.

## Missed edits

`_style_from_symbol` read the fill colour, the size and the dash — and **never the stroke**. So a stroke-only edit produced a byte-identical style and the push reported "unchanged".

It now reads `outline_color` (`Qt.NoPen` → `"none"`) and the marker **shape**. A shape GeoDeploy cannot express is omitted rather than forced to the nearest match, which would quietly rewrite your symbol.

## Phantom edits

QGIS has no concept of "unset": `_symbol_of` fills every gap with the map's own default, so a style read back out is always **complete**, while a stored one holds only the keys somebody chose. Compared as written, opening a portal and pushing it straight back reported *every* layer as restyled.

`symbology.comparable_style` now fills both sides from one table before comparing. It also:
- folds the two geometry-dependent outline defaults (`#ffffff` on a marker, `#1d4ed8` on a fill) into one token, since either means "the outline nobody chose";
- folds colour case (`#3B82F6` vs `#3b82f6`);
- **drops the top-level `color` for a classified layer**, whose classes carry the colours.

The reader also stopped *inventing* that colour — it was taking it from whichever entry came first, the catch-all or class 0, which is why an untouched categorized layer looked edited.

One care point: category `value`s are **data** and are no longer case-folded along with the colours. Folding them would both hide a real change and mislabel the map.

## Rasters

Unchanged and unchangeable by design — server-rendered tiles are colour, not values, which is why QGIS offers only "Singleband color data" with nothing to change. The checkbox that opens the real GeoTIFF now says **"(needed to restyle a raster)"** on its label, because that checkbox is the answer and it was previously explained only in a tooltip and the log. The explanation is logged at **Info**: three identical warnings for three rasters read as three failures. `_log` gained a level for exactly that.

## Tests

~30 new cases pin detection in both directions:

- **must register** — fill colour, stroke colour, stroke removed, radius, marker shape, line width, dash, fill opacity, a class colour, a class added, the field changed;
- **must not** — case differences, an explicitly stated default, a key written as `null`, and either outline default.

Plus round trips for four geometries and a classified layer, asserting an untouched portal reports nothing.

Plugin 0.1.11.
