### PR TITLE
Let a raster be restyled at all, and carry every symbol property

### DIFF
--- a/api/geodeploy/routers/README.md
+++ b/api/geodeploy/routers/README.md
@@ -311,6 +311,14 @@ deliberately NOT visibility-filtered (published portals depend on them).
 - No rate limiting beyond nginx; no pagination on list endpoints (fine at current scale).
 
 ## Last updated
+2026-08-17d (`data/raster.py`: **`/cog` is no longer public-or-nothing.** It required `is_public` with
+no authenticated path, so an unshared raster's pixels were unreachable by everyone including its
+owner. That is not a download nicety: server-rendered tiles are colour, not values, so the COG is the
+only way a raster's bands reach QGIS — and therefore the only way to restyle one. Now `is_public` OR a
+signed-in user that `visible_to` already permits, which grants nothing new and stops withholding
+pixels from people already entitled to them. Still stricter than the DESCRIPTION endpoints
+(`_describable`, which also accepts "drawn by a published portal"): being shown a picture in a portal
+is not a licence to download the source data.)
 2026-08-17c (`public.py`: new **`GET /api/public/layers/{kind}/{ref}`** — ONE public layer in the
 shape the layer page reads, so a public layer has a shareable address (the QGIS plugin's "Open in
 GeoDeploy", and the new public UI route `/layers/:kind/:id`). Same readability rule as the display

--- a/api/geodeploy/routers/common.py
+++ b/api/geodeploy/routers/common.py
@@ -36,12 +36,17 @@ def by_ref(model, ref):
     conds = []
     if raw:
         conds.append(model.uid == raw)
-    # A uid is hex, so it CAN be all digits — check both rather than either/or.
+    # A uid is hex, so it CAN be all digits — check both rather than either/or. But only when the
+    # number FITS the id column: `id` is a 32-bit integer in Postgres, and comparing it to a bigger
+    # value is not "no match", it is a DataError — a 500 where the caller should have seen a 404.
+    # A twelve-digit uid is a perfectly ordinary uid, and one turned up in testing straight away.
     if raw.isdigit():
         try:
-            conds.append(model.id == int(raw))
+            number = int(raw)
         except ValueError:
-            pass
+            number = None
+        if number is not None and -2147483648 <= number <= 2147483647:
+            conds.append(model.id == number)
     if not conds:
         return model.id == -1        # matches nothing, without special-casing at every call site
     return or_(*conds)

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -389,15 +389,34 @@ async def raster_export_download(layer_ref: str, job_id: str, db: AsyncSession =
 
 
 @router.get("/{layer_ref}/cog")
-async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
-    """PUBLIC range proxy for the layer's Cloud-Optimized GeoTIFF — ONLY when the admin shared
-    the layer (`is_public`). This is what makes `/vsicurl/https://host/api/data/raster/{id}/cog`
-    work in QGIS/GDAL (full pixel access, the modern WCS — notes §0h) and gives a direct
-    download URL. Same pmtiles/parquet proxy pattern: Range → 206, creds stay server-side."""
+async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db),
+                     user: User | None = Depends(resolve_optional_user)):
+    """Range proxy for the layer's Cloud-Optimized GeoTIFF — the modern WCS (notes §0h).
+
+    This is what makes `/vsicurl/https://host/api/data/raster/{id}/cog` work in QGIS/GDAL with full
+    pixel access, and it is a direct download URL. Same pmtiles/parquet proxy pattern: Range → 206,
+    creds stay server-side.
+
+    PUBLIC when the layer is shared — and readable by a SIGNED-IN user who may see the layer, which
+    it was not before. That omission had a consequence far from here: server-rendered tiles are
+    colour rather than values, so the only way to restyle a raster in QGIS is to open this GeoTIFF,
+    and for any raster that was not shared publicly the owner could not open it AT ALL. "I am still
+    unable to change a raster's symbology from QGIS" was, for a private raster, exactly this 404.
+    `visible_to` is the same rule the rest of the authenticated surface uses, so this grants nothing
+    new — it stops withholding the pixels from people already entitled to them.
+    """
     result = await db.execute(select(RasterLayer).where(by_ref(RasterLayer, layer_ref)))
     layer = result.scalar_one_or_none()
-    if not layer or layer.status != "ready" or not layer.is_public or not layer.s3_key:
+    if not layer or layer.status != "ready" or not layer.s3_key:
         raise HTTPException(404, "No shared raster for this layer.")
+    if not layer.is_public:
+        allowed = False
+        if user is not None:
+            allowed = (await db.execute(
+                select(RasterLayer.id).where(RasterLayer.id == layer.id,
+                                             visible_to(user, RasterLayer)))).scalar_one_or_none()
+        if not allowed:
+            raise HTTPException(404, "No shared raster for this layer.")
 
     from starlette.concurrency import run_in_threadpool
     from fastapi.responses import StreamingResponse

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -389,8 +389,7 @@ async def raster_export_download(layer_ref: str, job_id: str, db: AsyncSession =
 
 
 @router.get("/{layer_ref}/cog")
-async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db),
-                     user: User | None = Depends(resolve_optional_user)):
+async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depends(get_db)):
     """Range proxy for the layer's Cloud-Optimized GeoTIFF — the modern WCS (notes §0h).
 
     This is what makes `/vsicurl/https://host/api/data/raster/{id}/cog` work in QGIS/GDAL with full
@@ -410,11 +409,14 @@ async def raster_cog(layer_ref: str, request: Request, db: AsyncSession = Depend
     if not layer or layer.status != "ready" or not layer.s3_key:
         raise HTTPException(404, "No shared raster for this layer.")
     if not layer.is_public:
-        allowed = False
-        if user is not None:
-            allowed = (await db.execute(
-                select(RasterLayer.id).where(RasterLayer.id == layer.id,
-                                             visible_to(user, RasterLayer)))).scalar_one_or_none()
+        # Resolved in the BODY, like the `/legend` route below — `resolve_optional_user` is a plain
+        # async helper taking `(request, db)`, not a FastAPI dependency. Wiring it through `Depends`
+        # makes FastAPI inspect its signature, find `db: AsyncSession` with no `Depends` default, and
+        # refuse to build the app at all.
+        user = await resolve_optional_user(request, db)
+        allowed = user is not None and (await db.execute(
+            select(RasterLayer.id).where(RasterLayer.id == layer.id,
+                                         visible_to(user, RasterLayer)))).scalar_one_or_none()
         if not allowed:
             raise HTTPException(404, "No shared raster for this layer.")
 

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -310,11 +310,25 @@ class TestRasterCogAccess:
     open their own pixels — reported as "I am still unable to change a raster's symbology from QGIS".
     """
 
+    @pytest.fixture(autouse=True)
+    def _fake_storage(self, monkeypatch):
+        """Stand in for object storage. What is under test is the AUTHORIZATION decision, and CI has
+        no MinIO — without this the route gets past the gate and then dies inside boto3, which reads
+        as a failure of the thing that actually worked."""
+        class _Body:
+            def iter_chunks(self, size):
+                yield b"II*"                # a plausible-enough TIFF opening
+
+        class _S3:
+            def get_object(self, **kw):
+                return {"Body": _Body(), "ContentLength": 4}
+
+        import geodeploy.services.minio as minio
+        monkeypatch.setattr(minio, "get_s3_client", lambda *a, **k: _S3())
+
     async def test_a_shared_raster_is_readable_anonymously(self, client, seeded):
-        # Reaching storage is not what is under test; the authorization decision is. A shared layer
-        # must get PAST the 404 gate.
         r = await client.get("/api/data/raster/eeeeeeeeeeee/cog")
-        assert r.status_code != 404, r.text
+        assert r.status_code == 200, r.text
 
     async def test_an_unshared_raster_is_404_anonymously(self, client, seeded, db):
         db.add(RasterLayer(id=2, user_id=1, uid="ffffffffffff", name="Private DEM",
@@ -329,4 +343,4 @@ class TestRasterCogAccess:
                            visibility="organization", band_count=1))
         await db.commit()
         r = await client.get("/api/data/raster/999999999999/cog", headers=_as(1))
-        assert r.status_code != 404, ("a member may see this layer, so its pixels too", r.text)
+        assert r.status_code == 200, ("a member may see this layer, so its pixels too", r.text)

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -299,3 +299,34 @@ class TestOnePublicLayer:
         # request sees the new value.
         r = await client.get("/api/public/layers/vector/aaaaaaaaaaaa")
         assert r.status_code == 404, r.status_code
+
+
+class TestRasterCogAccess:
+    """`GET /api/data/raster/{ref}/cog` — the GeoTIFF, and who may read it.
+
+    Not a cosmetic permission: server-rendered tiles are colour rather than values, so this file is
+    the ONLY way to get a raster's real bands into QGIS, and therefore the only way to restyle one.
+    Requiring `is_public` with no authenticated path meant the owner of an unshared raster could not
+    open their own pixels — reported as "I am still unable to change a raster's symbology from QGIS".
+    """
+
+    async def test_a_shared_raster_is_readable_anonymously(self, client, seeded):
+        # Reaching storage is not what is under test; the authorization decision is. A shared layer
+        # must get PAST the 404 gate.
+        r = await client.get("/api/data/raster/eeeeeeeeeeee/cog")
+        assert r.status_code != 404, r.text
+
+    async def test_an_unshared_raster_is_404_anonymously(self, client, seeded, db):
+        db.add(RasterLayer(id=2, user_id=1, uid="ffffffffffff", name="Private DEM",
+                           s3_key="rasters/1/x/private.tif", status="ready", is_public=False,
+                           visibility="organization", band_count=1))
+        await db.commit()
+        assert (await client.get("/api/data/raster/ffffffffffff/cog")).status_code == 404
+
+    async def test_an_unshared_raster_is_readable_by_a_signed_in_user(self, client, seeded, db):
+        db.add(RasterLayer(id=3, user_id=1, uid="999999999999", name="Org DEM",
+                           s3_key="rasters/1/x/org.tif", status="ready", is_public=False,
+                           visibility="organization", band_count=1))
+        await db.commit()
+        r = await client.get("/api/data/raster/999999999999/cog", headers=_as(1))
+        assert r.status_code != 404, ("a member may see this layer, so its pixels too", r.text)

--- a/api/tests/test_public_index.py
+++ b/api/tests/test_public_index.py
@@ -338,9 +338,29 @@ class TestRasterCogAccess:
         assert (await client.get("/api/data/raster/ffffffffffff/cog")).status_code == 404
 
     async def test_an_unshared_raster_is_readable_by_a_signed_in_user(self, client, seeded, db):
+        # An ALL-DIGIT uid on purpose: a uid is hex, so this is ordinary, and `by_ref` also tries it
+        # as an integer id — where it overflowed the 32-bit column and produced a 500 instead of a
+        # lookup. Keeping it here keeps that fixed.
         db.add(RasterLayer(id=3, user_id=1, uid="999999999999", name="Org DEM",
                            s3_key="rasters/1/x/org.tif", status="ready", is_public=False,
                            visibility="organization", band_count=1))
         await db.commit()
         r = await client.get("/api/data/raster/999999999999/cog", headers=_as(1))
         assert r.status_code == 200, ("a member may see this layer, so its pixels too", r.text)
+
+
+class TestRefLookup:
+    """`by_ref` — a reference that cannot possibly match must 404, never 500.
+
+    `id` is a 32-bit column. A number larger than that is not "no match" to Postgres, it is a
+    DataError, and the caller gets a 500 for what is really a bad address. All-digit uids are
+    ordinary (a uid is hex), so this is reachable from a normal URL, not just a hostile one.
+    """
+
+    async def test_an_oversized_number_is_a_404(self, client, seeded):
+        for ref in ("999999999999999999999", "2147483648", "-2147483649"):
+            r = await client.get("/api/public/layers/vector/" + ref)
+            assert r.status_code == 404, (ref, r.status_code)
+
+    async def test_a_number_inside_the_range_still_resolves(self, client, seeded):
+        assert (await client.get("/api/public/layers/vector/1")).status_code == 200

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -65,6 +65,27 @@ python integrations/qgis-plugin/scripts/vendor.py --check  # what CI runs
   resampling on the user's behalf, and ingest converts to COG anyway.
 
 ## Last updated
+2026-08-17l (**a raster could not be restyled at all, and three symbol properties never travelled.**
+*The raster blocker was server-side and two layers deep:* the only source of a raster's real band
+values is its COG, and `routers/data/raster.py::raster_cog` required `is_public` with NO authenticated
+path — so the owner of an unshared raster could not open their own pixels, and "tick Prefer the real
+data and restyle the GeoTIFF" was advice that could not be followed. Now readable by any signed-in
+user `visible_to` already lets see the layer. **And GDAL needed the token separately:** `/vsicurl/`
+does not go through `QgsNetworkAccessManager`, so the Qt request preprocessor never touched it. New
+`_install_gdal_auth` sets `GDAL_HTTP_HEADERS` **path-specifically** for the instance's prefix —
+never the global option, which would send this instance's bearer token to every `/vsicurl/` URL in
+the project. GDAL < 3.6 has only the global option, so it declines and says so.
+*Properties:* `outline_width` is a RATIO of the marker radius (`markerImage` draws
+`lineWidth = radius * ratio`, default 0.28) and was neither applied nor read — the plugin wrote a flat
+1 px, i.e. ratio 0.2, and a width change was invisible. Reported as "stroke color now works well, but
+stroke width doesn't seem to be saved". Marker SHAPE and size-BY-FIELD (`_size_from_qgis`, parsing the
+`scale_linear` expression `_apply_data_defined_size` writes) now round-trip too.
+*And a push stopped deleting things:* `symbology.merge_style` lays the read-back visual keys OVER the
+stored style, so 3D extrusion, imported MapLibre paint and popup fields survive a restyle from QGIS
+instead of being replaced by the subset QGIS can express. A change of colour or size MODE still clears
+the previous mode's leftovers.
+`comparable_style` covers the new keys, folds integer-vs-float class bounds, and ignores the derived
+`classes_n`. Tests: 7 full styles round-trip with no phantom change, plus every property individually.)
 2026-08-17k (**change detection was wrong in both directions, and the user diagnosed it exactly: "when
 I only change the symbol fill it detects the change; when I only change the stroke colour it doesn't."**
 *Missed edits:* `_style_from_symbol` read the fill colour, the size and the dash — and never the

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.1.11
+version=0.1.12
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -21,7 +21,15 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.1.11 - Change detection is right in both directions. Changing only a symbol's STROKE
+changelog=0.1.12 - Rasters can finally be restyled, and every symbol property now travels. A
+    raster's real bands come from its GeoTIFF, and that file was refused unless the layer was shared
+    publicly - so for a private raster there was no way to restyle it at all. It is now readable by
+    anyone who may see the layer, and the plugin gives GDAL the token (scoped to your instance) so
+    /vsicurl/ can use it. Tick "Prefer the real data over the styled view", restyle, then "Save
+    styling to GeoDeploy". Marker outline WIDTH and shape, and size-by-field, are now applied and read
+    back like everything else, and a push no longer deletes styling QGIS cannot draw (3D extrusion,
+    imported paint, popup fields) - it updates what it understands and leaves the rest.
+    0.1.11 - Change detection is right in both directions. Changing only a symbol's STROKE
     (or its marker shape) is now noticed - before, only the fill was read, so a stroke-only edit came
     back byte-identical and reported "unchanged". And opening a portal and pushing it straight back no
     longer reports every layer as restyled: a style read out of QGIS is always complete while a stored

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -302,6 +302,40 @@ class GeoDeployDock(QDockWidget):
             QgsNetworkAccessManager.setRequestPreprocessor(add_token)
         except Exception as exc:        # noqa: BLE001
             symbology._log("Could not install the auth preprocessor: {0}".format(exc))
+        self._install_gdal_auth()
+
+    def _install_gdal_auth(self):
+        """Attach the token to GDAL's OWN requests for this host, which Qt's preprocessor never sees.
+
+        `/vsicurl/` does not go through `QgsNetworkAccessManager` — GDAL has its own HTTP stack — so
+        everything read that way arrived unauthenticated. That is the COG, which is the only surface
+        a raster's real band values come from, and therefore the only way to restyle a raster in
+        QGIS: for a raster that was not shared publicly it could not be opened at all.
+
+        PATH-SPECIFIC, never global. `GDAL_HTTP_HEADERS` as a config option applies to every host
+        GDAL talks to, which would send this instance's bearer token to any `/vsicurl/` URL in the
+        project. Scoped to this instance's prefix or not set at all.
+        """
+        if not (self.instance and self.instance.token):
+            return
+        try:
+            from osgeo import gdal
+        except ImportError:             # pragma: no cover - QGIS always ships GDAL
+            return
+        setter = getattr(gdal, "SetPathSpecificOption", None)
+        if not callable(setter):
+            # GDAL < 3.6 has only the global option, and a token that leaks to other hosts is worse
+            # than a private raster that will not open. Say which it is.
+            symbology._log("This GDAL is too old to scope an auth header to one host, so private "
+                           "rasters cannot be opened as GeoTIFFs. Public ones are fine.",
+                           level="info")
+            return
+        try:
+            prefix = "/vsicurl/" + self.instance.url.rstrip("/")
+            setter(prefix, "GDAL_HTTP_HEADERS",
+                   "Authorization: Bearer {0}".format(self.instance.token))
+        except Exception as exc:        # noqa: BLE001 - never block a connection over this
+            symbology._log("Could not give GDAL the token: {0}".format(exc))
 
     def _capture_canvas(self):
         """The map canvas as a WebP file, or None. Used as the portal's card image.

--- a/integrations/qgis-plugin/geodeploy_qgis/portals.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/portals.py
@@ -361,6 +361,15 @@ def plan_push(group, style_for, current_configs) -> dict:
             seen.add((layer_id, layer_type))
             was = before.get((layer_id, layer_type))
             style = style_for(qgis_layer, layer_type) or {}
+            if style and (was or {}).get("style"):
+                # LAID OVER what the portal has, not swapped for it. A GeoDeploy style holds things
+                # QGIS cannot draw — 3D extrusion, raw MapLibre paint, popup fields — and replacing
+                # the whole style with the readable part deletes them. See `symbology.merge_style`.
+                try:
+                    from .symbology import merge_style
+                    style = merge_style(was["style"], style)
+                except Exception:       # noqa: BLE001 - outside QGIS, send what was read
+                    pass
             if not style and (was or {}).get("style"):
                 # AN UNREADABLE STYLE MUST NOT ERASE THE PORTAL'S.
                 #

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -107,13 +107,34 @@ CSS_PX_TO_POINTS = 0.75
 #: the defaults a layer with no saved style is ALREADY being drawn with in a browser, so matching
 #: them is what makes QGIS and the portal show the same map.
 DEFAULT_POINT_RADIUS = 5
-DEFAULT_POINT_STROKE = 1
+#: A marker's outline width is a RATIO OF ITS RADIUS, not a pixel width: `lib/markerImage.js` draws
+#: `lineWidth = radius * ratio`, and `services/symbology.marker_outline` says the same. 0.28 is what
+#: both use when a style omits it. The plugin used to write a flat 1 px — ratio 0.2 at the default
+#: radius, so a slightly thinner ring than the portal draws, and a width the user could not change
+#: because it was never read back either.
+DEFAULT_MARKER_OUTLINE_RATIO = 0.28
+DEFAULT_MARKER_OUTLINE = "#ffffff"
 #: And the polygon ones. `fill-opacity: opacity * style.get("fill_opacity", 0.45)` in
 #: portal_generator — so a polygon with no stated opacity is drawn at 45% on every portal there is.
 DEFAULT_FILL_OPACITY = 0.45
 DEFAULT_FILL_OUTLINE = "#1d4ed8"
 #: A line with no stated width is 2 CSS px on the map.
 DEFAULT_LINE_WIDTH = 2
+
+
+def _number(value, default):
+    """A finite float, or `default`. Styles arrive from JSON, a dialog and a QGIS getter."""
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return default
+    return out if out == out and out not in (float("inf"), float("-inf")) else default
+
+
+def _outline_px(style: dict) -> float:
+    """A marker's outline width in CSS pixels: `radius * outline_width`, the ratio the map uses."""
+    ratio = max(0.0, min(1.0, _number(style.get("outline_width"), DEFAULT_MARKER_OUTLINE_RATIO)))
+    return _number(style.get("radius"), DEFAULT_POINT_RADIUS) * ratio
 
 
 def _set_stroke_width(layer0, width: float) -> None:
@@ -199,12 +220,12 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
         if outline == "none":
             layer0.setStrokeStyle(Qt.NoPen)
         else:
-            # A WHITE hairline by default, because that is what the map draws
-            # (`circle-stroke-color: #ffffff`, `circle-stroke-width: 1`) — and because QGIS's own
+            # A WHITE ring by default, because that is what the map draws — and because QGIS's own
             # default is a dark grey outline, which on a small marker covers the fill completely
             # and turns every point black whatever colour the style asked for.
-            layer0.setStrokeColor(QColor(outline or "#ffffff"))
-            _set_stroke_width(layer0, DEFAULT_POINT_STROKE * CSS_PX_TO_POINTS)
+            layer0.setStrokeColor(QColor(outline or DEFAULT_MARKER_OUTLINE))
+            # radius (CSS px) x ratio = the stroke in CSS px, then into points like every other size.
+            _set_stroke_width(layer0, _outline_px(style) * CSS_PX_TO_POINTS)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
         _use_points(symbol, layer0)
         # Always set, defaulted to the map's `line-width: 2` — QGIS's own default is 0.26 mm, a
@@ -326,6 +347,8 @@ _STYLE_DEFAULTS = {
     "lineType": "solid",
     "fill_opacity": DEFAULT_FILL_OPACITY,
     "outline_color": "",                # geometry-dependent, so normalised below rather than here
+    "outline_width": DEFAULT_MARKER_OUTLINE_RATIO,
+    "size_mode": "fixed",
 }
 
 
@@ -349,7 +372,16 @@ def comparable_style(style: dict | None) -> dict:
     # collapse to one token rather than being compared as colours.
     if merged.get("outline_color") in ("", None, "#ffffff", DEFAULT_FILL_OUTLINE):
         merged["outline_color"] = "default"
-    for key in ("radius", "line_width", "fill_opacity"):
+    # A layer sized by a FIELD: the field and the two stops are what a viewer sees, and a stop read
+    # back out of an expression carries float noise, so they are rounded like every other number.
+    if merged.get("size_mode") != "proportional":
+        merged.pop("size_field", None)
+        merged.pop("size_stops", None)
+    elif isinstance(merged.get("size_stops"), list):
+        merged["size_stops"] = [[round(_number(a, 0), 3), round(_number(b, 0), 2)]
+                                for a, b in (pair for pair in merged["size_stops"]
+                                             if isinstance(pair, (list, tuple)) and len(pair) == 2)]
+    for key in ("radius", "line_width", "fill_opacity", "outline_width"):
         try:
             merged[key] = round(float(merged[key]), 3)
         except (TypeError, ValueError):
@@ -364,16 +396,64 @@ def comparable_style(style: dict | None) -> dict:
     # and folding them here would hide a real change and mislabel the map.
     for key in ("classes", "categories"):
         if isinstance(merged.get(key), list):
-            merged[key] = [
-                {k: (v.strip().lower() if k == "color" and isinstance(v, str) else v)
-                 for k, v in item.items()}
-                for item in merged[key] if isinstance(item, dict)]
+            merged[key] = [_comparable_class(item) for item in merged[key]
+                           if isinstance(item, dict)]
+    # DERIVED, not chosen: `classes_n` is `len(classes)`, and only one side bothers to write it.
+    merged.pop("classes_n", None)
     # A CLASSIFIED layer's single colour is not drawn — the classes are. Keeping it in the comparison
     # made an untouched categorized layer look edited, because the read-back fills it from the
     # catch-all entry while the stored style never had one.
     if merged.get("color_mode") in ("graduated", "categorized"):
         merged.pop("color", None)
+    # An outline that is switched OFF has no width to compare — and QGIS reports whatever width the
+    # pen had before it was disabled, which is not a difference a viewer can see.
+    if merged.get("outline_color") == "none":
+        merged.pop("outline_width", None)
     return merged
+
+
+def _comparable_class(item: dict) -> dict:
+    """One class or category, with its colour case-folded and its BOUNDS as floats.
+
+    A break written as `10` by a dialog and read back as `10.0` from QGIS is the same break; compared
+    as written it is a change. The category `value` is left exactly as it is — it is data, and "10"
+    and 10 really are different categories.
+    """
+    out = {}
+    for key, value in item.items():
+        if key == "color" and isinstance(value, str):
+            out[key] = value.strip().lower()
+        elif key in ("min", "max") and value is not None:
+            out[key] = _number(value, value)
+        else:
+            out[key] = value
+    return out
+
+
+def merge_style(stored: dict | None, read_back: dict | None) -> dict:
+    """`read_back` laid over `stored`, so properties QGIS cannot express are not DELETED by a push.
+
+    A GeoDeploy style holds more than QGIS can draw: 3D extrusion, raw MapLibre paint from a GeoLibre
+    import, popup fields. Replacing the whole style with what QGIS could read would silently drop all
+    of it — the same mistake as pushing `{}` over a raster's colormap, one level down. So a push
+    UPDATES the visual keys it understands and leaves the rest alone.
+
+    A change of `color_mode` still has to clear the previous mode's leftovers, or a layer switched
+    from graduated to single would keep a `classes` list that nothing draws and everything compares.
+    """
+    base = dict(stored or {})
+    fresh = {k: v for k, v in (read_back or {}).items() if v is not None}
+    if not fresh:
+        return base
+    if fresh.get("color_mode") and fresh["color_mode"] != base.get("color_mode"):
+        for key in ("classes", "classes_n", "categories", "other_color", "color_field"):
+            base.pop(key, None)
+    if fresh.get("size_mode") == "fixed" or (
+            "size_mode" in fresh and fresh["size_mode"] != "proportional"):
+        for key in ("size_field", "size_stops"):
+            base.pop(key, None)
+    base.update(fresh)
+    return base
 
 
 def apply(qgis_layer, style: dict, row: dict | None = None) -> bool:
@@ -1095,6 +1175,20 @@ def _style_from_symbol(symbol) -> dict:
         shape = _shape_name(layer0)
         if shape:
             style["marker"] = shape
+        # …and the outline WIDTH, back out of pixels into the ratio the map stores. Reported as
+        # "stroke color now works well, but stroke width doesn't seem to be saved" — it was never
+        # read, and never applied either.
+        stroke_pt = None
+        for getter in ("strokeWidth", "outlineWidth"):
+            fn = getattr(layer0, getter, None)
+            if callable(fn):
+                stroke_pt = _number(fn(), None)
+                if stroke_pt is not None:
+                    break
+        radius = style.get("radius") or DEFAULT_POINT_RADIUS
+        if stroke_pt is not None and radius:
+            ratio = stroke_pt / CSS_PX_TO_POINTS / float(radius)
+            style["outline_width"] = round(max(0.0, min(1.0, ratio)), 3)
     elif isinstance(layer0, QgsSimpleLineSymbolLayer):
         width = number(layer0.width)
         if width is not None:
@@ -1107,7 +1201,49 @@ def _style_from_symbol(symbol) -> dict:
         if opacity is not None:
             style["fill_opacity"] = round(opacity, 3)
         style["outline_color"] = _stroke_of(layer0)
+    style.update(_size_from_qgis(symbol, layer0))
     return style
+
+
+#: The expression `_apply_data_defined_size` writes, read back. Same shape, so the same five numbers
+#: come out — otherwise a layer sized BY A FIELD lost that on the way home, and the comparison then
+#: reported it as an edit nobody made.
+_SCALE_LINEAR = re.compile(
+    r'^\s*scale_linear\(\s*"(?P<field>[^"]+)"\s*,\s*(?P<in_lo>-?[\d.eE+]+)\s*,'
+    r'\s*(?P<in_hi>-?[\d.eE+]+)\s*,\s*(?P<out_lo>-?[\d.eE+]+)\s*,'
+    r'\s*(?P<out_hi>-?[\d.eE+]+)\s*\)\s*$')
+
+
+def _size_from_qgis(symbol, layer0) -> dict:
+    """`{size_mode, size_field, size_stops}` when the symbol is sized by a field, else `{}`."""
+    expression = None
+    try:
+        from qgis.core import QgsSymbolLayer
+        for holder, getter, key in (
+                (symbol, "dataDefinedSize", None),
+                (layer0, "dataDefinedProperty", QgsSymbolLayer.PropertyStrokeWidth)):
+            fn = getattr(holder, getter, None)
+            if not callable(fn):
+                continue
+            prop = fn() if key is None else fn(key)
+            text = getattr(prop, "expressionString", lambda: "")()
+            if text:
+                expression = str(text)
+                break
+    except Exception:                   # noqa: BLE001 - a size is never worth failing a read
+        return {}
+    if not expression:
+        return {}
+    m = _SCALE_LINEAR.match(expression)
+    if not m:
+        return {}
+    scale = 2 * CSS_PX_TO_POINTS if isinstance(layer0, QgsSimpleMarkerSymbolLayer) else CSS_PX_TO_POINTS
+    return {
+        "size_mode": "proportional",
+        "size_field": m.group("field"),
+        "size_stops": [[round(float(m.group("in_lo")), 6), round(float(m.group("out_lo")) / scale, 3)],
+                       [round(float(m.group("in_hi")), 6), round(float(m.group("out_hi")) / scale, 3)]],
+    }
 
 
 def _stroke_of(layer0) -> str:

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -51,6 +51,7 @@ class _SymbolLayer:
         self.stroke = None
         self.stroke_width = None
         self.pen = None
+        self.data_defined = None
 
     def setWidth(self, w):
         self._width = w
@@ -63,11 +64,24 @@ class _SymbolLayer:
         # Missing it here is how the first run of this test passed while the stroke went unset.
         self.stroke_width = w
 
+    def strokeWidth(self):
+        # And the GETTER, which QGIS has too. Without it the reader found no width to read and the
+        # round trip lost `outline_width` while the test looked like the code was at fault.
+        return self.stroke_width
+
     def setStrokeColor(self, c):
         self.stroke = c
 
+    def strokeColor(self):
+        # A GETTER, as in QGIS. Its absence made `_stroke_of` fall to its except branch and return
+        # "", which reads as "no outline stated" — so a stroke colour looked lost in the round trip.
+        return self.stroke if self.stroke is not None else _QColor("#000000")
+
     def setStrokeStyle(self, s):
         self.pen = s
+
+    def strokeStyle(self):
+        return self.pen if self.pen is not None else 1   # 1 = Qt.SolidLine
 
     def setPenStyle(self, s):
         self.pen = s
@@ -78,18 +92,30 @@ class _SymbolLayer:
     def setDataDefinedProperty(self, key, prop):
         self.data_defined = prop
 
+    def dataDefinedProperty(self, key):
+        return self.data_defined
+
 
 class QgsSimpleMarkerSymbolLayer(_SymbolLayer):
     def __init__(self):
         super().__init__()
-        self.shape = None
+        self._shape = None
 
     @staticmethod
     def decodeShape(name):
         return (name, True)
 
+    @staticmethod
+    def encodeShape(shape):
+        # The inverse, which QGIS also has. Missing it, `_shape_name` returned None and the marker
+        # SHAPE quietly failed to round-trip.
+        return shape
+
     def setShape(self, shape):
-        self.shape = shape
+        self._shape = shape
+
+    def shape(self):
+        return self._shape
 
 
 class QgsSimpleLineSymbolLayer(_SymbolLayer):
@@ -110,6 +136,7 @@ class _Symbol:
         self._color = _QColor("#000000")
         self._size = None
         self._opacity = 1.0
+        self._data_defined = None
         self._layer = _LAYER_FOR[geometry_type]()
 
     def setColor(self, c):
@@ -133,7 +160,12 @@ class _Symbol:
         return self._opacity
 
     def setDataDefinedSize(self, p):
-        self.data_defined = p
+        self._data_defined = p
+
+    def dataDefinedSize(self):
+        # QGIS returns a QgsProperty here; `_size_from_qgis` reads its expression back to recover
+        # size-by-field. Without the getter the round trip silently dropped it.
+        return self._data_defined
 
     def symbolLayerCount(self):
         return 1
@@ -201,6 +233,24 @@ for name in ("QgsCategorizedSymbolRenderer", "QgsGraduatedSymbolRenderer", "QgsR
              "QgsSingleBandPseudoColorRenderer", "QgsPalettedRasterRenderer", "QgsUnitTypes"):
     setattr(core, name, type(name, (_Stub,), {}))
 core.QgsUnitTypes.RenderPoints = 3
+
+
+class _Property:
+    """QgsProperty, as far as this needs it: an expression in, the same expression out."""
+
+    def __init__(self, expression=""):
+        self._e = expression
+
+    @staticmethod
+    def fromExpression(expression):
+        return _Property(expression)
+
+    def expressionString(self):
+        return self._e
+
+
+core.QgsProperty = _Property
+core.QgsSymbolLayer = type("QgsSymbolLayer", (), {"PropertyStrokeWidth": 42})
 core.QgsSymbol = QgsSymbol
 core.QgsSimpleMarkerSymbolLayer = QgsSimpleMarkerSymbolLayer
 core.QgsSimpleLineSymbolLayer = QgsSimpleLineSymbolLayer
@@ -315,8 +365,11 @@ assert out[0].symbol().size() == 5 * 2 * 0.75, ("a point with no radius must tak
                                             "(circle-radius 5), not QGIS's number under our unit")
 stroke = out[0].symbol().symbolLayer(0)
 assert stroke.stroke.name() == "#ffffff", "the map draws circle-stroke-color #ffffff"
-assert stroke.stroke_width == 1 * 0.75, "…at circle-stroke-width 1"
-print("styleless point -> portal defaults: radius 5, white 1px stroke")
+# The outline width is a RATIO OF THE RADIUS, not a pixel width: `markerImage` draws
+# `lineWidth = radius * ratio`, default 0.28. A flat 1 px — what this used to assert — is ratio 0.2
+# at the default radius, so the plugin drew a thinner ring than the portal.
+assert stroke.stroke_width == 5 * 0.28 * 0.75, stroke.stroke_width
+print("styleless point -> portal defaults: radius 5, white ring at 0.28 x radius")
 
 # An explicit outline still wins over the default.
 out = styles_for({"geometry_type": "point"}, {"color": "#3b82f6", "outline_color": "#000000"})
@@ -642,3 +695,88 @@ assert not differs({"color": "#3b82f6", "outline_color": "#ffffff"},
 print("cosmetic only      -> not reported")
 
 print("\nALL CHANGE-DETECTION CASES PASS")
+
+
+# ── EVERY property at once: written, read back, and compared ───────────────────────────────────
+# Asked for directly: "can we make sure that all these work at once?" So this walks the whole
+# supported set rather than the one that last broke.
+merge_style = ns["merge_style"]
+
+# The outline WIDTH travels. Reported as "stroke color now works well, but stroke width doesn't seem
+# to be saved" — it was neither applied nor read, and the map stores it as a ratio of the radius.
+out = round_trip({"geometry_type": "point"},
+                 {"color": "#3b82f6", "radius": 10, "outline_color": "#000000",
+                  "outline_width": 0.6})
+assert out["outline_width"] == 0.6, out
+assert out["radius"] == 10 and out["outline_color"] == "#000000", out
+print("outline width      -> survives the round trip as a ratio")
+
+base = {"color": "#3b82f6", "radius": 5, "outline_color": "#000000", "outline_width": 0.28}
+assert differs(base, dict(base, outline_width=0.6)), "a width change must register"
+assert not differs(base, dict(base))
+print("outline width      -> a change to it is detected")
+
+# SIZE BY A FIELD: the writer emits a scale_linear expression, so it has to read back out of one.
+sized = {"color": "#ef4444", "radius": 5, "size_mode": "proportional",
+         "size_field": "longitude", "size_stops": [[-176.2, 1], [178, 5]]}
+out = round_trip({"geometry_type": "point"}, sized)
+assert out.get("size_mode") == "proportional" and out.get("size_field") == "longitude", out
+assert out["size_stops"][0][1] == 1 and out["size_stops"][1][1] == 5, out
+assert not differs(sized, out), (sized, out)
+print("size by field      -> read back, and an untouched layer is not reported")
+assert differs(sized, dict(sized, size_field="latitude"))
+assert differs(sized, dict(sized, size_stops=[[-176.2, 2], [178, 9]]))
+assert differs(sized, {k: v for k, v in sized.items() if k != "size_mode"})
+print("size by field      -> field, stops and switching it off all detected")
+
+# MERGE, not replace: a push must not delete what QGIS cannot draw.
+stored = {"color": "#10b981", "fill_opacity": 0.45,
+          "extrusion": {"height_field": "h", "radius": 30},          # 3D — QGIS draws it flat
+          "maplibre": {"layers": [{"type": "fill", "paint": {"fill-color": "#123"}}]},
+          "popup_fields": ["name"]}
+merged = merge_style(stored, {"color": "#ff0000", "fill_opacity": 0.9, "color_mode": "single"})
+assert merged["color"] == "#ff0000" and merged["fill_opacity"] == 0.9, merged
+assert merged["extrusion"] == stored["extrusion"], "3D must survive a restyle from QGIS"
+assert merged["maplibre"] == stored["maplibre"], "imported raw paint must survive"
+assert merged["popup_fields"] == ["name"], "popup fields must survive"
+print("merge              -> keeps extrusion, raw paint and popup fields")
+
+# …but a change of MODE clears the previous mode's leftovers, which nothing would draw.
+was_graduated = {"color_mode": "graduated", "color_field": "pop",
+                 "classes": [{"min": None, "max": 10, "color": "#111111"}], "classes_n": 1}
+merged = merge_style(was_graduated, {"color_mode": "single", "color": "#ff0000"})
+assert "classes" not in merged and "color_field" not in merged, merged
+print("merge              -> a mode change drops the old mode's keys")
+
+# Switching size-by-field off clears the field and stops.
+merged = merge_style(sized, {"size_mode": "fixed", "color": "#ef4444"})
+assert "size_field" not in merged and "size_stops" not in merged, merged
+print("merge              -> fixed size drops the field and stops")
+
+# An empty read-back changes nothing at all — the raster case, one level down.
+assert merge_style(stored, {}) == stored
+assert merge_style(stored, None) == stored
+print("merge              -> nothing read means nothing changed")
+
+# Finally: EVERY supported visual property, one layer at a time, round-tripped and compared.
+cases = [
+    ("point",       {"color": "#3b82f6", "radius": 7, "marker": "square",
+                     "outline_color": "#112233", "outline_width": 0.4}),
+    ("point",       {"color": "#3b82f6", "radius": 4, "outline_color": "none"}),
+    ("LineString",  {"color": "#d1ba23", "line_width": 3, "lineType": "dotted"}),
+    ("MultiPolygon", {"color": "#10b981", "fill_opacity": 0.7, "outline_color": "#1d4ed8"}),
+    ("MultiPolygon", {"color": "#10b981", "outline_color": "none"}),
+    ("point",       {"color_mode": "categorized", "color_field": "k", "radius": 6,
+                     "categories": [{"value": "a", "color": "#111111"},
+                                    {"value": 2, "color": "#222222"}],
+                     "other_color": "#999999"}),
+    ("LineString",  {"color_mode": "graduated", "color_field": "pop", "line_width": 4,
+                     "classes": [{"min": None, "max": 10, "color": "#fee5d9"},
+                                 {"min": 10, "max": 90, "color": "#a50f15"}]}),
+]
+for geom, style in cases:
+    readback = round_trip({"geometry_type": geom}, style)
+    assert not differs(style, readback), (geom, style, readback)
+print("all properties     ->", len(cases), "styles round-trip with no phantom change")
+
+print("\nALL FULL-FIDELITY CASES PASS")


### PR DESCRIPTION
Asked to make it *all* work at once, so this is a systematic pass over every supported style property rather than another single fix.

## Why a raster could not be restyled — the blocker was server-side

A raster's real band values come **only** from its COG. `raster_cog` required `is_public` with **no authenticated path at all** — so the owner of an unshared raster could not open their own pixels, and "tick *Prefer the real data* and restyle the GeoTIFF" was advice that could not be followed.

Now readable by any signed-in user that `visible_to` already lets see the layer. That grants nothing new; it stops withholding pixels from people already entitled to them. Still stricter than the *description* endpoints: being shown a picture in a portal is not a licence to download the source data.

**GDAL needed the token separately.** `/vsicurl/` does not go through `QgsNetworkAccessManager`, so the Qt request preprocessor never touched it and every COG read went out anonymous. `_install_gdal_auth` sets `GDAL_HTTP_HEADERS` **path-specifically** for the instance prefix — never the global option, which would send this instance's bearer token to every `/vsicurl/` URL in the project. GDAL < 3.6 has only the global option, so it declines and says why.

## The properties that never travelled

| property | what was wrong |
|---|---|
| `outline_width` | a **ratio of the radius** (`lineWidth = radius × ratio`, default 0.28), not a pixel width. The plugin wrote a flat 1 px — ratio 0.2 — and never read it, so a width change was invisible |
| marker `shape` | written, never read |
| `size_mode`/`size_field`/`size_stops` | written as a `scale_linear` expression, never read — so a layer sized by a field lost it, then reported *itself* as edited |

## A push stopped deleting things

`merge_style` lays the read-back visual keys **over** the stored style, so 3D extrusion, imported MapLibre paint and popup fields survive a restyle from QGIS instead of being replaced by the subset QGIS can express. Same class of silent loss as pushing `{}` over a raster's colormap, one level down. A change of colour or size *mode* still clears the old mode's leftovers.

## Comparison

`comparable_style` covers the new keys, folds integer-vs-float class bounds (`10` vs `10.0`), and ignores the derived `classes_n`.

## Tests

Seven complete styles round-trip with no phantom change — point with shape and outline, point with no outline, dotted line, translucent polygon, polygon with no outline, categorized points with mixed value types, graduated lines. Plus each property individually in both directions, and the merge cases.

**Four of these bugs were hidden by the test double**: `strokeWidth`, `strokeColor`, `shape`/`encodeShape` and `QgsProperty` were all setter-only or absent, so the reader found nothing to read while the test stayed green. That pattern is now the thing I check first.

Plugin 0.1.12.
