### PR TITLE
Say which of the four interfaces to reach for

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,24 @@ Replace the host with your own instance, e.g. `https://geodeploy.example.org/api
 This page is deliberately a pointer rather than a copy of the endpoint list: a hand-written endpoint
 table is out of date the day after it is written.
 
+## Which interface should I use?
+
+Four ways in, all talking to the same API and enforcing the same permissions. Pick by what you are
+doing, not by what is most powerful:
+
+| | Reach for it when | Where |
+| --- | --- | --- |
+| **Dashboard** | you are looking at data, building a portal, or administering the instance | your instance in a browser |
+| **[QGIS plugin](qgis.md)** | the work is cartography — restyle a layer or a whole portal with QGIS's own tools, then publish back | Plugins ▸ Install from ZIP |
+| **[CLI](cli.md)** — `pip install geodeploy` | it should happen repeatedly or unattended: a nightly upload, a portal rebuilt in CI, a hundred files at once | any shell |
+| **Python client** — the same package | you are writing a script and want objects rather than parsing `--json` | `from geodeploy import Client` |
+| **HTTP API** | you are in another language, or building something GeoDeploy does not do | `/api/docs` |
+
+They are layers of one thing rather than alternatives: the QGIS plugin **vendors** the Python
+client, the CLI **is** that client with an argument parser, and the client is a thin wrapper over
+the HTTP API. Anything the plugin can do is therefore scriptable, and anything you can script is
+reachable from another language.
+
 ## Authenticating
 
 Two ways in:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,8 @@
 The CLI talks to the same API the dashboard uses, so anything you can do in the app you can script:
 a nightly upload from a field database, a portal rebuilt in CI, a hundred GeoTIFFs pushed in one
 command. It is also the Python client the **QGIS plugin** is built on, so what you learn here
-carries over.
+carries over. (Not sure which of the four interfaces you want?
+[Compare them](api-reference.md#which-interface-should-i-use).)
 
 ```bash
 pip install geodeploy

--- a/docs/qgis.md
+++ b/docs/qgis.md
@@ -4,7 +4,9 @@ Browse a GeoDeploy instance from inside QGIS, add its layers, restyle them, and 
 without exporting anything.
 
 The plugin talks to the same public API as everything else, so nothing is special-cased for it: what
-it can see is what your account can see, and what it publishes is what a portal serves.
+it can see is what your account can see, and what it publishes is what a portal serves. It vendors
+the same Python client the [CLI](cli.md) is built on — so anything you can do here, you can also
+script. ([Which interface should I use?](api-reference.md#which-interface-should-i-use))
 
 ## Which QGIS you need
 


### PR DESCRIPTION
The dashboard, QGIS plugin, CLI, Python client and HTTP API are each documented, but nothing said how they relate — so "I want to do X, where do I go?" had no short answer.

Adds a comparison table to the API reference, chosen by task rather than by capability, and states the relationship plainly: they are layers of one thing. The plugin vendors the Python client, the CLI is that client with an argument parser, and the client wraps the HTTP API.

Linked from `cli.md` and `qgis.md`.