### PR TITLE
Fix an unparseable metadata.txt, add tags and a package README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,15 @@ jobs:
           missing = [k for k in required if not g.get(k)]
           if missing:
               sys.exit(f"metadata.txt is missing: {missing}")
-          print("metadata.txt ok —", g["name"], g["version"])
+          # EVERY key, not just the required ones. ConfigParser interpolates on get(), so a bare
+          # `%` anywhere — "45% fill" in a changelog entry — raises InterpolationSyntaxError for
+          # whoever reads that key. QGIS and plugins.qgis.org parse this file the same way, and the
+          # old check passed happily because it never read the changelog.
+          for key in g:
+              g.get(key)
+          if not g.get("tags"):
+              sys.exit("metadata.txt has no tags — they are how the Plugin Manager finds it")
+          print("metadata.txt ok —", g["name"], g["version"], "| tags:", g["tags"][:40])
           PY
 
   ui:

--- a/integrations/qgis-plugin/geodeploy_qgis/README.md
+++ b/integrations/qgis-plugin/geodeploy_qgis/README.md
@@ -1,0 +1,38 @@
+# GeoDeploy for QGIS
+
+Browse a [GeoDeploy](https://github.com/bravemaster3/GeoDeploy) instance from inside QGIS, add its
+layers, restyle them, and publish back — without exporting anything.
+
+**Full documentation: <https://docs-geodeploy.kndev.org/qgis/>**
+
+## What it does
+
+- **Browse an instance** by pasting its URL. No account is needed for public data; a token adds
+  whatever else you can see.
+- **Add a layer** from the fastest source it offers — vector tiles, OGC API - Features, a COG or a
+  PMTiles archive — chosen per layer, with a picker that says what each one costs.
+- **Open a portal as a QGIS group**, in its own order, folders and styling. Either as the portal
+  draws it, or with every layer opened from its data so all of QGIS's symbology applies.
+- **Restyle and publish back.** Symbology travels both ways: single symbol, graduated and
+  categorized; colour, marker, size, line width and dash, fill opacity, outline colour and width;
+  size from a field; and for rasters the colour ramp, stretch, band, classes, hillshade and
+  contours.
+- **Upload** a QGIS layer, including multi-gigabyte files, which go straight to object storage.
+
+## Requirements
+
+QGIS **3.28** or newer. Nothing to install: the Python client is vendored, so the plugin has no
+dependencies.
+
+## Known limitations
+
+- 3D extrusion is carried safely — a round trip cannot delete it — but is **not drawn** in QGIS's
+  3D view yet.
+- Symbology QGIS has and GeoDeploy does not (inverted polygons, 2.5D, hatch and gradient fills,
+  rule-based rendering, labels) is simplified on the way in and not carried back.
+
+Both are tracked on the [roadmap](https://docs-geodeploy.kndev.org/roadmap/).
+
+## Licence and issues
+
+Apache-2.0. Issues and source: <https://github.com/bravemaster3/GeoDeploy>

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -13,6 +13,10 @@ email=noumonvikoffidodji@hotmail.fr
 tracker=https://github.com/bravemaster3/GeoDeploy/issues
 repository=https://github.com/bravemaster3/GeoDeploy
 homepage=https://docs-geodeploy.kndev.org/qgis/
+; Tags are how somebody finds this in the Plugin Manager's search. The cookbook asks for
+; informative ones — "vector" tells a reader nothing, "geoparquet" tells them whether this is for
+; them — so these name the SURFACES and formats the plugin actually speaks.
+tags=web,cloud,server,upload,publish,style,symbology,portal,webmap,ogc,stac,cog,pmtiles,geoparquet,postgis
 category=Web
 icon=icon.png
 experimental=True
@@ -122,7 +126,7 @@ changelog=0.3.0 - First public release. Browse a GeoDeploy instance (no account 
     that describe a layer are fetched once and reused - in the background thread, not between
     layers. A portal opened WITHOUT an account now uses the portal's own colours, width, outline and
     transparency rather than each layer's default style, and no longer loses a layer when a vector
-    and a raster share an id. Polygons are drawn at the map's 45% fill, lines at its default width.
+    and a raster share an id. Polygons are drawn at the map's 0.45 fill opacity, lines at its default width.
     0.1.3 - A raster opened as part of a portal is drawn the way THAT portal draws it, not
     in the layer's default style - the portal bakes its colormap, stretch and hillshade into its own
     tile URL, and the same raster can look different in two portals. Layer opacity now travels in as


### PR DESCRIPTION
Checking the zip against the [official rules](https://docs.qgis.org/3.44/en/docs/pyqgis_developer_cookbook/plugins/releasing.html) found a bug CI could not see.

**`metadata.txt` contained a literal `%`** ("the map's 45% fill" in a changelog entry). ConfigParser interpolates on `get()`, so reading that key raises `InterpolationSyntaxError` — and QGIS and plugins.qgis.org parse this file the same way, with the site displaying the changelog. The existing CI check passed because it only read the nine required fields and never touched the changelog; it now reads **every** key.

Also adds `tags` (how the Plugin Manager finds it) and a README inside the package, both cookbook recommendations we did not meet.