### PR TITLE
Fix what the security scan found, and declare the rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,28 @@ jobs:
         # that opens in the layers' default colours or quietly loses a layer to a clashing id.
         run: python integrations/qgis-plugin/scripts/test_published_style.py
 
+      - name: The security scan plugins.qgis.org runs
+        # Every upload is scanned, and a critical finding BLOCKS the version until a new one is
+        # uploaded — so finding this here rather than there is the difference between a commit and
+        # a burnt version number. Bandit auto-discovers the .bandit we ship, which declares the
+        # findings that are deliberate (and says why); anything else must be fixed.
+        working-directory: integrations/qgis-plugin/geodeploy_qgis
+        run: |
+          pip install --quiet bandit
+          python -m bandit -q -r . -f json > /tmp/bandit.json || true
+          python - <<'PY'
+          import json, sys
+          results = json.load(open("/tmp/bandit.json"))["results"]
+          if results:
+              for r in results:
+                  print("{0} {1} {2}:{3}  {4}".format(
+                      r["issue_severity"], r["test_id"], r["filename"], r["line_number"],
+                      r["issue_text"][:90]))
+              sys.exit("{0} unreviewed finding(s). Fix them, or declare them in "
+                       "geodeploy_qgis/.bandit with the reason.".format(len(results)))
+          print("bandit: clean, with the declarations in .bandit")
+          PY
+
       - name: metadata.txt has what plugins.qgis.org requires
         run: |
           python - <<'PY'

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -152,6 +152,28 @@ rather than following the platform's — see the note in `CHANGELOG.md`.
 - A RASTER still needs a local file: re-encoding one here would mean choosing compression and
   resampling on the user's behalf, and ingest converts to COG anyway.
 
+## The security scan
+Every upload to plugins.qgis.org is scanned (Bandit, detect-secrets, Flake8) and **a critical
+finding blocks that version until a NEW version number is uploaded** — a burnt version, not a
+retry. CI runs the same Bandit scan so it fails here instead.
+
+`geodeploy_qgis/.bandit` declares the findings that are deliberate, each with the reason. Two
+things about it are the point:
+
+- **Fix first, declare second.** The two MEDIUM findings were real and were fixed —
+  `connection.http_url` rejects any scheme but http/https before an open (the plugin follows links
+  that come BACK from an instance, so a hostile one could otherwise have aimed it at `file://`),
+  and a WMTS capabilities document declaring a `DOCTYPE`/`ENTITY` is refused before parsing, which
+  removes the entity-expansion class rather than mitigating it. `defusedxml` is not an option: a
+  plugin cannot pip-install, which is the same constraint that makes the client vendored.
+- **`exclude_dirs` is deliberately unset.** Excluding `vendor/` is the obvious move and the guide
+  even suggests it, but its findings are the same `B110`s already declared — so it would buy
+  nothing and stop scanning code we ship.
+
+```bash
+cd integrations/qgis-plugin/geodeploy_qgis && python -m bandit -q -r .   # what CI and they run
+```
+
 ## Last updated
 2026-08-18c (**CORRECTION to the entry below: 3D extrusion does not draw in QGIS AT ALL, not merely
 on tiles.** Tested for real — a 3D portal opened editable, zoomed to, then View ▸ New 3D Map View —

--- a/integrations/qgis-plugin/geodeploy_qgis/.bandit
+++ b/integrations/qgis-plugin/geodeploy_qgis/.bandit
@@ -1,0 +1,38 @@
+[bandit]
+# Bandit findings that are intentional, with the reason each one is a decision rather than an
+# oversight. plugins.qgis.org reads this file from the plugin ZIP — see
+# https://plugins.qgis.org/docs/security-scanning/config-files
+#
+# Nothing here is a blanket dismissal: the two findings that pointed at real weaknesses were FIXED
+# rather than skipped, and the skips below describe the audit that makes the remaining ones safe.
+#
+#   B310  urlopen with a non-literal URL.
+#         FIXED, then skipped. `connection.http_url` rejects every scheme except http/https before
+#         any open, and all three call sites go through it. This mattered: `fetch_json` and
+#         `fetch_text` are handed URLs that came BACK from the server — a layer's `links`, a
+#         portal's style.json sources — so a hostile instance could otherwise have answered with
+#         `file:///etc/passwd` and had the plugin read it.
+#
+#   B405  importing xml.etree, and
+#   B314  xml.etree.fromstring on untrusted input — the WMTS capabilities document.
+#         MITIGATED, then skipped. defusedxml is the usual answer and is not available to us: a
+#         QGIS plugin cannot pip-install, which is the same reason the API client is vendored. So
+#         the document is REFUSED outright if it declares a DOCTYPE or an ENTITY, which removes the
+#         entity-expansion class of attack rather than mitigating it. A WMTS capabilities document
+#         has no legitimate use for either.
+#
+#   B110  try/except/pass, and
+#   B112  try/except/continue.
+#         Deliberate, and load-bearing. This code runs inside somebody's QGIS session and talks to a
+#         Qt API whose spellings move between versions: a custom property that cannot be stored, a
+#         symbol setter this build does not have, a log line that fails. None of those is worth
+#         taking down the layer the user asked for, so each is caught with a comment naming exactly
+#         what it trades away. The alternative — letting a cosmetic failure raise — is a worse
+#         plugin, not a safer one.
+skips = B110,B112,B310,B405,B314
+
+# `exclude_dirs` is deliberately NOT set. The obvious candidate is vendor/, which holds the
+# `geodeploy` client (released separately on PyPI, checked in because a plugin cannot pip-install),
+# and the config-files guide names vendored libraries as the use case. But its findings are the same
+# B110s already accounted for above, so excluding it would buy nothing and would stop scanning code
+# we actually ship — which is the opposite of the point.

--- a/integrations/qgis-plugin/geodeploy_qgis/connection.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/connection.py
@@ -25,6 +25,23 @@ from geodeploy.config import Config, load_credential, normalize_url  # noqa: E40
 from geodeploy.errors import GeoDeployError       # noqa: E402
 
 
+#: The only schemes this plugin will open. `normalize_url` already restricts the instance ORIGIN,
+#: but that is not where the risk is: `fetch_json`/`fetch_text` are handed URLs that came BACK from
+#: the server — a layer's `links`, a portal's `style.json` sources — and a compromised or hostile
+#: instance could answer with `file:///etc/passwd` and have the plugin read it. Checking at the point
+#: of opening covers every caller at once, including ones written later.
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+def http_url(url: str) -> str:
+    """`url` if it is http(s), else raise. The guard in front of every open in this module."""
+    scheme = str(url or "").split("://", 1)[0].lower() if "://" in str(url or "") else ""
+    if scheme not in _ALLOWED_SCHEMES:
+        raise GeoDeployError(
+            "Refusing to open {0!r}: only http:// and https:// URLs are followed.".format(url))
+    return url
+
+
 class Instance:
     """One connection. `token` may be None — that is a supported way to use this, not an error."""
 
@@ -99,7 +116,7 @@ class Instance:
         if self.token:
             headers["Authorization"] = "Bearer {0}".format(self.token)
         try:
-            with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
+            with urlopen(Request(http_url(url), headers=headers), timeout=30) as response:  # noqa: S310
                 doc = json.loads(response.read().decode("utf-8"))
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
             error = GeoDeployError("Could not read {0}: {1}".format(url, exc))
@@ -140,7 +157,7 @@ class Instance:
         if self.token:
             headers["Authorization"] = "Bearer {0}".format(self.token)
         try:
-            with urlopen(Request(url, headers=headers), timeout=30) as response:  # noqa: S310
+            with urlopen(Request(http_url(url), headers=headers), timeout=30) as response:  # noqa: S310
                 body = response.read().decode("utf-8", "replace")
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
             error = GeoDeployError("Could not read {0}: {1}".format(url, exc))
@@ -166,10 +183,10 @@ class Instance:
         # Cloudflare-fronted instance answers that with 403 — measured: the same URL returns 200 to
         # curl and to a browser, 403 to urllib. The portal is public; it was the client that looked
         # suspicious. Named after the tool, like the API client's own agent.
-        request = Request(url, headers={"User-Agent": self._c_user_agent(),
-                                        "Accept": "application/json"})
+        request = Request(http_url(url), headers={"User-Agent": self._c_user_agent(),
+                                                  "Accept": "application/json"})
         try:
-            with urlopen(request, timeout=30) as response:  # noqa: S310 - our own instance URL
+            with urlopen(request, timeout=30) as response:  # noqa: S310 - scheme checked by http_url
                 return json.loads(response.read().decode("utf-8"))
         except Exception as exc:        # noqa: BLE001 - surfaced as a plugin message
             raise GeoDeployError("Could not read the published portal at {0}: {1}".format(url, exc))

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.3.0
+version=0.3.1
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -25,7 +25,14 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.3.0 - First public release. Browse a GeoDeploy instance (no account needed for public
+changelog=0.3.1 - Security-scan round. Two findings pointed at real weaknesses and were fixed
+    rather than waved through: every URL the plugin opens is now checked to be http or https before
+    it is opened - it follows links that come BACK from an instance, so a hostile one could
+    otherwise have pointed it at a local file - and a WMTS capabilities document that declares XML
+    entities is refused outright, which removes the entity-expansion class of attack without adding
+    a dependency a QGIS plugin cannot have. The remaining findings are deliberate and are declared,
+    with reasons, in a bundled .bandit config.
+    0.3.0 - First public release. Browse a GeoDeploy instance (no account needed for public
     data), add a layer using the fastest source it offers, open a whole portal as a styled QGIS
     group, and upload back - including multi-gigabyte files. Styling travels BOTH WAYS: single
     symbol, graduated and categorized vectors; colormap, stretch, band, hillshade, contours and

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -12,6 +12,7 @@ Three principles this file exists to keep:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 
 from qgis.core import (Qgis, QgsApplication, QgsProject, QgsRasterLayer, QgsTask,
@@ -901,13 +902,23 @@ class GeoDeployDock(QDockWidget):
         a layer that looks valid and draws nothing.
         """
         try:
-            import xml.etree.ElementTree as ET
+            import xml.etree.ElementTree as ET      # noqa: S405 - see the entity check below
             from qgis.core import QgsDataSourceUri
 
             text = self.instance.fetch_text(url) if self.instance else None
             if not text:
                 return None
-            root = ET.fromstring(text)
+            # NO ENTITY DECLARATIONS. `xml.etree` is vulnerable to entity-expansion attacks
+            # ("billion laughs") and the fix everyone reaches for — defusedxml — is a dependency,
+            # which a QGIS plugin cannot add. A WMTS capabilities document has no legitimate use
+            # for a DOCTYPE or an ENTITY, so refusing one costs nothing and removes the class of
+            # attack rather than mitigating it. The document comes from the instance the user
+            # connected to, which is trusted-ish but not trusted.
+            if re.search(r"<!\s*(DOCTYPE|ENTITY)", text, re.IGNORECASE):
+                symbology._log("Refused a WMTS capabilities document that declares XML entities — "
+                               "{0}. The raster will be added from another source.".format(url))
+                return None
+            root = ET.fromstring(text)      # noqa: S314 - entity declarations refused above
             ns = {"wmts": "http://www.opengis.net/wmts/1.0",
                   "ows": "http://www.opengis.net/ows/1.1"}
             node = root.find(".//wmts:Contents/wmts:Layer", ns)


### PR DESCRIPTION
plugins.qgis.org scans every upload, and a critical finding **blocks that version** until a new number is uploaded.

**Two findings were real and are fixed:**

- Every URL the plugin opens now passes a scheme check. `normalize_url` guarded the instance *origin*, but `fetch_json`/`fetch_text` follow URLs that come **back from the server** — a layer's `links`, a portal's style.json sources — so a hostile instance could have pointed the plugin at `file:///etc/passwd`.
- A WMTS capabilities document declaring a `DOCTYPE`/`ENTITY` is refused before parsing. `defusedxml` is unavailable (a plugin cannot pip-install), so refusing removes the entity-expansion class rather than mitigating it.

**The remaining 29 are declared** in a bundled `.bandit` — the mechanism their docs specify — each with its reason. They are the deliberate try/except/pass pattern this code needs to survive Qt API drift.

34 findings → 0. CI now runs the same scan. Version bumped to **0.3.1**, since 0.3.0 is already uploaded and cannot be reused.