### PR TITLE
Read every enum in a way that works on Qt5 and Qt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,12 @@ jobs:
         # that opens in the layers' default colours or quietly loses a layer to a clashing id.
         run: python integrations/qgis-plugin/scripts/test_published_style.py
 
+      - name: Enums resolve on Qt5 and Qt6 alike
+        # QGIS 4 is Qt6, where an enum member is only reachable through its scope. The migration
+        # touched 94 call sites; one flat `Qgis.Warning` typed later would be invisible until a user
+        # on QGIS 4 hit that path, so the test walks the AST of every module and refuses one.
+        run: python integrations/qgis-plugin/scripts/test_qt6_compat.py
+
       - name: The security scan plugins.qgis.org runs
         # Every upload is scanned, and a critical finding BLOCKS the version until a new one is
         # uploaded — so finding this here rather than there is the difference between a commit and

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -152,6 +152,21 @@ rather than following the platform's — see the note in `CHANGELOG.md`.
 - A RASTER still needs a local file: re-encoding one here would mean choosing compression and
   resampling on the user's behalf, and ingest converts to COG anyway.
 
+## Qt6 / QGIS 4
+QGIS 4 is Qt6, where an enum member is only reachable through its scope — `Qt.PenStyle.NoPen`, not
+`Qt.NoPen`. The plugin has to run on both, since its floor is QGIS 3.28 (Qt5), so `compat.enum`
+asks for the scoped name and falls back to the flat one. Every enum read goes through it;
+`scripts/test_qt6_compat.py` walks the AST of every module and fails on a flat one, because the
+migration was mechanical across 94 sites and a single one typed later would be invisible until a
+user on QGIS 4 hit that path.
+
+**Do not apply the plugins.qgis.org Qt6 report verbatim.** It reports
+`QLineEdit.Password` as *"add 'EchoMode' before 'Password'"*, which reads as `Qt.EchoMode.Password`
+— a name that does not exist, because `EchoMode` belongs to `QLineEdit`. Every scope in the map was
+resolved against the real class instead. And not everything capitalised is an enum:
+`QgsVectorFileWriter.SaveVectorOptions` and `QgsColorRampShader.ColorRampItem` are classes, and
+scoping them would be a silent `AttributeError`.
+
 ## The security scan
 Every upload to plugins.qgis.org is scanned (Bandit, detect-secrets, Flake8) and **a critical
 finding blocks that version until a NEW version number is uploaded** — a burnt version, not a retry.

--- a/integrations/qgis-plugin/geodeploy_qgis/compat.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/compat.py
@@ -1,0 +1,36 @@
+"""Enum access that works on Qt5 and Qt6 alike.
+
+QGIS 4 moves to Qt6, where enum members are only reachable through their enclosing scope:
+`Qt.NoPen` becomes `Qt.PenStyle.NoPen`, `Qgis.Warning` becomes `Qgis.MessageLevel.Warning`. The
+plugin has to run on both — our declared floor is QGIS 3.28, which is Qt5 — so it cannot simply be
+rewritten to the new spelling and it cannot stay on the old one.
+
+`enum()` asks for the scoped name and falls back to the flat one, which is exactly the overlap:
+every Qt5 build that has `Qt.PenStyle.NoPen` gives the identical value as `Qt.NoPen`, and the few
+that do not still answer the flat name. Verified against PyQt5 5.15 for every name this plugin uses.
+
+TWO TRAPS THIS EXISTS TO AVOID, both found rather than imagined:
+
+* **The scope is not always the class you are calling.** QGIS's Qt6 checker reports
+  `QLineEdit.Password` as "add 'EchoMode' before 'Password'", which reads as `Qt.EchoMode.Password`
+  — a name that does not exist. `EchoMode` belongs to `QLineEdit`. Applying the checker's advice
+  literally breaks the connect dialog, so every scope here was resolved against the real class.
+* **Not everything capitalised is an enum.** `QgsVectorFileWriter.SaveVectorOptions` and
+  `QgsColorRampShader.ColorRampItem` are CLASSES. Scoping those would be a silent AttributeError.
+"""
+from __future__ import annotations
+
+
+def enum(owner, scope: str, name: str):
+    """`owner.scope.name` when this Qt has scoped enums, else `owner.name`.
+
+    Resolved at the call site rather than cached in a module constant, because most of the QGIS
+    classes involved are imported lazily inside functions — a module-level constant would have to
+    import them at load time, which is the one thing `__init__.py` must not do.
+    """
+    holder = getattr(owner, scope, None)
+    if holder is not None:
+        value = getattr(holder, name, None)
+        if value is not None:
+            return value
+    return getattr(owner, name)

--- a/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/diffdialog.py
@@ -12,6 +12,11 @@ layers — are separate opt-ins rather than one blanket "OK". Unchanged layers a
 """
 from __future__ import annotations
 
+try:                                    # a package, inside QGIS
+    from .compat import enum
+except ImportError:                     # pragma: no cover - exec'd standalone by the test harness
+    from compat import enum
+
 try:                                    # pragma: no cover - only present inside QGIS
     from qgis.PyQt.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QLabel, QVBoxLayout,
                                      QTextEdit)
@@ -119,7 +124,7 @@ def confirm(parent, portal_title: str, plan: dict, creating: bool):
     buttons.rejected.connect(dialog.reject)
     layout.addWidget(buttons)
 
-    if dialog.exec_() != QDialog.Accepted:
+    if dialog.exec() != enum(QDialog, "DialogCode", "Accepted"):
         return (False, False, False)
     return (True, upload_box.isChecked() and bool(uploads),
             drop_box.isChecked() and bool(removed))

--- a/integrations/qgis-plugin/geodeploy_qgis/export.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/export.py
@@ -23,6 +23,10 @@ from qgis.core import (QgsCoordinateTransformContext, QgsVectorFileWriter, QgsVe
 
 from .vendor.geodeploy.uploads import (GEOPARQUET_EXTENSIONS, LARGE_VECTOR_EXTENSIONS,
                                        RASTER_EXTENSIONS)
+try:                                    # a package, inside QGIS
+    from .compat import enum
+except ImportError:                     # pragma: no cover - exec'd standalone by the test harness
+    from compat import enum
 
 # What the server will actually take. Imported rather than restated: a list copied into the plugin
 # would drift from the client's, and the user would learn about it as an HTTP 400 mid-upload.
@@ -126,7 +130,7 @@ def prepare(layer, on_status=None) -> tuple[str, bool]:
         layer, tmp, QgsCoordinateTransformContext(), options)
     # V3 returns (errorCode, errorMessage) on modern QGIS and a 3-tuple on some builds.
     code = error[0] if isinstance(error, (tuple, list)) else error
-    if code != QgsVectorFileWriter.NoError:
+    if code != enum(QgsVectorFileWriter, "WriterError", "NoError"):
         message = error[1] if isinstance(error, (tuple, list)) and len(error) > 1 else code
         raise NotUploadable(f"QGIS could not write this layer out: {message}")
     return tmp, True

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -6,7 +6,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.3.2
+version=0.3.3
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -25,7 +25,12 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.3.2 - The 0.3.1 security declarations are applied inline instead of in a bundled
+changelog=0.3.3 - Ready for QGIS 4. Qt6 only reaches an enum member through its scope
+    (Qt.PenStyle.NoPen, not Qt.NoPen), so every one of the 94 places this plugin read an enum now
+    goes through a small resolver that asks for the scoped name and falls back to the flat one -
+    which keeps QGIS 3.28 working exactly as before. Dialogs call exec() rather than the removed
+    exec_(). No behaviour changes on QGIS 3.
+    0.3.2 - The 0.3.1 security declarations are applied inline instead of in a bundled
     .bandit file. plugins.qgis.org runs bandit with an explicit list of tests, and a config file
     that skips any of them makes bandit abort without scanning anything - which is what the 0.3.1
     scan report showed. Same declarations, same fixes, now honoured.

--- a/integrations/qgis-plugin/geodeploy_qgis/plugin.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/plugin.py
@@ -25,6 +25,10 @@ from qgis.PyQt.QtWidgets import (QAbstractItemView, QAction, QCheckBox, QComboBo
 from . import (diffdialog, export, portals as portal_sync, sources, symbology,
                uploadpicker)
 from .connection import GeoDeployError, Instance, saved_instances
+try:                                    # a package, inside QGIS
+    from .compat import enum
+except ImportError:                     # pragma: no cover - exec'd standalone by the test harness
+    from compat import enum
 
 PLUGIN_NAME = "GeoDeploy"
 
@@ -33,7 +37,7 @@ class _Job(QgsTask):
     """Run one client call off the UI thread. `finished_ok(result)` / `failed(message)`."""
 
     def __init__(self, description, fn):
-        super().__init__(description, QgsTask.CanCancel)
+        super().__init__(description, enum(QgsTask, "Flag", "CanCancel"))
         self._fn = fn
         self.result = None
         self.error = ""
@@ -127,7 +131,7 @@ class GeoDeployDock(QDockWidget):
 
         self.token = QLineEdit()
         self.token.setPlaceholderText("API token (optional — public data needs none)")
-        self.token.setEchoMode(QLineEdit.Password)
+        self.token.setEchoMode(enum(QLineEdit, "EchoMode", "Password"))
         outer.addWidget(self.token)
 
         self.status = QLabel("Not connected.")
@@ -137,7 +141,7 @@ class GeoDeployDock(QDockWidget):
         # -- layers -------------------------------------------------------------------------------
         self.tree = QTreeWidget()
         self.tree.setHeaderLabels(["Layer", "Kind", "Features"])
-        self.tree.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.tree.setSelectionMode(enum(QAbstractItemView, "SelectionMode", "SingleSelection"))
         self.tree.itemDoubleClicked.connect(lambda *_: self.add_selected())
         outer.addWidget(self.tree, 1)
 
@@ -243,7 +247,7 @@ class GeoDeployDock(QDockWidget):
 
     # -- helpers -----------------------------------------------------------------------------------
 
-    def _say(self, text, level=Qgis.Info, bar=True):
+    def _say(self, text, level=enum(Qgis, "MessageLevel", "Info"), bar=True):
         """`bar=False` for progress: the dock label updates, the message bar does not.
 
         QGIS's message bar is a STACK. Pushing "Uploading…" and then pushing a failure on top means
@@ -259,7 +263,7 @@ class GeoDeployDock(QDockWidget):
         bar_widget.clearWidgets()
         # A warning or an error waits to be dismissed. Six seconds is fine for "done"; it is not
         # fine for the one message that explains why the thing you asked for did not happen.
-        duration = 0 if level in (Qgis.Warning, Qgis.Critical) else 6
+        duration = 0 if level in (enum(Qgis, "MessageLevel", "Warning"), enum(Qgis, "MessageLevel", "Critical")) else 6
         bar_widget.pushMessage(PLUGIN_NAME, text, level=level, duration=duration)
 
     def _apply_auth_ui(self):
@@ -305,7 +309,7 @@ class GeoDeployDock(QDockWidget):
             # Older QGIS: private layers over OAPIF will not open, but everything else works.
             self._say("This QGIS is too old to attach a token to its own requests, so private "
                       "layers cannot be added as OGC API - Features. Public layers are fine.",
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
             return
         host = (QUrl(self.instance.url).host() or "").lower()
         token = self.instance.token
@@ -413,7 +417,7 @@ class GeoDeployDock(QDockWidget):
     def connect_to_instance(self):
         url = (self.url.currentText() or "").strip()
         if not url:
-            self._say("Enter the instance URL first.", Qgis.Warning)
+            self._say("Enter the instance URL first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         token = (self.token.text() or "").strip() or None
         if not token:
@@ -425,7 +429,7 @@ class GeoDeployDock(QDockWidget):
         try:
             self.instance = Instance(url, token)
         except Exception as exc:                      # noqa: BLE001 - a bad URL is a message
-            self._say(f"That URL will not do: {exc}", Qgis.Critical)
+            self._say(f"That URL will not do: {exc}", enum(Qgis, "MessageLevel", "Critical"))
             return
         self._busy(True)
         self._run(_Job("GeoDeploy: connecting", self.instance.check), self._connected)
@@ -433,7 +437,7 @@ class GeoDeployDock(QDockWidget):
     def _connected(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         info = job.result or {}
         # Before any layer is added: an OAPIF layer is fetched by QGIS itself, so the token has to
@@ -475,7 +479,7 @@ class GeoDeployDock(QDockWidget):
     def _listed(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         result = job.result or {}
         self._rows = result.get("layers") or []
@@ -495,7 +499,7 @@ class GeoDeployDock(QDockWidget):
             item = QTreeWidgetItem(parent, [row.get("name") or "?",
                                             row.get("geometry_type") or backend,
                                             f"{count:,}" if isinstance(count, int) else ""])
-            item.setData(0, Qt.UserRole, row)
+            item.setData(0, enum(Qt, "ItemDataRole", "UserRole"), row)
         # Portals last: they are things to LOOK at rather than add, so they sit below the data.
         if self._portals:
             parent = QTreeWidgetItem(self.tree, ["Portals"])
@@ -517,7 +521,7 @@ class GeoDeployDock(QDockWidget):
                 # everything downstream — the group name, the status messages — read `title` off
                 # this dict, found nothing, and fell back to the slug. Anonymous rows carry a title
                 # like authenticated ones do, so there was never a reason for the two to differ.
-                item.setData(0, Qt.UserRole, dict(portal, _portal=True, slug=slug,
+                item.setData(0, enum(Qt, "ItemDataRole", "UserRole"), dict(portal, _portal=True, slug=slug,
                                                   _base=self.instance.url if self.instance else ""))
 
         if not self._rows and not self._portals:
@@ -527,7 +531,7 @@ class GeoDeployDock(QDockWidget):
 
     def _selected_row(self) -> dict | None:
         items = self.tree.selectedItems()
-        return items[0].data(0, Qt.UserRole) if items else None
+        return items[0].data(0, enum(Qt, "ItemDataRole", "UserRole")) if items else None
 
     def _on_selection_changed(self):
         """A portal cannot be added to the map, so the button says what it WILL do instead."""
@@ -623,20 +627,20 @@ class GeoDeployDock(QDockWidget):
     def add_selected(self):
         row = self._selected_row()
         if not row:
-            self._say("Pick a layer first.", Qgis.Warning)
+            self._say("Pick a layer first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         if row.get("_portal"):
             self._open_portal(row)
             return
         source = self._chosen_source(row)
         if not source:
-            self._say("That layer offers nothing QGIS can read yet.", Qgis.Warning)
+            self._say("That layer offers nothing QGIS can read yet.", enum(Qgis, "MessageLevel", "Warning"))
             return
 
         name = row.get("name") or "GeoDeploy layer"
         layer, source = self._open_best(row, source, name)
         if layer is None:
-            self._say(f"QGIS could not open the {source['kind']} source for {name}.", Qgis.Critical)
+            self._say(f"QGIS could not open the {source['kind']} source for {name}.", enum(Qgis, "MessageLevel", "Critical"))
             return
 
         # EVERYTHING BEFORE THE LAYER GOES ON THE MAP. Adding it first and styling it after is what
@@ -1055,7 +1059,7 @@ class GeoDeployDock(QDockWidget):
         """
         row = self._selected_row()
         if not row or not row.get("_portal"):
-            self._say("Select a portal in the list first.", Qgis.Warning)
+            self._say("Select a portal in the list first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         if not self.instance:
             return
@@ -1109,12 +1113,12 @@ class GeoDeployDock(QDockWidget):
     def _portal_opened(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         doc = job.result or {}
         configs = doc.get("layer_configs") or []
         if not configs:
-            self._say("That portal has no layers yet.", Qgis.Warning)
+            self._say("That portal has no layers yet.", enum(Qgis, "MessageLevel", "Warning"))
             return
 
         project = QgsProject.instance()
@@ -1278,7 +1282,7 @@ class GeoDeployDock(QDockWidget):
                else "as the portal draws it")
         self._say("Opened " + str(doc.get("title")) + " as a group - " + str(added) +
                   " layer(s), " + how + "." + note + " Restyle it, then use Push group to portal.",
-                  Qgis.Warning if (missing or not_editable or flat_3d) else Qgis.Info)
+                  enum(Qgis, "MessageLevel", "Warning") if (missing or not_editable or flat_3d) else enum(Qgis, "MessageLevel", "Info"))
 
     def push_group(self):
         """Push the selected QGIS group back as a portal — after showing exactly what will change.
@@ -1289,14 +1293,14 @@ class GeoDeployDock(QDockWidget):
         approved, and the two consequential parts are separate opt-ins rather than one blanket OK.
         """
         if not self.instance or not self.instance.token:
-            self._say("Pushing a portal needs a token with write access.", Qgis.Warning)
+            self._say("Pushing a portal needs a token with write access.", enum(Qgis, "MessageLevel", "Warning"))
             return
         view = self.iface.layerTreeView()
         nodes = view.selectedNodes() if view else []
         groups = [n for n in nodes if hasattr(n, "addLayer")]
         if len(groups) != 1:
             self._say("Select exactly one GROUP in the Layers panel - that group becomes the "
-                      "portal.", Qgis.Warning)
+                      "portal.", enum(Qgis, "MessageLevel", "Warning"))
             return
         group = groups[0]
         portal_id, title = portal_sync.group_portal(group)
@@ -1315,13 +1319,13 @@ class GeoDeployDock(QDockWidget):
             try:
                 current = (client.portals.get(portal_id) or {}).get("layer_configs") or []
             except GeoDeployError as exc:
-                self._say(f"Could not read the portal to compare against: {exc}", Qgis.Critical)
+                self._say(f"Could not read the portal to compare against: {exc}", enum(Qgis, "MessageLevel", "Critical"))
                 return
 
         try:
             plan = portal_sync.plan_push(group, style_for, current)
         except Exception as exc:            # noqa: BLE001 - never crash QGIS over a layer tree
-            self._say(f"Could not read that group: {exc}", Qgis.Critical)
+            self._say(f"Could not read that group: {exc}", enum(Qgis, "MessageLevel", "Critical"))
             return
 
         go, upload_new, drop_removed = diffdialog.confirm(
@@ -1403,7 +1407,7 @@ class GeoDeployDock(QDockWidget):
     def _group_pushed(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         result = job.result or {}
         doc = result.get("portal") or {}
@@ -1434,7 +1438,7 @@ class GeoDeployDock(QDockWidget):
         """
         row = self._selected_row()
         if not row:
-            self._say("Pick a layer or a portal first.", Qgis.Warning)
+            self._say("Pick a layer or a portal first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         if row.get("_portal"):
             # A PORTAL OPENS IN THE EDITOR, not in view mode — "Add to map" already offers the
@@ -1445,14 +1449,14 @@ class GeoDeployDock(QDockWidget):
             portal_id = row.get("id")
             if not (self.instance and self.instance.token) or portal_id is None:
                 self._say("Editing a portal needs a token with write access. Without one, use "
-                          "“Open portal in browser” to see the published page.", Qgis.Warning)
+                          "“Open portal in browser” to see the published page.", enum(Qgis, "MessageLevel", "Warning"))
                 return
             self._open_url("{0}/portals/{1}/edit".format(base, portal_id))
             return
         base = (row.get("_base") or (self.instance.url if self.instance else "")).rstrip("/")
         ref = row.get("uid") or row.get("id")
         if not base or ref is None:
-            self._say("That layer has no address on the instance.", Qgis.Warning)
+            self._say("That layer has no address on the instance.", enum(Qgis, "MessageLevel", "Warning"))
             return
         kind = "raster" if (row.get("layer_type") == "raster"
                             or row.get("kind") == "raster"
@@ -1467,7 +1471,7 @@ class GeoDeployDock(QDockWidget):
             QDesktopServices.openUrl(QUrl(url))
             self._say("Opened {0} in your browser.".format(url))
         except Exception as exc:        # noqa: BLE001 - still give them the address
-            self._say("Open it at {0} ({1}).".format(url, exc), Qgis.Warning)
+            self._say("Open it at {0} ({1}).".format(url, exc), enum(Qgis, "MessageLevel", "Warning"))
 
     def _open_portal(self, row):
         """A portal is a published web map — QGIS cannot render one, so open it where it lives."""
@@ -1479,7 +1483,7 @@ class GeoDeployDock(QDockWidget):
             base = (row.get("_base") or "").rstrip("/")
             slug = row.get("slug") or ""
             if not base or not slug:
-                self._say("That portal has no address yet — publish it first.", Qgis.Warning)
+                self._say("That portal has no address yet — publish it first.", enum(Qgis, "MessageLevel", "Warning"))
                 return
             url = f"{base}/portals/{slug}/"
         self._open_url(url)
@@ -1505,16 +1509,16 @@ class GeoDeployDock(QDockWidget):
         """
         layer = self.iface.activeLayer()
         if layer is None:
-            self._say("Select the layer to restyle in the Layers panel first.", Qgis.Warning)
+            self._say("Select the layer to restyle in the Layers panel first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         identity = portal_sync.layer_identity(layer)
         if identity is None:
             self._say("{0} did not come from GeoDeploy, so there is no other source to open it "
                       "from. QGIS is already showing everything it has.".format(layer.name()),
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
             return
         if not self.instance:
-            self._say("Connect to the instance this layer came from first.", Qgis.Warning)
+            self._say("Connect to the instance this layer came from first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         layer_id, kind = identity
         row = self._row_for(layer_id, kind)
@@ -1522,7 +1526,7 @@ class GeoDeployDock(QDockWidget):
             self._say("{0} is not in this instance's listing — a portal can serve a layer that is "
                       "not published on its own, and only the portal knows where it is. Sign in "
                       "with a token that can see it, then try again.".format(layer.name()),
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
             return
 
         # WHAT IT LOOKS LIKE NOW, from the most specific source available. A portal's raster wears
@@ -1549,14 +1553,14 @@ class GeoDeployDock(QDockWidget):
             self._say("Could not open {0}'s data source ({1}). The reason is in View > Panels > "
                       "Log Messages, under GeoDeploy.".format(layer.name(),
                                                               (source or {}).get("kind", "?")),
-                      Qgis.Critical)
+                      enum(Qgis, "MessageLevel", "Critical"))
             return
 
         replacement.setName(layer.name())
         applied = symbology.apply(replacement, style, row) if style else False
         _set_opacity(replacement, portal_sync._opacity_of(layer))
         if not self._swap_layer(layer, replacement):
-            self._say("Could not put {0} back where it was.".format(layer.name()), Qgis.Critical)
+            self._say("Could not put {0} back where it was.".format(layer.name()), enum(Qgis, "MessageLevel", "Critical"))
             return
         self.iface.setActiveLayer(replacement)
         # The picker's default is deliberately NOT changed. Restyling one layer is a targeted act;
@@ -1610,7 +1614,7 @@ class GeoDeployDock(QDockWidget):
         which layer on the server is meant.
         """
         if not self.instance or not self.instance.token:
-            self._say("Saving a style needs a token with write access.", Qgis.Warning)
+            self._say("Saving a style needs a token with write access.", enum(Qgis, "MessageLevel", "Warning"))
             return
         view = self.iface.layerTreeView()
         chosen = [l for l in (view.selectedLayers() if view else []) if l is not None]
@@ -1618,7 +1622,7 @@ class GeoDeployDock(QDockWidget):
             active = self.iface.activeLayer()
             chosen = [active] if active is not None else []
         if not chosen:
-            self._say("Select a layer that came from this instance.", Qgis.Warning)
+            self._say("Select a layer that came from this instance.", enum(Qgis, "MessageLevel", "Warning"))
             return
 
         jobs, skipped = [], []
@@ -1656,7 +1660,7 @@ class GeoDeployDock(QDockWidget):
         if not jobs:
             self._say("Nothing to save: " + (", ".join(skipped) or "no layer from this instance") +
                       ". A layer must have been ADDED from GeoDeploy to be saved back to it.",
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
             return
 
         client = self.instance.client
@@ -1675,23 +1679,23 @@ class GeoDeployDock(QDockWidget):
     def _style_saved(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         result = job.result or {}
         saved, skipped = result.get("saved") or [], result.get("skipped") or []
         note = " Skipped: " + ", ".join(skipped[:3]) + "." if skipped else ""
         self._say("Saved styling for " + ", ".join(saved[:3]) +
                   (" and {0} more".format(len(saved) - 3) if len(saved) > 3 else "") + "." + note,
-                  Qgis.Warning if skipped else Qgis.Info)
+                  enum(Qgis, "MessageLevel", "Warning") if skipped else enum(Qgis, "MessageLevel", "Info"))
         self.refresh_layers()
 
     def upload_active(self):
         if not self.instance:
-            self._say("Connect to an instance first.", Qgis.Warning)
+            self._say("Connect to an instance first.", enum(Qgis, "MessageLevel", "Warning"))
             return
         if not self.instance.token:
             self._say("Uploading needs a token with data:write. Public browsing does not.",
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
             return
         # Whatever is SELECTED in the Layers panel, falling back to the active layer. Sending five
         # layers is a normal thing to want, and doing it one at a time means five round trips
@@ -1700,7 +1704,7 @@ class GeoDeployDock(QDockWidget):
         if not layers:
             active = self.iface.activeLayer()
             if active is None:
-                self._say("Select one or more layers in the Layers panel first.", Qgis.Warning)
+                self._say("Select one or more layers in the Layers panel first.", enum(Qgis, "MessageLevel", "Warning"))
                 return
             layers = [active]
 
@@ -1718,7 +1722,7 @@ class GeoDeployDock(QDockWidget):
             self._say("Nothing was uploaded.", bar=False)
             return
         if not chosen:
-            self._say("No layers were selected to upload.", Qgis.Warning)
+            self._say("No layers were selected to upload.", enum(Qgis, "MessageLevel", "Warning"))
             return
         layers = [l for l in layers if l.name() in set(chosen)]
 
@@ -1746,7 +1750,7 @@ class GeoDeployDock(QDockWidget):
 
         if not jobs:
             # Everything was refused — say why, for each, rather than a generic failure.
-            self._say(" | ".join(refused) or "Nothing could be uploaded.", Qgis.Warning)
+            self._say(" | ".join(refused) or "Nothing could be uploaded.", enum(Qgis, "MessageLevel", "Warning"))
             return
 
         client = self.instance.client
@@ -1789,7 +1793,7 @@ class GeoDeployDock(QDockWidget):
     def _uploaded(self, job):
         self._busy(False)
         if job.error:
-            self._say(job.error, Qgis.Critical)
+            self._say(job.error, enum(Qgis, "MessageLevel", "Critical"))
             return
         result = job.result or {}
         uploaded = result.get("uploaded") or []
@@ -1813,9 +1817,9 @@ class GeoDeployDock(QDockWidget):
             # Partial success is its own outcome. Reporting it as failure hides work that landed;
             # reporting it as success hides work that did not.
             self._say(f"Uploaded {len(uploaded)}, but {len(failed)} did not: " + " | ".join(failed),
-                      Qgis.Warning)
+                      enum(Qgis, "MessageLevel", "Warning"))
         else:
-            self._say(" | ".join(failed) or "Nothing was uploaded.", Qgis.Critical)
+            self._say(" | ".join(failed) or "Nothing was uploaded.", enum(Qgis, "MessageLevel", "Critical"))
         if uploaded:
             self.refresh_layers()
 
@@ -1855,6 +1859,6 @@ class GeoDeployPlugin:
     def show(self):
         if self.dock is None:
             self.dock = GeoDeployDock(self.iface)
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock)
+            self.iface.addDockWidget(enum(Qt, "DockWidgetArea", "RightDockWidgetArea"), self.dock)
         self.dock.show()
         self.dock.raise_()

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -22,6 +22,10 @@ from __future__ import annotations
 import re
 
 from .connection import GeoDeployError  # noqa: F401  (re-exported for callers)
+try:                                    # a package, inside QGIS
+    from .compat import enum
+except ImportError:                     # pragma: no cover - exec'd standalone by the test harness
+    from compat import enum
 
 try:                                    # pragma: no cover - only present inside QGIS
     from qgis.core import (QgsCategorizedSymbolRenderer, QgsGraduatedSymbolRenderer,
@@ -99,7 +103,7 @@ def _apply_data_defined_size(symbol, layer0, style: dict) -> None:
         elif isinstance(layer0, QgsSimpleLineSymbolLayer):
             expr = 'scale_linear("{0}", {1}, {2}, {3}, {4})'.format(
                 field, in_lo, in_hi, out_lo * CSS_PX_TO_POINTS, out_hi * CSS_PX_TO_POINTS)
-            layer0.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeWidth,
+            layer0.setDataDefinedProperty(enum(QgsSymbolLayer, "Property", "PropertyStrokeWidth"),
                                           QgsProperty.fromExpression(expr))
     except Exception as exc:            # noqa: BLE001 - a size must never stop a layer drawing
         _log("Could not apply size-by-field ({0}): {1}".format(field, exc))
@@ -180,7 +184,7 @@ def _use_points(symbol, layer0) -> None:
     """
     try:
         from qgis.core import QgsUnitTypes
-        pt = QgsUnitTypes.RenderPoints
+        pt = enum(QgsUnitTypes, "RenderUnit", "RenderPoints")
     except Exception:                   # noqa: BLE001 - very old QGIS: leave the default
         return
     for target, setter in ((symbol, "setSizeUnit"), (layer0, "setSizeUnit"),
@@ -239,7 +243,7 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
         symbol.setSize(float(style.get("radius") or DEFAULT_POINT_RADIUS) * 2 * CSS_PX_TO_POINTS)
         outline = style.get("outline_color")
         if outline == "none":
-            layer0.setStrokeStyle(Qt.NoPen)
+            layer0.setStrokeStyle(enum(Qt, "PenStyle", "NoPen"))
         else:
             # A WHITE ring by default, because that is what the map draws — and because QGIS's own
             # default is a dark grey outline, which on a small marker covers the fill completely
@@ -254,13 +258,13 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
         layer0.setWidth(float(style.get("line_width") or DEFAULT_LINE_WIDTH) * CSS_PX_TO_POINTS)
         dash = (style.get("lineType") or "solid").lower()
         if dash == "dashed":
-            layer0.setPenStyle(Qt.DashLine)
+            layer0.setPenStyle(enum(Qt, "PenStyle", "DashLine"))
         elif dash == "dotted":
-            layer0.setPenStyle(Qt.DotLine)
+            layer0.setPenStyle(enum(Qt, "PenStyle", "DotLine"))
     elif isinstance(layer0, QgsSimpleFillSymbolLayer):
         outline = style.get("outline_color")
         if outline == "none":
-            layer0.setStrokeStyle(Qt.NoPen)
+            layer0.setStrokeStyle(enum(Qt, "PenStyle", "NoPen"))
         else:
             # The map's default outline, not QGIS's — `fill-outline-color: #1d4ed8` in
             # portal_generator when the style names none.
@@ -443,7 +447,7 @@ def _log(message: str, level: str = "warning") -> None:
     try:
         from qgis.core import Qgis, QgsMessageLog
         QgsMessageLog.logMessage(message, "GeoDeploy",
-                                 Qgis.Info if level == "info" else Qgis.Warning)
+                                 enum(Qgis, "MessageLevel", "Info") if level == "info" else enum(Qgis, "MessageLevel", "Warning"))
     except Exception:                   # noqa: BLE001 - logging must never raise  # nosec B110 - intentional: a cosmetic failure must not take down the layer
         pass
 
@@ -1194,7 +1198,7 @@ def _enhancement(provider, band, lo, hi):
     """A min/max stretch QGIS will apply to `band`."""
     enhancement = QgsContrastEnhancement(provider.dataType(band))
     enhancement.setContrastEnhancementAlgorithm(
-        QgsContrastEnhancement.StretchToMinimumMaximum, True)
+        enum(QgsContrastEnhancement, "ContrastEnhancementAlgorithm", "StretchToMinimumMaximum"), True)
     enhancement.setMinimumValue(lo)
     enhancement.setMaximumValue(hi)
     return enhancement
@@ -1214,8 +1218,8 @@ def _pseudocolor(provider, band, ramp, lo, hi, reverse: bool):
     # already holding — so passing the same object to both would leave this function sampling a ramp
     # C++ had just freed. It is sampled here, and the shader is given a clone of its own.
     shader_fn = QgsColorRampShader(lo, hi)
-    for setter, value in (("setColorRampType", QgsColorRampShader.Interpolated),
-                          ("setClassificationMode", QgsColorRampShader.Continuous)):
+    for setter, value in (("setColorRampType", enum(QgsColorRampShader, "Type", "Interpolated")),
+                          ("setClassificationMode", enum(QgsColorRampShader, "ClassificationMode", "Continuous"))):
         if hasattr(shader_fn, setter):
             getattr(shader_fn, setter)(value)
     span = (hi - lo) or 1.0
@@ -1276,7 +1280,7 @@ def _default_range(qgis_layer, band):
         # SAMPLED, not exhaustive: 250k pixels is what QGIS's own renderer uses to decide a stretch,
         # and it is bounded whatever the raster's size.
         from qgis.core import QgsRasterBandStats, QgsRectangle
-        stats = provider.bandStatistics(band, QgsRasterBandStats.Min | QgsRasterBandStats.Max,
+        stats = provider.bandStatistics(band, enum(QgsRasterBandStats, "Stats", "Min") | enum(QgsRasterBandStats, "Stats", "Max"),
                                         QgsRectangle(), 250000)
         if _finite(stats.minimumValue) and stats.maximumValue > stats.minimumValue:
             return (float(stats.minimumValue), float(stats.maximumValue))
@@ -1787,8 +1791,8 @@ def _geometry_name(qgis_layer):
         return str(recorded).lower()
     try:
         from qgis.core import QgsWkbTypes
-        return {QgsWkbTypes.PointGeometry: "point", QgsWkbTypes.LineGeometry: "line",
-                QgsWkbTypes.PolygonGeometry: "polygon"}.get(qgis_layer.geometryType())
+        return {enum(QgsWkbTypes, "GeometryType", "PointGeometry"): "point", enum(QgsWkbTypes, "GeometryType", "LineGeometry"): "line",
+                enum(QgsWkbTypes, "GeometryType", "PolygonGeometry"): "polygon"}.get(qgis_layer.geometryType())
     except Exception:                   # noqa: BLE001 - not a feature layer
         return None
 
@@ -1839,14 +1843,14 @@ def apply_to_vector_tiles(tile_layer, row: dict, source_layer: str | None,
     # one geometry anyway.
     geom = (row.get("geometry_type") or "").lower()
     if "polygon" in geom:
-        geometry_types = [QgsWkbTypes.PolygonGeometry]
+        geometry_types = [enum(QgsWkbTypes, "GeometryType", "PolygonGeometry")]
     elif "line" in geom:
-        geometry_types = [QgsWkbTypes.LineGeometry]
+        geometry_types = [enum(QgsWkbTypes, "GeometryType", "LineGeometry")]
     elif "point" in geom:
-        geometry_types = [QgsWkbTypes.PointGeometry]
+        geometry_types = [enum(QgsWkbTypes, "GeometryType", "PointGeometry")]
     else:
-        geometry_types = [QgsWkbTypes.PolygonGeometry, QgsWkbTypes.LineGeometry,
-                          QgsWkbTypes.PointGeometry]
+        geometry_types = [enum(QgsWkbTypes, "GeometryType", "PolygonGeometry"), enum(QgsWkbTypes, "GeometryType", "LineGeometry"),
+                          enum(QgsWkbTypes, "GeometryType", "PointGeometry")]
         if geom:
             _log("Unrecognised geometry {0!r}; styling every geometry type.".format(geom))
 
@@ -2344,11 +2348,11 @@ def style_from_vector_tiles(tile_layer) -> dict:
         recorded = str(recorded).lower()
         from qgis.core import QgsWkbTypes
         if "polygon" in recorded:
-            wanted = QgsWkbTypes.PolygonGeometry
+            wanted = enum(QgsWkbTypes, "GeometryType", "PolygonGeometry")
         elif "line" in recorded:
-            wanted = QgsWkbTypes.LineGeometry
+            wanted = enum(QgsWkbTypes, "GeometryType", "LineGeometry")
         elif "point" in recorded:
-            wanted = QgsWkbTypes.PointGeometry
+            wanted = enum(QgsWkbTypes, "GeometryType", "PointGeometry")
     except Exception:                   # noqa: BLE001 - fall through to every entry
         wanted = None
 
@@ -2548,8 +2552,8 @@ def _style_from_symbol(symbol) -> dict:
         if width is not None:
             style["line_width"] = round(width / CSS_PX_TO_POINTS, 2)
         pen = layer0.penStyle()
-        style["lineType"] = ("dashed" if pen == Qt.DashLine
-                             else "dotted" if pen == Qt.DotLine else "solid")
+        style["lineType"] = ("dashed" if pen == enum(Qt, "PenStyle", "DashLine")
+                             else "dotted" if pen == enum(Qt, "PenStyle", "DotLine") else "solid")
     elif isinstance(layer0, QgsSimpleFillSymbolLayer):
         opacity = number(symbol.opacity)
         if opacity is not None:
@@ -2582,7 +2586,7 @@ def _size_from_qgis(symbol, layer0) -> dict:
         from qgis.core import QgsSymbolLayer
         for holder, getter, key in (
                 (symbol, "dataDefinedSize", None),
-                (layer0, "dataDefinedProperty", QgsSymbolLayer.PropertyStrokeWidth)):
+                (layer0, "dataDefinedProperty", enum(QgsSymbolLayer, "Property", "PropertyStrokeWidth"))):
             fn = getattr(holder, getter, None)
             if not callable(fn):
                 continue
@@ -2610,7 +2614,7 @@ def _size_from_qgis(symbol, layer0) -> dict:
 def _stroke_of(layer0) -> str:
     """A symbol layer's outline as GeoDeploy states it: a colour, or `"none"` for no outline."""
     try:
-        if layer0.strokeStyle() == Qt.NoPen:
+        if layer0.strokeStyle() == enum(Qt, "PenStyle", "NoPen"):
             return "none"
     except Exception:                   # noqa: BLE001 - not every symbol layer has one  # nosec B110 - intentional: a cosmetic failure must not take down the layer
         pass

--- a/integrations/qgis-plugin/geodeploy_qgis/uploadpicker.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/uploadpicker.py
@@ -10,6 +10,11 @@ click rather than a rearrangement of the project.
 """
 from __future__ import annotations
 
+try:                                    # a package, inside QGIS
+    from .compat import enum
+except ImportError:                     # pragma: no cover - exec'd standalone by the test harness
+    from compat import enum
+
 try:                                    # pragma: no cover - only present inside QGIS
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QLabel,
@@ -51,18 +56,18 @@ def choose(parent, candidates):
     layout.addWidget(label)
 
     listing = QListWidget()
-    listing.setSelectionMode(QAbstractItemView.NoSelection)
+    listing.setSelectionMode(enum(QAbstractItemView, "SelectionMode", "NoSelection"))
     listing.setMinimumSize(420, 240)
     for name, why in candidates:
         item = QListWidgetItem(name if not why else "{0}  —  {1}".format(name, why))
-        item.setData(Qt.UserRole, name)
+        item.setData(enum(Qt, "ItemDataRole", "UserRole"), name)
         if why:
             # Visible but unusable: knowing WHY a layer is absent beats it silently not being there.
-            item.setFlags(Qt.ItemIsUserCheckable)
-            item.setCheckState(Qt.Unchecked)
+            item.setFlags(enum(Qt, "ItemFlag", "ItemIsUserCheckable"))
+            item.setCheckState(enum(Qt, "CheckState", "Unchecked"))
         else:
-            item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
-            item.setCheckState(Qt.Checked)
+            item.setFlags(enum(Qt, "ItemFlag", "ItemIsUserCheckable") | enum(Qt, "ItemFlag", "ItemIsEnabled"))
+            item.setCheckState(enum(Qt, "CheckState", "Checked"))
         listing.addItem(item)
     layout.addWidget(listing)
 
@@ -72,7 +77,7 @@ def choose(parent, candidates):
     buttons.rejected.connect(dialog.reject)
     layout.addWidget(buttons)
 
-    if dialog.exec_() != QDialog.Accepted:
+    if dialog.exec() != enum(QDialog, "DialogCode", "Accepted"):
         return None
-    return [listing.item(i).data(Qt.UserRole) for i in range(listing.count())
-            if listing.item(i).checkState() == Qt.Checked]
+    return [listing.item(i).data(enum(Qt, "ItemDataRole", "UserRole")) for i in range(listing.count())
+            if listing.item(i).checkState() == enum(Qt, "CheckState", "Checked")]

--- a/integrations/qgis-plugin/scripts/test_3d_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_3d_symbology.py
@@ -342,11 +342,16 @@ import os                                                                       
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis", "vendor"))
+# …and the package itself, so the module under test can import its own `compat` helper.
+sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis"))
 
 lines = open(os.path.join(HERE, "..", "geodeploy_qgis", "symbology.py"),
              encoding="utf-8").read().splitlines()
 src = "\n".join(l for l in lines if not l.startswith("from .connection"))
-ns = {}
+# A real module always has __name__, and the module under test now uses it: its
+# `from .compat import enum` needs a package context to fail as an ImportError so the
+# standalone fallback can take over. Without it Python raises KeyError instead.
+ns = {"__name__": "symbology"}
 exec(compile(src, "symbology", "exec"), ns)                                     # noqa: S102
 assert ns["QGIS"] is True, "the fake qgis.core was not picked up"
 

--- a/integrations/qgis-plugin/scripts/test_published_style.py
+++ b/integrations/qgis-plugin/scripts/test_published_style.py
@@ -28,7 +28,7 @@ def _load(name):
     lines = open(os.path.join(PKG, name + ".py"), encoding="utf-8").read().splitlines()
     src = "\n".join(l for l in lines
                     if not (l.startswith("from .connection") or l.startswith("from .symbology")))
-    ns = {}
+    ns = {"__name__": name}
     exec(compile(src, name, "exec"), ns)                                        # noqa: S102
     return ns
 

--- a/integrations/qgis-plugin/scripts/test_qt6_compat.py
+++ b/integrations/qgis-plugin/scripts/test_qt6_compat.py
@@ -1,0 +1,106 @@
+"""Prove the plugin reads enums in a way that survives QGIS 4 — and keep it that way.
+
+QGIS 4 is Qt6, where an enum member is only reachable through its scope: `Qt.NoPen` becomes
+`Qt.PenStyle.NoPen`, `Qgis.Warning` becomes `Qgis.MessageLevel.Warning`. The plugin must run on
+both, because its declared floor is QGIS 3.28 (Qt5), so `compat.enum` asks for the scoped name and
+falls back to the flat one.
+
+Two things are tested, and the second is the one that matters over time:
+
+1. the resolver works against a Qt5-shaped owner AND a Qt6-shaped one;
+2. **no source file reaches for a flat enum member any more.** That is the regression guard: the
+   fix was mechanical across 94 call sites, and a single `Qgis.Warning` typed later would be
+   invisible until a user on QGIS 4 hit that code path.
+"""
+import ast
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PLUGIN = os.path.join(HERE, "..", "geodeploy_qgis")
+sys.path.insert(0, PLUGIN)
+
+from compat import enum                                                         # noqa: E402
+
+
+# ── 1. the resolver ──────────────────────────────────────────────────────────────────────────────
+class Qt5Style:
+    """Qt5: the member sits directly on the class (and, in PyQt5, also under its scope)."""
+    NoPen = 0
+
+
+class Qt6Style:
+    """Qt6: only the scope has it."""
+    class PenStyle:
+        NoPen = 0
+
+
+class BothStyle:
+    """PyQt5 in practice: both, and they must agree."""
+    NoPen = 7
+
+    class PenStyle:
+        NoPen = 7
+
+
+assert enum(Qt5Style, "PenStyle", "NoPen") == 0, "flat-only owner (Qt5) must still resolve"
+assert enum(Qt6Style, "PenStyle", "NoPen") == 0, "scoped-only owner (Qt6) must resolve"
+assert enum(BothStyle, "PenStyle", "NoPen") == 7, "when both exist, the scoped one is used"
+try:
+    enum(Qt5Style, "PenStyle", "Nonexistent")
+    raise AssertionError("an unknown member must raise, not return None")
+except AttributeError:
+    pass
+print("resolver           -> Qt5, Qt6 and both-styles all resolve; an unknown member still raises")
+
+
+# ── 2. nothing reaches for a flat enum any more ──────────────────────────────────────────────────
+#
+# The map is repeated here on purpose. If someone edits the one in the fixer and not this one, the
+# test stops covering what it claims to — so this is the list the CHECK is written against, and a
+# disagreement between the two is itself a signal.
+FLAT = {
+    "Qgis": ("Info", "Warning", "Critical", "Success", "NoLevel"),
+    "Qt": ("NoPen", "DashLine", "DotLine", "SolidLine", "UserRole", "ItemIsUserCheckable",
+           "ItemIsEnabled", "Checked", "Unchecked", "RightDockWidgetArea"),
+    "QLineEdit": ("Password",),
+    "QMessageBox": ("Ok", "Cancel"),
+    "QDialog": ("Accepted", "Rejected"),
+    "QAbstractItemView": ("SingleSelection", "NoSelection"),
+    "QgsWkbTypes": ("PointGeometry", "LineGeometry", "PolygonGeometry"),
+    "QgsTask": ("CanCancel",),
+    "QgsUnitTypes": ("RenderPoints",),
+    "QgsContrastEnhancement": ("StretchToMinimumMaximum",),
+    "QgsColorRampShader": ("Interpolated", "Discrete", "Exact", "Continuous", "EqualInterval",
+                           "Quantile"),
+    "QgsRasterBandStats": ("Min", "Max"),
+    "QgsSymbolLayer": ("PropertyStrokeWidth",),
+    "QgsVectorFileWriter": ("NoError",),
+}
+
+offenders = []
+for name in sorted(os.listdir(PLUGIN)):
+    if not name.endswith(".py") or name == "compat.py":
+        continue
+    path = os.path.join(PLUGIN, name)
+    tree = ast.parse(open(path, encoding="utf-8").read(), filename=name)
+    # AST, not a regex: a regex cannot tell `Qgis.Warning` in code from the same words inside the
+    # docstring that explains the migration, and compat.py is full of the latter.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name):
+            continue
+        if node.attr in FLAT.get(node.value.id, ()):
+            offenders.append("{0}:{1}  {2}.{3}".format(name, node.lineno, node.value.id, node.attr))
+
+assert not offenders, "flat enum access, which breaks on QGIS 4:\n  " + "\n  ".join(offenders)
+print("sources            -> no flat enum access in any module")
+
+# `exec_()` is gone from Qt6 as well.
+for name in sorted(os.listdir(PLUGIN)):
+    if name.endswith(".py"):
+        body = open(os.path.join(PLUGIN, name), encoding="utf-8").read()
+        assert ".exec_()" not in body, "{0} still calls exec_(), which Qt6 removed".format(name)
+print("dialogs            -> exec(), not exec_()")
+
+print("\nALL QT6 COMPATIBILITY CASES PASS")

--- a/integrations/qgis-plugin/scripts/test_raster_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_raster_symbology.py
@@ -349,7 +349,10 @@ sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis"))
 lines = open(os.path.join(HERE, "..", "geodeploy_qgis", "symbology.py"),
              encoding="utf-8").read().splitlines()
 src = "\n".join(l for l in lines if not l.startswith("from .connection"))
-ns = {}
+# A real module always has __name__, and the module under test now uses it: its
+# `from .compat import enum` needs a package context to fail as an ImportError so the
+# standalone fallback can take over. Without it Python raises KeyError instead.
+ns = {"__name__": "symbology"}
 exec(compile(src, "symbology", "exec"), ns)                                     # noqa: S102
 assert ns["QGIS"] is True, "the fake qgis.core was not picked up"
 assert ns["QGIS_RASTER"] is True, "the raster half of the qgis.core import did not resolve"

--- a/integrations/qgis-plugin/scripts/test_tile_symbology.py
+++ b/integrations/qgis-plugin/scripts/test_tile_symbology.py
@@ -269,11 +269,16 @@ import os                                                                       
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis", "vendor"))
+# …and the package itself, so the module under test can import its own `compat` helper.
+sys.path.insert(0, os.path.join(HERE, "..", "geodeploy_qgis"))
 
 lines = open(os.path.join(HERE, "..", "geodeploy_qgis", "symbology.py"),
              encoding="utf-8").read().splitlines()
 src = "\n".join(l for l in lines if not l.startswith("from .connection"))
-ns = {}
+# A real module always has __name__, and the module under test now uses it: its
+# `from .compat import enum` needs a package context to fail as an ImportError so the
+# standalone fallback can take over. Without it Python raises KeyError instead.
+ns = {"__name__": "symbology"}
 exec(compile(src, "symbology", "exec"), ns)                                     # noqa: S102
 apply_to_vector_tiles = ns["apply_to_vector_tiles"]
 assert ns["QGIS"] is True, "the fake qgis.core was not picked up"


### PR DESCRIPTION
plugins.qgis.org's QGIS-4 readiness check reported 102 findings. They do not block approval, but the plugin must keep working on QGIS 3.28 (Qt5) — so this is **not** a rewrite to the Qt6 spelling.

`compat.enum` asks for the scoped name and falls back to the flat one. All 94 enum reads go through it; dialogs use `exec()`.

**Two traps that would have shipped if the report were applied verbatim:**

- It reports `QLineEdit.Password` as *"add 'EchoMode' before 'Password'"* → `Qt.EchoMode.Password` **does not exist** (`EchoMode` belongs to `QLineEdit`). That breaks the connect dialog.
- `QgsVectorFileWriter.SaveVectorOptions` and `QgsColorRampShader.ColorRampItem` are **classes**, not enums — scoping them is a silent AttributeError.

`test_qt6_compat.py` verifies the resolver against Qt5-, Qt6- and both-shaped owners, then walks the AST of every module and fails on any flat enum access.

⚠️ **Not verified inside QGIS** — the Qt half is checked against PyQt5 5.15, the QGIS enums rely on the fallback. Wants a smoke test before publishing.