### PR TITLE
Tile projected GeoParquet layers to where they actually are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ upgrade needs manual work.
 
 ## Unreleased
 
+- **A GeoParquet layer in a projected CRS now tiles to the right place.** Tiles were built with
+  DuckDB's three-argument `ST_Transform`, whose `always_xy` defaults to false — and EPSG:4326
+  declares lat/lon, so every coordinate came out swapped. A Swiss layer (EPSG:2056) tiled to the
+  Gulf of Aden while the map still opened on Switzerland: no error, no failed request, just an empty
+  map. Layers already in EPSG:4326 were never affected, and neither was anything served from
+  PostGIS. **Archives tiled before this fix must be re-tiled** (Tile, in My Data) — the fix only
+  changes what new tiles contain.
+
 - **A pasted GeoDeploy link now shows the GeoDeploy card.** The dashboard, every published portal
   (with its own title and description) and the docs emit Open Graph tags against a shipped
   1200x630 image, so a link posted to LinkedIn, Slack or Teams stops rendering as a bare title and

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -131,7 +131,29 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   through one path). Parquet has no index — it is a scan with `LIMIT 1`, fine for the single-feature
   permalink it serves, never a substitute for the bbox queries.
 
+- **DuckDB `ST_Transform` needs `always_xy=true` — FIXED 2026-08-28 (`duckdb_engine._st_transform_4326`).**
+  DuckDB spatial defaults the 4th argument to FALSE, which honours the authority's declared axis
+  order, and **EPSG:4326 declares LAT/LON**. The three-argument form therefore returned every
+  coordinate SWAPPED. It hit the two DuckDB reprojection sites — `stream_tiling_geojsonseq` (the
+  PRIMARY PMTiles feed) and `export_geoparquet_to_fgb` — so any GeoParquet layer in a projected CRS
+  built tiles that were somewhere else entirely: the live Swiss buildings layer (EPSG:2056, 3.4 M
+  points) landed at lon 46 / lat 7, in the Gulf of Aden. Nothing errored, and the layer's OWN bbox
+  stayed correct (that is computed with pyproj, `always_xy=True`), so the portal fitted to
+  Switzerland and drew an empty map. Diagnosis shortcut: the archive's own bounds are exposed by
+  `GET /api/data/vector/{ref}/tilejson` — compare them with the layer's `bbox`; swapped bounds are
+  the whole tell, and neither call needs a login. **PostGIS `ST_Transform` is always lon/lat**, so
+  no PostGIS path was affected, and neither were the deck.gl viewport feeds
+  (`query_features_geojson`/`_arrow`, pyproj) — which is why an UNTILED projected layer displayed
+  fine and a tiled one did not. Archives tiled before the fix must be RE-TILED
+  (`POST /data/vector/{id}/tile`); the fix only changes what new tiles contain. Regression test:
+  `api/tests/test_native_crs.py`.
+
 ## Last updated
+2026-08-28 (**DuckDB `ST_Transform` axis-order fix** — `_st_transform_4326()` now passes
+`always_xy=true`; without it every projected-CRS GeoParquet layer tiled to PMTiles at swapped
+coordinates. Two call sites: `stream_tiling_geojsonseq`, `export_geoparquet_to_fgb`. Existing
+archives need a re-tile.)
+
 2026-08-18 (`portal_generator._social_meta` + the `<head>` injection above — a pasted portal link rendered as a bare card because nothing in the stack emitted `og:` tags at all.)
 2026-08-17b (`portal_generator`: **a portal's raster with no `rescale` now inherits the layer's.**
 TiTiler needs a stretch for anything not already 0-255, and without one a float DEM or index raster

--- a/api/geodeploy/services/duckdb_engine.py
+++ b/api/geodeploy/services/duckdb_engine.py
@@ -215,6 +215,20 @@ def _read_geo_metadata(conn: duckdb.DuckDBPyConnection, loc: str) -> dict:
     return out
 
 
+def _st_transform_4326(expr: str, src_epsg: str) -> str:
+    """`expr` reprojected to EPSG:4326 by DuckDB spatial, in LON/LAT order.
+
+    The 4th argument (`always_xy`) is NOT optional. DuckDB's ST_Transform defaults it to FALSE,
+    which honours the authority's declared axis order — and EPSG:4326 declares LAT/LON. Leaving it
+    off silently returns every coordinate swapped: the Swiss buildings layer (EPSG:2056) tiled to
+    PMTiles landed at lon 46 / lat 7, in the Gulf of Aden. Nothing errors, and the layer's own bbox
+    stays right (that one is computed with pyproj, `always_xy=True`), so the portal fits to
+    Switzerland and draws an empty map — the tiles are simply somewhere else. PostGIS's
+    ST_Transform is always lon/lat, which is why only these DuckDB paths were affected.
+    """
+    return f"ST_Transform({expr}, '{src_epsg}', 'EPSG:4326', true)"
+
+
 def _reproject_bbox(bbox: list[float], src_epsg: str, dst_epsg: str = "EPSG:4326") -> list[float]:
     if src_epsg == dst_epsg:
         return bbox
@@ -929,7 +943,7 @@ def export_geoparquet_to_fgb(s3_key: str, out_path: str, creds: dict | None = No
             else f"ST_GeomFromWKB({gq})"
         geom_expr = base_geom
         if src_epsg and src_epsg != "EPSG:4326":
-            geom_expr = f"ST_Transform({base_geom}, '{src_epsg}', 'EPSG:4326')"
+            geom_expr = _st_transform_4326(base_geom, src_epsg)
         sel = ", ".join([f"{geom_expr} AS {gq}"] +
                         [_fgb_prop_expr(c, col_types.get(c, "")) for c in prop_cols])
         out_q = out_path.replace("'", "''")
@@ -991,7 +1005,7 @@ def stream_tiling_geojsonseq(s3_key: str, out, creds: dict | None = None, bucket
         gq = _q(geom_col)
         gexpr = gq if "GEOMETRY" in col_types.get(geom_col, "").upper() else f"ST_GeomFromWKB({gq})"
         if src_epsg and src_epsg != "EPSG:4326":
-            gexpr = f"ST_Transform({gexpr}, '{src_epsg}', 'EPSG:4326')"
+            gexpr = _st_transform_4326(gexpr, src_epsg)
         if simplify_tol and simplify_tol > 0:
             gexpr = f"ST_Simplify({gexpr}, {float(simplify_tol)})"
         sel = ", ".join([f"ST_AsGeoJSON({gexpr}) AS __gj"] + [_q(c) for c in prop_cols])

--- a/api/tests/test_native_crs.py
+++ b/api/tests/test_native_crs.py
@@ -3,7 +3,9 @@ record it; the read round-trip recovers it from the GeoParquet footer; the downl
 CRS-correct clip envelope and can output native. Pure-logic units (no DB / fiona / storage)."""
 import json
 
-from geodeploy.services.duckdb_engine import _crs_to_epsg
+import pytest
+
+from geodeploy.services.duckdb_engine import _crs_to_epsg, _st_transform_4326
 from geodeploy.tasks.export import _env_sql, _geom_out
 from geodeploy.tasks.vector_ingest import _write_geo_footer, _srid_of
 
@@ -55,3 +57,36 @@ def test_geom_out_only_transforms_when_srids_differ():
 def test_srid_of_none_for_missing_or_unresolvable():
     assert _srid_of(None) is None
     assert _srid_of("") is None
+
+
+# ── DuckDB reprojection must be LON/LAT, not the authority's axis order ─────────────────────────────
+# Regression guard for the bug that made every projected GeoParquet layer tile to the wrong place:
+# DuckDB's ST_Transform defaults `always_xy` to FALSE, and EPSG:4326 declares LAT/LON, so the
+# three-argument form returned every coordinate swapped. The tiles carried it, nothing errored, and
+# the layer's own bbox stayed right (pyproj, always_xy=True) — so the portal fitted to the country
+# and drew an empty map. See notes_temp/notes_for_future.md.
+
+def test_st_transform_4326_pins_always_xy():
+    """The 4th argument is the whole point — losing it is silent and total."""
+    assert _st_transform_4326('"geom"', "EPSG:2056") == (
+        """ST_Transform("geom", 'EPSG:2056', 'EPSG:4326', true)""")
+
+
+def test_st_transform_4326_really_returns_lon_lat():
+    """Round-trip through the real extension: LV95 Bern must come back as lon 7.4, lat 46.9 —
+    NOT lat 46.9, lon 7.4. Skipped where `spatial` cannot be loaded (it is baked into the api
+    image; a bare checkout without it simply does not exercise this)."""
+    duckdb = pytest.importorskip("duckdb")
+    from geodeploy.services.duckdb_engine import _load_extension
+    conn = duckdb.connect(":memory:")
+    try:
+        try:
+            _load_extension(conn, "spatial")
+        except Exception:
+            pytest.skip("duckdb spatial extension unavailable")
+        sql = _st_transform_4326("ST_Point(2600000, 1200000)", "EPSG:2056")
+        lon, lat = json.loads(conn.execute(f"SELECT ST_AsGeoJSON({sql})").fetchone()[0])["coordinates"]
+    finally:
+        conn.close()
+    assert 7.4 < lon < 7.5, f"longitude in the longitude slot, got {lon}"
+    assert 46.9 < lat < 47.0, f"latitude in the latitude slot, got {lat}"


### PR DESCRIPTION
Fixes #76.

## The bug

A GeoParquet layer whose CRS is not EPSG:4326 rendered an **empty map** once tiled to PMTiles — no
error, no failed request, archive serving `206`s, map opening on the right country with nothing on
it. It broke the published portal, the editor preview, the layer page and the dashboard map widget
simultaneously, because a layer with `tile_status == 'ready'` bypasses the deck.gl overlay and
renders from `pmtiles://…` in all four.

## Root cause

The tiling feed built its reprojection with DuckDB's three-argument `ST_Transform`. The fourth
argument, `always_xy`, **defaults to false** — which honours the axis order each authority declares,
and EPSG:4326 declares lat/lon:

```
ST_Transform(ST_Point(2600000,1200000),'EPSG:2056','EPSG:4326')       -> [46.951, 7.439]   # lat, lon
ST_Transform(ST_Point(2600000,1200000),'EPSG:2056','EPSG:4326', true) -> [7.439, 46.951]   # lon, lat
```

The layer's own bbox is computed separately with pyproj (`always_xy=True`) and stayed correct, so
the camera was right and the tiles were ~4000 km away. On the affected instance the archive's own
bounds gave it away — `[45.82, 5.96, 47.80, 10.49]` against a layer bbox of
`[5.91, 45.79, 10.55, 47.80]`, latitude sitting in the longitude slot.

It presented as "point layers don't display" purely by coincidence: the projected layers on that
instance happened to be the point ones. The real variable is **tiled vs untiled**.

## The change

One helper, `_st_transform_4326()`, carrying `always_xy=true`, used at both DuckDB reprojection
sites — `stream_tiling_geojsonseq` (the primary tippecanoe feed) and `export_geoparquet_to_fgb`.

**PostGIS is deliberately untouched**: its `ST_Transform` is always lon/lat, so all ~15 PostGIS call
sites are already correct and must not be "fixed". The deck.gl viewport feeds
(`query_features_geojson` / `query_features_arrow`) use pyproj and were always right, which is why an
untiled projected layer displayed fine.

## Testing

`api/tests/test_native_crs.py` gains two cases: one pinning the SQL shape (losing that argument is
silent and total, so it deserves an exact assertion) and one round-tripping LV95 Bern through the
real extension, skipped where `spatial` cannot be loaded.

Verified out-of-band by running the real `partition_with_covering` + `stream_tiling_geojsonseq` over
a synthetic EPSG:2056 point layer: the feed now emits lon 6.11–10.50 / lat 45.79–47.81, matching the
layer's own bbox. The deck.gl path was audited at the same time and is sound end to end — encoding,
`geoarrow.point`, and the real `.arrow` bytes accepted by `GeoArrowScatterplotLayer`.

## Deploying it

The tiling task runs in **celery**, which shares the api image, so both containers need recreating:

```
docker compose build geodeploy-api && docker compose up -d --force-recreate geodeploy-api celery
```

The fix only changes what **new** tiles contain. Every archive built from a non-4326 source must be
re-tiled — `POST /api/data/vector/{id}/tile`, or the Tile action in My Data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)