### PR TITLE
v1.4.1 — the projected-CRS tiling hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ Notable changes, newest first. Versions are **major.minor** — `v1.0`, `v1.1`, 
 `v2.0`. The minor number moves for anything shipped, features or fixes; the major changes when an
 upgrade needs manual work.
 
-## Unreleased
+## v1.4.1 — 2026-08-28
+
+A patch release, and the second deliberate exception to the major.minor convention above: a
+GeoParquet layer in a projected CRS built its tiles at coordinates that were not its own, and that
+should not wait for v1.5. Two smaller things already on main ride along with it.
 
 - **A GeoParquet layer in a projected CRS now tiles to the right place.** Tiles were built with
   DuckDB's three-argument `ST_Transform`, whose `always_xy` defaults to false — and EPSG:4326

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.4",
+    version="1.4.1",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cuts **v1.4.1** for the fix merged in #77 (issue #76).

A GeoParquet layer whose CRS was not EPSG:4326 built its PMTiles archive at swapped coordinates, so
it rendered nothing anywhere it was drawn from tiles — silently, with the map still opening on the
right country. Following the v1.3.1 precedent, that gets a patch release rather than waiting for
v1.5; the major.minor convention still holds for planned work.

## What this release contains

- **The projected-CRS tiling fix** (#77) — the reason for the release.
- **The link-preview card** (#73, #74) — already on main, unreleased.
- **`installer/update.sh` applies an `nginx.conf` change** instead of skipping it — already on main,
  unreleased.
- QGIS plugin packaging, docs and lint follow-ups (#64–#72, #75) — plugin-side, not changelogged.

## Version strings

`api/geodeploy/main.py` and `ui/package.json` move to `1.4.1`. **The CLI stays at `1.4.0`** — it is
untouched by this fix, so there is nothing to re-upload to PyPI. Same split as v1.3.1.

## Upgrading

The tiling task runs in celery, which shares the api image, so both containers need recreating.
Then **re-tile any layer tiled from a non-4326 source** — the fix only changes what new tiles
contain, so existing archives stay wrong until they are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)