### PR TITLE
v1.5.1 — a dashboard you can actually author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ upgrade needs manual work.
 
 ## Unreleased
 
+## v1.5.1 — 2026-08-31
+
+A fortnight of building real dashboards with v1.5. Almost everything here is something that could
+not be said, sized or read until someone tried to author a board with it. No migration, no
+configuration change: publish a portal again and it picks all of this up.
+
+### Charts you can author
+
+- **Wide data plots.** Let the **columns** be the X axis, for data stored one column per year or
+  period (`gdp1960`, `gdp1961`, …) rather than one row per observation. Up to 120 columns, with a
+  select-all rather than 120 clicks, and the groups become the series.
+- **Tick labels from column names.** Column names rarely read as axis labels, so the shared prefix
+  can be trimmed to leave the numbers and an **offset** applied when the numbers are not the values
+  meant (`gdp1` + 1959 reads as `1960`).
+- **An overall line** across the whole current selection on a multi-column chart, to read the
+  individual series against.
+- **Axis titles and widget subtitles are yours to write**, and the card's heading follows them. A
+  column name is what the data is called, not what it measures — and after a shapefile has cut it
+  to ten characters it is often neither.
+- **Plot a chosen column per group.** The measure field could not be picked alongside a grouping
+  field, so "GDP per country" was unaskable and only counts and averages were offered.
+- **Readable axes.** Gridlines and ticks at intervals on line and scatter plots rather than only
+  the two extremes; rotated category labels that no longer straddle their ticks; a histogram that
+  names the range it covers.
+- **The legend gets its room before the plot does** — on the multi-series line, the grouped bars
+  and the pie, all of which drew at `height: 100%` and pushed their key into the card's scrollbar.
+  Making the widget taller grew the plot by exactly as much, so height never helped. **Plot size**
+  now overrules the measured split on any chart with a key, not only a pie.
+- **The gauge** no longer clips its own arc: its box is derived from the arc's geometry instead of
+  being a constant that stopped matching it.
+- Bar-only controls are hidden on line charts, where they changed nothing.
+
+### Reading a dashboard
+
+- **Several table rows at once** — <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> adds and removes, <kbd>Shift</kbd>
+  takes the run between. The map fits the **whole** selection rather than the row last clicked, and
+  the selection survives a page turn.
+- **A scatter can say which feature a dot is**: hover labels from up to three columns you nominate.
+  An outlier is the point of a scatter and was the one thing it could not tell you about. Point
+  size is adjustable too — 2px read as dust on a small card.
+- **A new selection replaces the last** rather than compounding with it. Drawing a box after
+  clicking a feature was asking for the features that are both, and getting none.
+- **Zoom to what a chart selected**, so the filter and the view agree. On by default for chart
+  clicks, off per widget; map clicks never move the camera.
+- **Fill the screen**, per dashboard: the grid rows share the height of the window instead of each
+  being exactly the row height, so a board laid out on a laptop does not stop a third of the way
+  down a large monitor. It stretches but never squeezes — the row height stays the floor — so a
+  phone or a portrait display scrolls exactly as before.
+- A **filter that matched nothing** because the clicked geometry had zero area now matches: a
+  point round-tripped through GeoJSON is precision-fragile against an exact `intersects`.
+
+### On the map
+
+- **Basemaps that are free without an account.** The three CARTO styles asked for an API key;
+  they are replaced, and **OpenStreetMap now leads the list** as the default.
+- **The selection tools can be dragged** clear of whatever they overlap, by the visitor, on a
+  published portal.
+- **The coordinate readout names its CRS** (`EPSG:4326`) — two numbers alone are ambiguous — and
+  now sits at the **bottom centre**, sharing one line with the scale bar and the attribution. The
+  scale bar had floated above the credit on every map in the product since the first shared-runtime
+  refactor.
+- **Both map readouts are legible in dark mode.** Each took one colour from the theme and one from
+  nowhere.
+- Drawing on a phone no longer opens the attribute table on every tap.
+
+### Portals, everywhere
+
+- **A dashboard's card thumbnail is the whole dashboard**, not the map cell inside it — two boards
+  over the same layer used to get the same picture.
+- **A plain map is no longer refused as a blank one.** The capture check was a byte floor, and a map
+  zoomed in far enough to show no detail is a real picture that compresses to almost nothing.
+- **The legend opens beside the map** rather than at the top of the page on a phone, sizes itself to
+  its content, and "start collapsed" now works for a docked list.
+- **A big number shrinks to fit its card** instead of overflowing it.
+- **A dragged widget no longer lands on top of another.**
+- The loading cover is held until the widgets have answered, so a dashboard does not appear empty
+  before it appears full.
+- **View on GitHub** in the sidebar, on the demo instance only.
+
 ## v1.5 — 2026-08-29
 
 ### Dashboards — a fourth experience

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ couple of minutes later. No terminal, no Docker knowledge, no database configura
 - **Operate it from the browser.** Service logs, a terminal, scheduled backups to a separate
   destination, an in-app restore, and one-button updates.
 
+## Where it fits
+
+If you have been looking for one of these, it is the same thing under a different name:
+
+- a **self-hosted alternative to a hosted geoportal** — ArcGIS Online, ArcGIS Hub and the like —
+  where the data stays on your server and there is no per-seat licence;
+- a **geoportal builder** or small **spatial data infrastructure (SDI)** in one package, rather
+  than a tile server, a catalog, a database and a front end assembled and kept in step by hand;
+- a **GIS data catalog** with OGC API - Features and STAC endpoints, for publishing open data;
+- a **geospatial dashboard** tool, for putting charts and figures around a map.
+
+It does not replace a desktop GIS, and does not try to. QGIS stays where the analysis happens — the
+[plugin](https://docs-geodeploy.kndev.org/qgis/) and the
+[Python client](https://pypi.org/project/geodeploy/) connect the two.
+
 ## How data flows
 
 ```

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.5",
+    version="1.5.1",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/api/geodeploy/routers/data/raster.py
+++ b/api/geodeploy/routers/data/raster.py
@@ -552,6 +552,10 @@ async def raster_zonal_stats(layer_ref: str, req: ZonalRequest,
     if not geom or not (geom.get("type") and (geom.get("coordinates") is not None
                                               or geom.get("geometry") or geom.get("features"))):
         raise HTTPException(400, "A GeoJSON geometry is required.")
+    # Same normalisation the vector side does at `_spec`: a clicked POINT has no area, and a
+    # zero-area window over a raster reads no pixels at all. Grown, it samples the one it is on.
+    from ...services.aggregate import usable_geometry
+    geom = usable_geometry(geom)
     try:
         out = await zonal.compute(layer.s3_key, geom, stats=req.stats or [],
                                   band=req.band, categorical=bool(req.categorical))

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -867,6 +867,9 @@ class AggregateRequest(BaseModel):
 
 
 class ScatterRequest(BaseModel):
+    #: Columns whose values name each point on hover — see `aggregate._label_fields`. A scatter
+    #: otherwise plots two numbers and cannot say which feature they belong to.
+    labelFields: list[str] | None = None
     """Y against X, per feature. Sampled server-side — see `services/aggregate.parquet_scatter`."""
     xField: str | None = None
     yField: str | None = None

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -967,8 +967,17 @@ async def _resolve_joins(spec: dict, layer: VectorLayer, db: AsyncSession) -> st
 
 def _spec(model: BaseModel) -> dict:
     """A request model → the plain dict `services/aggregate` takes. `exclude_none` is deliberate:
-    the service distinguishes "absent" from "explicitly null" for `groupBy` and `sort`."""
-    return model.model_dump(exclude_none=True)
+    the service distinguishes "absent" from "explicitly null" for `groupBy` and `sort`.
+
+    The geometry is normalised HERE, once, rather than in each of the five services that read it:
+    aggregate, table, scatter, profile and pick all take the same `geometry` and all inherit the
+    same zero-area problem. See `aggregate.usable_geometry`.
+    """
+    from ...services.aggregate import usable_geometry
+    spec = model.model_dump(exclude_none=True)
+    if spec.get("geometry") is not None:
+        spec["geometry"] = usable_geometry(spec["geometry"])
+    return spec
 
 
 @router.post("/{layer_ref}/scatter")

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -203,6 +203,8 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   `api/tests/test_native_crs.py`.
 
 ## Last updated
+2026-08-31 (`dashboard.py`: `style.pointSize` for scatter widgets, 1.5-8, default 3.5.)
+
 2026-08-29 (**`keysOnly` aggregates + `MAX_KEYS`** — a keys-only request returns just the distinct
 values and is clamped by its own ceiling, because `MAX_GROUPS` (200) was silently truncating the
 map's 5 000-key linked filter. Plus `linkedFilterCap` and chart `plotSize` in `dashboard.py`.)

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -203,6 +203,9 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   `api/tests/test_native_crs.py`.
 
 ## Last updated
+2026-08-31 (`dashboard.py`: `grid.fit` — `"rows"` (default, unchanged) or `"screen"`, which lets the
+runtime stretch the rows to the viewport. Default stays `"rows"` so no published board restyles.)
+
 2026-08-31 (`dashboard.py`: `style.pointSize` for scatter widgets, 1.5-8, default 3.5.)
 
 2026-08-29 (**`keysOnly` aggregates + `MAX_KEYS`** — a keys-only request returns just the distinct

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -1525,6 +1525,43 @@ def _bounds_out(row) -> dict:
     return {"bounds": b}
 
 
+#: How far a zero-area filter geometry is grown before it is tested. 1e-6 degrees is about 11 cm at
+#: the equator: far larger than the precision a geometry loses on its round trip, far smaller than
+#: the distance between any two features anyone would want to tell apart.
+GEOM_EPS = 1e-6
+
+
+def usable_geometry(geom: dict | None) -> dict | None:
+    """A geometry filter that can actually match what it came from.
+
+    Clicking a POINT layer publishes the picked feature's own geometry as the area filter, and that
+    filter then matched NOTHING — not even the feature it was taken from. The point makes the round
+    trip as GeoJSON, rounded to nine decimals on the way out and reprojected on the way back, and an
+    exact `intersects` between two zero-area geometries fails on the last few digits. Measured on a
+    live layer: the picked point scored 0, the same point grown by 1e-9 degrees scored 1.
+
+    What the visitor saw was worse than an error. The attribute channel matched (`Country_Na =
+    Luxembourg`, 1 row) and the geometry channel did not, so every widget answered "no records" and
+    the chart flattened to zero — a dashboard that looked like it had lost its data.
+
+    So a geometry with no area is grown by `GEOM_EPS` before it is used. Polygons are untouched:
+    they have area, their tests are not knife-edge, and nothing here should widen a selection the
+    visitor actually drew.
+    """
+    if not isinstance(geom, dict) or not geom.get("type"):
+        return geom
+    try:
+        from shapely.geometry import shape, mapping
+        g = shape(geom)
+        if g.is_empty or g.area > 0:
+            return geom
+        return mapping(g.buffer(GEOM_EPS))
+    except Exception:
+        # A geometry shapely cannot read is one the engines will reject with a better message than
+        # anything invented here.
+        return geom
+
+
 def _keys_out(rows, limit: int) -> dict:
     """Shape a keys-only answer: the distinct values themselves, and whether there were more.
 

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -37,7 +37,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 #: Aggregations. `count` takes no field.
-OPS = {"count", "sum", "avg", "min", "max"}
+#: `bounds` is not a summary of a column like the others — it is the EXTENT of whatever the current
+#: filter selects, four numbers in lon/lat. It lives here rather than in its own endpoint because it
+#: takes exactly the same filters, geometry and joins as every other question the dashboard asks,
+#: and a second endpoint would be a second place to keep that in step.
+OPS = {"count", "sum", "avg", "min", "max", "bounds"}
+#: The ops that summarise no column and therefore need no `field`.
+FIELDLESS_OPS = {"count", "bounds"}
 
 #: `date_trunc` units, spelled the same in Postgres and DuckDB — which is why the time-bucket
 #: implementation below is genuinely shared rather than two lookalike branches.
@@ -431,7 +437,7 @@ async def _postgis_aggregate_uncached(db, layer, spec: dict) -> dict:
     op = spec.get("op", "count")
     if op not in OPS:
         raise AggregateError(f"Unsupported aggregation: {op}")
-    field = None if op == "count" else _check_field(spec.get("field"), known, "field")
+    field = None if op in FIELDLESS_OPS else _check_field(spec.get("field"), known, "field")
     filters = normalize_filters(spec.get("filters"), known)
     geometry = spec.get("geometry") if isinstance(spec.get("geometry"), dict) else None
 
@@ -464,6 +470,15 @@ async def _postgis_aggregate_uncached(db, layer, spec: dict) -> dict:
         order = {"value_asc": "ORDER BY 2 ASC NULLS LAST",
                  "key_asc": "ORDER BY 1 ASC NULLS LAST"}.get(
                      spec.get("sort") or "value_desc", "ORDER BY 2 DESC NULLS LAST")
+    # THE EXTENT of the filtered set. Asked before the group-by branch because it never groups: the
+    # caller wants one rectangle for everything the filter selects, not one per category.
+    if op == "bounds":
+        g4326 = f"ST_Transform({qi(geom_col)}, 4326)"
+        row = (await db.execute(text(
+            f"SELECT ST_XMin(e), ST_YMin(e), ST_XMax(e), ST_YMax(e) "
+            f"FROM (SELECT ST_Extent({g4326}) AS e FROM {table} {where}) t"), params)).first()
+        return _bounds_out(row)
+
     # KEYS ONLY: no measures, no count, no ordering by a value that is not computed. The caller is
     # building a predicate, not a chart, so every column but the key is work nobody reads.
     if spec.get("keysOnly"):
@@ -732,6 +747,37 @@ def _duck_bbox_prune(meta: dict, geometry: dict | None) -> tuple[str | None, Any
         return f"struct_extract({qi(col)}, '{fields[f]}')"
     return (f"{ce('xmin')} <= {bbox[2]} AND {ce('xmax')} >= {bbox[0]} "
             f"AND {ce('ymin')} <= {bbox[3]} AND {ce('ymax')} >= {bbox[1]}"), geom
+
+
+def _duck_bounds(conn, src: str, meta: dict, cols: dict, where_sql: str) -> dict:
+    """The extent of the filtered set, in lon/lat.
+
+    Prefers the COVERING bbox struct the prep step writes: four numeric columns whose min/max is the
+    extent, with no geometry decoded at all. Falls back to the geometry itself when a layer has no
+    covering column — correct either way, and the difference is whole seconds on a large file.
+
+    Reprojected at the END rather than per row: the extent of the reprojected set and the reprojected
+    extent differ only for a shape spanning a projection's discontinuity, and reprojecting four
+    numbers instead of millions is the reason this is worth asking for at all.
+    """
+    covering = meta.get("covering")
+    if covering:
+        col, f = covering
+        def ce(k):
+            return f"struct_extract({qi(col)}, '{f[k]}')"
+        sel = f"MIN({ce('xmin')}), MIN({ce('ymin')}), MAX({ce('xmax')}), MAX({ce('ymax')})"
+    else:
+        g = qi(_duck_geom_col(meta, cols))
+        sel = f"MIN(ST_XMin({g})), MIN(ST_YMin({g})), MAX(ST_XMax({g})), MAX(ST_YMax({g}))"
+    row = conn.execute(f"SELECT {sel} FROM {src} {where_sql}").fetchone()
+    if not row or row[0] is None:
+        return {"bounds": None}
+    b = [float(row[0]), float(row[1]), float(row[2]), float(row[3])]
+    src_epsg = meta.get("epsg") or "EPSG:4326"
+    if src_epsg not in ("EPSG:4326", "4326"):
+        from . import duckdb_engine
+        b = list(duckdb_engine._reproject_bbox(b, src_epsg, "EPSG:4326"))
+    return {"bounds": b}
 
 
 def _duck_geom_col(meta: dict, cols: dict) -> str:
@@ -1111,7 +1157,7 @@ def _parquet_aggregate_uncached(layer, spec: dict) -> dict:
     op = spec.get("op", "count")
     if op not in OPS:
         raise AggregateError(f"Unsupported aggregation: {op}")
-    field = None if op == "count" else _check_field(spec.get("field"), known, "field")
+    field = None if op in FIELDLESS_OPS else _check_field(spec.get("field"), known, "field")
     filters = normalize_filters(spec.get("filters"), known)
     geometry = spec.get("geometry") if isinstance(spec.get("geometry"), dict) else None
     group_by = spec.get("groupBy")
@@ -1143,6 +1189,10 @@ def _parquet_aggregate_uncached(layer, spec: dict) -> dict:
             order = ("ORDER BY 1 ASC" if bucket else
                      {"value_asc": "ORDER BY 2 ASC", "key_asc": "ORDER BY 1 ASC"}.get(
                          spec.get("sort") or "value_desc", "ORDER BY 2 DESC"))
+            # THE EXTENT — see the PostGIS branch.
+            if op == "bounds":
+                return _duck_bounds(conn, src, meta, cols, where_sql)
+
             # KEYS ONLY — see the PostGIS branch: a predicate, not a chart.
             if spec.get("keysOnly"):
                 limit = max(2, min(int(spec.get("limit") or 12), MAX_KEYS))
@@ -1447,6 +1497,20 @@ def _series_specs(spec: dict, known: set[str]) -> list[dict]:
     op = spec.get("op", "count")
     field = None if op == "count" else spec.get("field")
     return [{"op": op, "field": field, "label": _series_label(op, field)}]
+
+
+def _bounds_out(row) -> dict:
+    """`{bounds: [minx, miny, maxx, maxy]}` in lon/lat, or `{bounds: None}`.
+
+    None is a real answer and the caller must handle it: a filter that matches nothing has no
+    extent, and neither does a set whose every geometry is null. Flying the map to a rectangle
+    invented for that case would be worse than not moving at all."""
+    if not row or row[0] is None:
+        return {"bounds": None}
+    b = [float(row[0]), float(row[1]), float(row[2]), float(row[3])]
+    # A single point selects a zero-area box, which `fitBounds` cannot frame — it is left to the
+    # client, which knows its own viewport and can simply centre on it.
+    return {"bounds": b}
 
 
 def _keys_out(rows, limit: int) -> dict:

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -1459,7 +1459,17 @@ def _pg_types(layer) -> dict[str, str]:
 
 #: Measures one chart may plot against a single group key. Four is where a legend stops being a
 #: legend and starts being a table, and where line colours stop being tellable apart at a glance.
-MAX_SERIES = 4
+#: How many aggregate expressions one grouped scan may carry.
+#:
+#: This was 4, borrowed from a READABILITY limit: four coloured lines is where a legend stops being
+#: a legend. That reasoning belongs to the client, and only to the mode where colour names the
+#: measure — when the measures become the X AXIS (a chart plotting one column per year), they are
+#: ticks, not legend entries, and four of them is a two-year timeline.
+#:
+#: What the server should bound is the QUERY: N measures are N aggregate expressions in one pass
+#: over one grouping, and twenty-four of those is still one scan. The builder keeps its own limit of
+#: four for hand-authored measures, where the legend argument does apply.
+MAX_SERIES = 24
 
 
 def _series_label(op: str, field: str | None) -> str:

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -453,6 +453,25 @@ async def _postgis_aggregate_uncached(db, layer, spec: dict) -> dict:
 
     group_by = spec.get("groupBy")
     if not group_by:
+        # SEVERAL MEASURES, NO GROUPING. The grouped path has always answered N aggregates in
+        # one pass; ungrouped it ignored `series` and answered the single `op`/`field` — so
+        # "average of these 56 columns over everything" was unaskable, and asking it with an op
+        # that needs a field but no field to give came back 400.
+        #
+        # It is the shape a chart's OVERALL line needs: the same measures as the per-group
+        # lines, over the whole selection rather than one group. Answered in the same shape as
+        # the grouped reply (`values` alongside `value`) so the client reads one thing.
+        if spec.get("series"):
+            series = _series_specs(spec, known)
+            vals = ", ".join(f"{_pg_value_expr(sp['op'], sp['field'])} AS v{i}"
+                             for i, sp in enumerate(series))
+            row = (await db.execute(
+                text(f"SELECT {vals}, COUNT(*) AS n FROM {table} {where}"), params)).first()
+            values = [_num(row[i]) for i in range(len(series))] if row else []
+            return {"op": op, "value": values[0] if values else None, "values": values,
+                    "count": int(row[len(series)]) if row else 0,
+                    "series": [{"label": sp["label"], "op": sp["op"], "field": sp.get("field")}
+                               for sp in series]}
         row = (await db.execute(text(f"SELECT {value} AS v, COUNT(*) AS n FROM {table} {where}"),
                                 params)).first()
         return {"op": op, "value": _num(row[0]) if row else None,
@@ -1180,6 +1199,25 @@ def _parquet_aggregate_uncached(layer, spec: dict) -> dict:
             # PURE SQL — one columnar pass, row groups pruned by the attribute predicates.
             value = _duck_value_expr(op, field)
             if not group_by:
+            # SEVERAL MEASURES, NO GROUPING. The grouped path has always answered N aggregates in
+            # one pass; ungrouped it ignored `series` and answered the single `op`/`field` — so
+            # "average of these 56 columns over everything" was unaskable, and asking it with an op
+            # that needs a field but no field to give came back 400.
+            #
+            # It is the shape a chart's OVERALL line needs: the same measures as the per-group
+            # lines, over the whole selection rather than one group. Answered in the same shape as
+            # the grouped reply (`values` alongside `value`) so the client reads one thing.
+                if spec.get("series"):
+                    series = _series_specs(spec, known)
+                    vals = ", ".join(_duck_value_expr(sp["op"], sp.get("field"))
+                                     for sp in series)
+                    row = conn.execute(
+                        f"SELECT {vals}, COUNT(*) FROM {src} {where_sql}").fetchone()
+                    values = [_num(row[i]) for i in range(len(series))] if row else []
+                    return {"op": op, "value": values[0] if values else None, "values": values,
+                            "count": int(row[len(series)]) if row else 0,
+                            "series": [{"label": sp["label"], "op": sp["op"],
+                                        "field": sp.get("field")} for sp in series]}
                 row = conn.execute(
                     f"SELECT {value}, COUNT(*) FROM {src} {where_sql}").fetchone()
                 return {"op": op, "value": _num(row[0]) if row else None,

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -1052,6 +1052,34 @@ async def _postgis_profile_uncached(db, layer, spec: dict) -> dict:
 #: chart, not more dots — and the browser has to draw every one of them.
 SCATTER_MAX_POINTS = 3000
 
+#: How many columns may name a scatter's points. Three is a line of hover text; more is a record,
+#: and a record belongs in the details panel, which is what a click already fills.
+MAX_LABEL_FIELDS = 3
+
+
+def _label_fields(spec: dict, known) -> list[str]:
+    """The columns a scatter's hover label is built from, validated like any other field.
+
+    A scatter plots two numbers per feature and, without this, says nothing about WHICH feature: the
+    reader can see an outlier and has no way to find out what it is. The label is built server-side
+    because the point is already being read there — sending the columns back so the browser can
+    concatenate them would be the same bytes and one more thing to keep in step.
+    """
+    out, seen = [], set()
+    for name in (spec.get("labelFields") or [])[:MAX_LABEL_FIELDS]:
+        if not isinstance(name, str) or name in seen:
+            continue
+        _check_field(name, known, "label field")
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def _label_of(row, start: int, count: int) -> str:
+    """One row's label, from `count` values beginning at `row[start]`."""
+    parts = [str(row[start + i]) for i in range(count) if row[start + i] is not None]
+    return " · ".join(parts)
+
 
 def _scatter_fields(spec: dict, known: set[str]) -> tuple[str, str]:
     x = _check_field(spec.get("xField"), known, "X field")
@@ -1087,14 +1115,19 @@ def _parquet_scatter_uncached(layer, spec: dict) -> dict:
         keep = f"{xe} IS NOT NULL AND {ye} IS NOT NULL"
         where_sql = (where_sql + " AND " + keep) if where_sql else ("WHERE " + keep)
 
+        labels = _label_fields(spec, known)
+        lab_sel = "".join(", " + qi(c) for c in labels)
         if geom is None:
             rows = conn.execute(
-                f"SELECT {xe} AS x, {ye} AS y FROM {src} {where_sql} "
+                f"SELECT {xe} AS x, {ye} AS y{lab_sel} FROM {src} {where_sql} "
                 f"USING SAMPLE {limit} ROWS").fetchall()
             total = conn.execute(f"SELECT COUNT(*) FROM {src} {where_sql}").fetchone()[0]
             pts = [[_num(r[0]), _num(r[1])] for r in rows]
-            return {"points": pts, "x": xf, "y": yf, "total": int(total or 0),
-                    "sampled": len(pts) < int(total or 0), "capped": False}
+            out = {"points": pts, "x": xf, "y": yf, "total": int(total or 0),
+                   "sampled": len(pts) < int(total or 0), "capped": False}
+            if labels:
+                out["labels"] = [_label_of(r, 2, len(labels)) for r in rows]
+            return out
 
         # With a geometry filter the exact test has to run before the sample, or the sample is drawn
         # from candidates that are not in the selection. Candidates are bounded by CANDIDATE_CAP as
@@ -1102,7 +1135,7 @@ def _parquet_scatter_uncached(layer, spec: dict) -> dict:
         from shapely import from_wkb, intersects
         geom_col = _duck_geom_col(meta, cols)
         rows = conn.execute(
-            f"SELECT {qi(geom_col)} AS __wkb, {xe} AS x, {ye} AS y FROM {src} {where_sql} "
+            f"SELECT {qi(geom_col)} AS __wkb, {xe} AS x, {ye} AS y{lab_sel} FROM {src} {where_sql} "
             f"LIMIT {CANDIDATE_CAP + 1}").fetchall()
         capped = len(rows) > CANDIDATE_CAP
         rows = rows[:CANDIDATE_CAP]
@@ -1121,8 +1154,12 @@ def _parquet_scatter_uncached(layer, spec: dict) -> dict:
             # order, so truncating would again plot one corner.
             step = total / float(limit)
             kept = [kept[int(i * step)] for i in range(limit)]
-        return {"points": [[_num(r[1]), _num(r[2])] for r in kept], "x": xf, "y": yf,
-                "total": total, "sampled": total > limit, "capped": capped}
+        out = {"points": [[_num(r[1]), _num(r[2])] for r in kept], "x": xf, "y": yf,
+               "total": total, "sampled": total > limit, "capped": capped}
+        if labels:
+            # 3, not 2: this SELECT leads with the geometry.
+            out["labels"] = [_label_of(r, 3, len(labels)) for r in kept]
+        return out
     finally:
         conn.close()
 
@@ -1154,12 +1191,17 @@ async def _postgis_scatter_uncached(db, layer, spec: dict) -> dict:
     where = (where + " AND " + keep) if where else ("WHERE " + keep)
 
     total = (await db.execute(text(f"SELECT COUNT(*) FROM {table} {where}"), params)).scalar() or 0
+    labels = _label_fields(spec, known)
+    lab_sel = "".join(", " + qi(c) for c in labels)
     rows = (await db.execute(text(
-        f"SELECT {xe} AS x, {ye} AS y FROM {table} {where} ORDER BY random() LIMIT {limit}"),
-        params)).fetchall()
+        f"SELECT {xe} AS x, {ye} AS y{lab_sel} FROM {table} {where} "
+        f"ORDER BY random() LIMIT {limit}"), params)).fetchall()
     pts = [[_num(r[0]), _num(r[1])] for r in rows]
-    return {"points": pts, "x": xf, "y": yf, "total": int(total),
-            "sampled": len(pts) < int(total), "capped": False}
+    out = {"points": pts, "x": xf, "y": yf, "total": int(total),
+           "sampled": len(pts) < int(total), "capped": False}
+    if labels:
+        out["labels"] = [_label_of(r, 2, len(labels)) for r in rows]
+    return out
 
 
 def parquet_aggregate(layer, spec: dict) -> dict:

--- a/api/geodeploy/services/aggregate.py
+++ b/api/geodeploy/services/aggregate.py
@@ -1467,9 +1467,11 @@ def _pg_types(layer) -> dict[str, str]:
 #: ticks, not legend entries, and four of them is a two-year timeline.
 #:
 #: What the server should bound is the QUERY: N measures are N aggregate expressions in one pass
-#: over one grouping, and twenty-four of those is still one scan. The builder keeps its own limit of
-#: four for hand-authored measures, where the legend argument does apply.
-MAX_SERIES = 24
+#: over one grouping, and a hundred of those is still one scan. Raised from 24 the first time a real
+#: file turned up: GDP per capita 1960-2016 is 57 columns, and a limit set to a comfortable-looking
+#: number rather than a measured one is a limit that fails on the first honest use. The builder keeps
+#: its own limit of four for hand-authored measures, where the legend argument does apply.
+MAX_SERIES = 120
 
 
 def _series_label(op: str, field: str | None) -> str:

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -483,11 +483,17 @@ def _normalize_style(widget_type: str, style: dict | None) -> dict:
                           "label": (_str(band.get("label")) or "")[:24]})
         bands.sort(key=lambda b: b["from"])
         out["bands"] = bands
-    if widget_type == "indicator":
-        # Comparison / target value — "vs. last month". `compareMode` says how to render the delta.
+    # The TARGET is a gauge's setting as much as an indicator's — arguably more, since a gauge exists
+    # to answer "are we there yet" and draws the target as a mark across its dial. It was normalised
+    # for the indicator alone, so a gauge could be given one in the builder and the publish step
+    # would drop it before the runtime ever saw it.
+    if widget_type in ("indicator", "gauge"):
         target = _num(s.get("target"), None)
         if target is not None:
             out["target"] = target
+    if widget_type == "indicator":
+        # How the delta against that target is rendered — "vs. last month". Indicator only: a gauge
+        # shows the comparison as a position on its arc, not as a signed number.
         out["compareMode"] = _str(s.get("compareMode"), {"delta", "percent", "none"}, "delta")
         out["goodDirection"] = _str(s.get("goodDirection"), {"up", "down", "none"}, "up")
     color = _hex(s.get("color"))

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -87,6 +87,11 @@ TIME_BUCKETS = {"hour", "day", "week", "month", "quarter", "year"}
 #: Mirrors `services/aggregate.MAX_SERIES`.
 MAX_CHART_SERIES = 4
 
+#: How many columns may form the X axis when a chart plots WIDE data — one column per year, per
+#: month, per survey round. Bounded by `aggregate.MAX_SERIES`, which is what the request becomes:
+#: one aggregate expression per column, in a single grouped scan.
+MAX_X_COLUMNS = 24
+
 #: How many join keys a map may pull into a style expression before it stops narrowing and says so.
 #: Offered as a short list because the trade-off is real in both directions: too low and the map
 #: gives up on selections it could have drawn, too high and every filter change moves a large
@@ -318,6 +323,21 @@ def _normalize_source(widget_type: str, source: dict | None) -> dict | None:
     if widget_type == "chart":
         ref["groupBy"] = _str(src.get("groupBy"))
         ref["timeBucket"] = _str(src.get("timeBucket"), TIME_BUCKETS)
+        # WIDE DATA: a set of columns that are really one variable measured repeatedly — gdp_1990,
+        # gdp_2000, gdp_2010. Named here, they become the chart's X axis, one aggregate each, and
+        # whatever `groupBy` says becomes a line per group rather than the axis.
+        #
+        # It is a reshape of the ANSWER, not a second query path: the request is the existing
+        # multi-measure one (one aggregate expression per column in a single grouped scan) and the
+        # runtime transposes what comes back. So there is nothing here the engines do not already do.
+        xcols, seen = [], set()
+        for c in (src.get("xColumns") or [])[:MAX_X_COLUMNS]:
+            name = _str(c)
+            if name and name not in seen:      # a column twice is a duplicated axis tick
+                seen.add(name)
+                xcols.append(name)
+        if xcols:
+            ref["xColumns"] = xcols
         ref["limit"] = _int(src.get("limit"), 12, 2, 100)
         ref["sort"] = _str(src.get("sort"), {"value_desc", "value_asc", "key_asc"}, "value_desc")
         # SEVERAL measures against the one grouping — "mean height AND mean age per district". Each

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -693,6 +693,19 @@ def resolve_dashboard(config: dict | None) -> dict | None:
             "cols": GRID_COLS,                                  # fixed: the builder's own geometry
             "rowHeight": _int(grid.get("rowHeight"), 90, 40, 240),
             "gap": _int(grid.get("gap"), 10, 0, 32),
+            # HOW THE BOARD MEETS THE SCREEN.
+            #
+            # "rows" is the original and stays the default, so no published dashboard changes: every
+            # row is exactly `rowHeight`, the board is as tall as its content, and a screen taller
+            # than that shows background below it. That is right for a long board someone scrolls
+            # and wrong for the case a dashboard is usually built for — one screen, taken in at a
+            # glance — where a board authored on a laptop leaves a third of a desktop monitor empty.
+            #
+            # "screen" makes the rows share the height instead. It cannot be a guarantee, and does
+            # not pretend to be: the runtime asks for `minmax(rowHeight, 1fr)`, so the rows stretch
+            # when there is room and fall back to scrolling when there is not. A phone, a portrait
+            # monitor and a board with thirty rows all land on the same floor they have today.
+            "fit": _str(grid.get("fit"), {"rows", "screen"}, "rows"),
         },
         "refresh": _int(config.get("refresh"), 0, 0, REFRESH_MAX) if config.get("refresh") else 0,
         "widgets": widgets,

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -496,6 +496,14 @@ def _normalize_style(widget_type: str, style: dict | None) -> dict:
         # shows the comparison as a position on its arc, not as a signed number.
         out["compareMode"] = _str(s.get("compareMode"), {"delta", "percent", "none"}, "delta")
         out["goodDirection"] = _str(s.get("goodDirection"), {"up", "down", "none"}, "up")
+    # AXIS TITLES. A column name is what the data is called; the title is what it measures, and the
+    # two are rarely the same string — least of all after a shapefile has cut the first to ten
+    # characters. Only where there are axes to title: a pie has none, an indicator has none.
+    if widget_type in ("chart", "scatter"):
+        for key in ("xTitle", "yTitle"):
+            title = _str(s.get(key))
+            if title:
+                out[key] = title[:40]
     color = _hex(s.get("color"))
     if color:
         out["color"] = color

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -338,6 +338,21 @@ def _normalize_source(widget_type: str, source: dict | None) -> dict | None:
                 xcols.append(name)
         if xcols:
             ref["xColumns"] = xcols
+            # WHAT THE TICKS SAY once the shared part of the column names is gone. `gdp60, gdp61`
+            # already trim to `60, 61`; these turn those into what they stand for.
+            #
+            #   offset   arithmetic on a label that is a number — 60 + 1900 = 1960
+            #   pattern  text around it, `{}` being the label — `19{}` also gives 1960, and
+            #            `Q{}` gives Q1; applied after the offset, so the two compose
+            #
+            # Two knobs rather than one expression language: an author writing an axis label should
+            # not be writing code, and these cover the cases the data actually produces.
+            ref["xLabelOffset"] = _num(src.get("xLabelOffset"), 0)
+            pattern = _str(src.get("xLabelPattern"))
+            if pattern and "{}" in pattern:
+                # A pattern with no placeholder would render every tick identically — the same label
+                # repeated across the axis. Dropped rather than obeyed.
+                ref["xLabelPattern"] = pattern[:24]
         ref["limit"] = _int(src.get("limit"), 12, 2, 100)
         ref["sort"] = _str(src.get("sort"), {"value_desc", "value_asc", "key_asc"}, "value_desc")
         # SEVERAL measures against the one grouping — "mean height AND mean age per district". Each

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -254,6 +254,12 @@ def _normalize_source(widget_type: str, source: dict | None) -> dict | None:
         # narrowed rather than quietly drawing everything. Default False because a map that narrows
         # for a small selection and stops for a large one is a worse thing to hand someone
         # unasked-for than a map that never claimed to narrow at all.
+        # ON by default, unlike `linkedFilter`. The two are opposites in what they risk: following a
+        # linked filter can leave a map that LOOKS filtered and is not, which must be opted into;
+        # framing the features a chart just selected is only a camera move, and it is what almost
+        # everyone expects when they click a bar. Off is one checkbox away for the dashboards where
+        # comparing categories in a fixed frame matters more.
+        out["zoomToFilter"] = bool(src.get("zoomToFilter", True))
         out["linkedFilter"] = bool(src.get("linkedFilter"))
         # A CHOICE, not a free number. The failure mode of too large a value is a sluggish map and a
         # fat response rather than an error, which is the kind of setting an author should not be

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -338,6 +338,10 @@ def _normalize_source(widget_type: str, source: dict | None) -> dict | None:
                 xcols.append(name)
         if xcols:
             ref["xColumns"] = xcols
+            # An overall line across the columns, beside the per-group ones. Its own question:
+            # "one line per country" and "the average of all of them" are different answers, and
+            # averaging the plotted lines would average the TOP N groups rather than the selection.
+            ref["meanLine"] = bool(src.get("meanLine"))
             # WHAT THE TICKS SAY once the shared part of the column names is gone. `gdp60, gdp61`
             # already trim to `60, 61`; these turn those into what they stand for.
             #

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -520,6 +520,12 @@ def _normalize_style(widget_type: str, style: dict | None) -> dict:
             title = _str(s.get(key))
             if title:
                 out[key] = title[:40]
+    # The line under the title. Every widget has one and none of them could be written: it is
+    # generated from the layer and the aggregation, which describes the QUERY where the reader wants
+    # the subject. Not per-type, because every widget draws one.
+    subtitle = _str(s.get("subtitle"))
+    if subtitle:
+        out["subtitle"] = subtitle[:48]
     color = _hex(s.get("color"))
     if color:
         out["color"] = color

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -90,7 +90,7 @@ MAX_CHART_SERIES = 4
 #: How many columns may form the X axis when a chart plots WIDE data — one column per year, per
 #: month, per survey round. Bounded by `aggregate.MAX_SERIES`, which is what the request becomes:
 #: one aggregate expression per column, in a single grouped scan.
-MAX_X_COLUMNS = 24
+MAX_X_COLUMNS = 120
 
 #: How many join keys a map may pull into a style expression before it stops narrowing and says so.
 #: Offered as a short list because the trade-off is real in both directions: too low and the map

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -320,6 +320,18 @@ def _normalize_source(widget_type: str, source: dict | None) -> dict | None:
             # keeps the widget alive and showing a true number, which is better than a red box: the
             # author sees a count where they expected a sum and fixes the binding.
             ref["op"] = "count"
+    if widget_type == "scatter":
+        # Columns that NAME each point on hover. A scatter plots two numbers per feature and, with
+        # nothing else, cannot say which feature they belong to — the reader sees an outlier and has
+        # no way to find out what it is.
+        names, seen = [], set()
+        for c in (src.get("labelFields") or [])[:3]:
+            name = _str(c)
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+        if names:
+            ref["labelFields"] = names
     if widget_type == "chart":
         ref["groupBy"] = _str(src.get("groupBy"))
         ref["timeBucket"] = _str(src.get("timeBucket"), TIME_BUCKETS)

--- a/api/geodeploy/services/dashboard.py
+++ b/api/geodeploy/services/dashboard.py
@@ -512,6 +512,12 @@ def _normalize_style(widget_type: str, style: dict | None) -> dict:
         # shows the comparison as a position on its arc, not as a signed number.
         out["compareMode"] = _str(s.get("compareMode"), {"delta", "percent", "none"}, "delta")
         out["goodDirection"] = _str(s.get("goodDirection"), {"up", "down", "none"}, "up")
+    if widget_type == "scatter":
+        # HOW BIG A DOT IS, in SVG px of radius. The right answer depends on how many points land on
+        # the card — a dozen features want a mark you can see and aim at, a few thousand want a grain
+        # that overlaps into a shape — and that is a fact about the data, so the author sets it.
+        # 3.5 is the default because the previous fixed 2 read as dust on a small card.
+        out["pointSize"] = max(1.5, min(8.0, _num(s.get("pointSize"), 3.5)))
     # AXIS TITLES. A column name is what the data is called; the title is what it measures, and the
     # two are rarely the same string — least of all after a shapefile has cut the first to ten
     # characters. Only where there are axes to title: a pie has none, an indicator has none.

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -18,28 +18,41 @@ from . import symbology
 # baked into every published portal as `geodeploy.basemaps` (so templates/shared/portal.js and
 # ui/src/views/PortalEditor.vue both consume it at runtime — neither hard-codes the catalog).
 BASEMAP_CATALOG = [
-    {"id": "positron", "name": "Positron",
-     "tiles": ["https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-               "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-               "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"],
-     "attribution": "© OpenStreetMap © CARTO",
-     "thumb": "https://a.basemaps.cartocdn.com/light_all/4/8/5.png"},
-    {"id": "voyager", "name": "Voyager",
-     "tiles": ["https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-               "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-               "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png"],
-     "attribution": "© OpenStreetMap © CARTO",
-     "thumb": "https://a.basemaps.cartocdn.com/rastertiles/voyager/4/8/5.png"},
-    {"id": "dark", "name": "Dark Matter",
-     "tiles": ["https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png",
-               "https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png"],
-     "attribution": "© OpenStreetMap © CARTO",
-     "thumb": "https://a.basemaps.cartocdn.com/dark_all/4/8/5.png"},
+    # OpenStreetMap FIRST, and therefore the default.
+    #
+    # It is also the thumbnail the switcher shows for the "Default" option on a portal published
+    # before basemaps were selectable (`BASEMAP_CATALOG[0].thumb` in portal.js) — which, while a
+    # CARTO style led this list, was a tile with API KEY REQUIRED printed across it.
     {"id": "osm", "name": "OpenStreetMap",
      "tiles": ["https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
                "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png"],
      "attribution": "© OpenStreetMap contributors",
      "thumb": "https://a.tile.openstreetmap.org/4/8/5.png"},
+
+    # ── The three that used to be CARTO ──────────────────────────────────────────────────────────
+    # CARTO now requires an API key. It does not refuse an unauthenticated request — it answers 200
+    # with the map, and "API KEY REQUIRED / carto.com/basemaps/apikey" watermarked diagonally across
+    # EVERY tile at EVERY zoom. So a portal on one of these did not fail; it silently went branded.
+    #
+    # THE IDS ARE DELIBERATELY UNCHANGED. Nine official templates name `positron`, and every portal
+    # already published records its choice by id in `geodeploy.defaultBasemap`. Renaming would break
+    # all of them for a tidier internal string, so the id stays what it always was and the NAME says
+    # what it now shows. An id is an identifier; only the label is a description.
+    {"id": "positron", "name": "Light Gray",
+     "tiles": ["https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"],
+     "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors",
+     "thumb": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/4/5/8"},
+    {"id": "voyager", "name": "Humanitarian",
+     "tiles": ["https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+               "https://b.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+               "https://c.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"],
+     "attribution": "© OpenStreetMap contributors | Tiles: Humanitarian OSM Team, hosted by OpenStreetMap France",
+     "thumb": "https://a.tile.openstreetmap.fr/hot/4/8/5.png"},
+    {"id": "dark", "name": "Dark Gray",
+     "tiles": ["https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"],
+     "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors",
+     "thumb": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/4/5/8"},
+
     {"id": "topo", "name": "OpenTopoMap",
      "tiles": ["https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
                "https://b.tile.opentopomap.org/{z}/{x}/{y}.png"],
@@ -54,6 +67,7 @@ BASEMAP_CATALOG = [
      "attribution": "© Esri",
      "thumb": "https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/4/5/8"},
 ]
+
 _BASEMAP_BY_ID = {b["id"]: b for b in BASEMAP_CATALOG}
 
 
@@ -2026,11 +2040,11 @@ def _default_basemap() -> dict:
             "basemap": {
                 "type": "raster",
                 "tiles": [
-                    "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-                    "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
+                    "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                    "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
                 ],
                 "tileSize": 256,
-                "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>",
+                "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
             }
         },
         "layers": [{"id": "basemap", "type": "raster", "source": "basemap"}],

--- a/api/tests/test_dashboard_archetype.py
+++ b/api/tests/test_dashboard_archetype.py
@@ -324,6 +324,23 @@ def test_gauge_range_cannot_be_inverted():
     assert style["max"] > style["min"]
 
 
+def test_scatter_points_have_a_visible_default_size_and_a_settable_one():
+    """2px read as dust on a small card, so the default is 3.5 and the author can change it — how
+    big a dot should be depends on how many of them land on the card, which the renderer cannot
+    know."""
+    def size(style):
+        out = resolve_dashboard({"widgets": [
+            _w("s", "scatter", dataSource={"layerType": "vector", "layerId": 1,
+                                           "xField": "a", "yField": "b"}, style=style)]})
+        return out["widgets"][0]["style"]["pointSize"]
+
+    assert size({}) == 3.5
+    assert size({"pointSize": 6}) == 6
+    assert size({"pointSize": 500}) == 8.0          # not a blob covering the plot
+    assert size({"pointSize": 0}) == 1.5            # nor an invisible one
+    assert size({"pointSize": "big"}) == 3.5        # nonsense falls back, it does not crash
+
+
 def test_refresh_is_bounded():
     assert resolve_dashboard({"refresh": 999999, "widgets": [_w("a", "indicator")]})["refresh"] == 3600
     assert resolve_dashboard({"widgets": [_w("a", "indicator")]})["refresh"] == 0

--- a/api/tests/test_dashboard_archetype.py
+++ b/api/tests/test_dashboard_archetype.py
@@ -341,6 +341,23 @@ def test_scatter_points_have_a_visible_default_size_and_a_settable_one():
     assert size({"pointSize": "big"}) == 3.5        # nonsense falls back, it does not crash
 
 
+def test_filling_the_screen_is_opt_in_and_leaves_published_boards_alone():
+    """The row height is the floor either way; "screen" only lets the rows stretch past it. Default
+    stays "rows" because changing it would restyle every dashboard already published."""
+    def fit(grid):
+        return resolve_dashboard({"grid": grid, "widgets": [_w("a", "indicator")]})["grid"]["fit"]
+
+    assert fit({}) == "rows"
+    assert fit({"fit": "screen"}) == "screen"
+    assert fit({"fit": "rows"}) == "rows"
+    assert fit({"fit": "stretch-everything"}) == "rows"   # not a mode we offer
+    assert fit({"fit": True}) == "rows"
+    # the floor the stretch is measured against is still the author's row height
+    out = resolve_dashboard({"grid": {"fit": "screen", "rowHeight": 120},
+                             "widgets": [_w("a", "indicator")]})
+    assert out["grid"]["rowHeight"] == 120
+
+
 def test_refresh_is_bounded():
     assert resolve_dashboard({"refresh": 999999, "widgets": [_w("a", "indicator")]})["refresh"] == 3600
     assert resolve_dashboard({"widgets": [_w("a", "indicator")]})["refresh"] == 0

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,15 @@ End-user / operator documentation (not developer internals — those live in eac
 - User-facing docs; for build quirks and debugging history use `notes_temp/notes_for_future.md` instead.
 
 ## Last updated
+2026-08-31 (**SEO pass + v1.5.1.** Every page now carries its own `description:` front matter —
+all eighteen were falling back to `site_description` from mkdocs.yml, so every GeoDeploy search
+result shipped an identical snippet. `index.md` also gained a `title:` so its `<title>` carries the
+words people search ("self-hosted geoportal builder") while the visible H1 stays the hero line; the
+nav label is unaffected because mkdocs.yml names it. Fixed a dead hero link — the button still
+pointed at `#three-kinds-of-portal`, which became "Four kinds" when dashboards shipped.
+`dashboards.md` documents the v1.5.1 authoring options; `roadmap.md` gained the v1.5.1 stop and its
+header now says v1.5.1 rather than v1.4.1.)
+
 2026-08-18 (link previews: `overrides/main.html` + `assets/og-image.png`.)
 2026-07-30 (created `api-reference.md` — the root README's link to it had always been dead; indexed
 `backups.md` + `roadmap.html`, which this file had never learned about; recorded the docs-site

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The GeoDeploy HTTP API: authentication, layers, portals, styling, uploads and administration, with the OpenAPI schema every instance serves.
+---
+
 # API reference
 
 Every GeoDeploy instance serves its **own** interactive, always-current API reference — generated

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Scheduled backups of database, files and state to a separate destination, backup history, and restoring a GeoDeploy instance in place.
+---
+
 # Backups and restore
 
 GeoDeploy can copy everything that cannot be regenerated to a **separate object store**: the

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Publish a searchable geospatial data catalog: browse and filter layers by metadata, preview them on a map, and download or connect to them over open standards.
+---
+
 # Catalogs
 
 A **catalog** is a browsing surface, for when you have more datasets than a single map should show

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The `geodeploy` command-line client: upload many files at once, style layers with data-driven symbology, build and publish portals, and administer an instance from a terminal.
+---
+
 # The command line
 
 **`geodeploy` — upload data, build and publish portals, and operate an instance, without a browser.**

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build a geospatial dashboard: a grid of charts, indicators, tables and a map that cross-filter each other, with aggregates computed in PostGIS or DuckDB rather than in the browser.
+---
+
 # Dashboards
 
 A **dashboard** is a portal where the map is one widget among many. Charts, numbers, lists and
@@ -58,23 +63,53 @@ resizable.
     as far as they must to stay legible. If too many are still dropped for your taste, a
     **horizontal** bar chart gives every category its own full-width label.
 
-    A pie or donut has a **plot size**, separate from the widget's size. The legend sits under the
-    circle, and growing the widget grows both together — so when a long legend ends up in a
-    scrollbar, shrink the plot rather than enlarging the card.
+    **The legend gets its room before the plot does.** Any chart with a key — a pie, a donut, or a
+    line or bar chart with more than one measure — measures the key first and gives the plot what
+    is left, so the key is never pushed out of sight and making the widget taller gives every new
+    pixel to the plot. **Plot size** overrules that: leave it at 100% (auto) for the measured
+    split, or move it down to hand the plot a fixed share of the card and let a long key scroll in
+    the remainder. Twelve series wrap to several lines, and sometimes the shape matters more than
+    the names.
 
     **Several measures at once** — a chart can plot more than one aggregate against the same
     grouping ("mean height *and* mean age per district"). Lines are drawn per measure with a
     legend; bars become clustered groups. Colour then identifies the *measure*, not the category,
     because with several lines on one axis colour is the only thing telling them apart.
 
+    **Columns as the X axis** — for data stored wide, one column per year or per period
+    (`gdp1960`, `gdp1961`, …). Choose the columns instead of a grouping field and each becomes a
+    point on the axis, with the groups as the series. Up to 120 columns, with a select-all rather
+    than 120 clicks.
+
+    Column names rarely make good tick labels, so they can be **trimmed and shifted**: strip the
+    shared prefix to leave the numbers, and add an offset when the numbers are not the values you
+    want (`gdp1` + 1959 reads as `1960`). An **overall line** can be drawn across the whole current
+    selection, for a mean to read the individual series against.
+
+    **Axis titles and the subtitle** are yours to write. A column name is what the data is called,
+    not what it measures — and after a shapefile has cut it to ten characters it is often neither.
+    The heading at the top right of the card follows the titles you set.
+
     **Scatter** — one dot per feature, two numeric columns against each other. This is the only
     chart that plots features rather than a summary of them, so it is **sampled**: a random sample,
     never the first N rows, and it says so under the plot when a sample is what you are seeing.
+
+    A scatter can **name its points on hover** — nominate up to three columns and the dot says
+    which feature it is. Without that a scatter shows two numbers per feature and cannot say whose
+    they are, which makes an outlier visible and unidentifiable. **Point size** is adjustable: a
+    dozen features want a mark you can see and aim at, a few thousand want a grain small enough
+    that overlapping dots read as density.
 
 === "Lists"
 
     **List / table** — attribute rows, sortable, paged on the server. Clicking a row zooms the map
     to that feature and fills the details panel.
+
+    **Several rows at once**, with the conventions every desktop list uses: <kbd>Ctrl</kbd> (or
+    <kbd>Cmd</kbd>) adds and removes one, <kbd>Shift</kbd> takes the run between. The map fits the
+    whole selection rather than the row last clicked — it widens to hold a row you add and narrows
+    when you remove one — and the selection survives turning the page, so rows chosen on page one
+    keep filtering while you pick more from page two.
 
     The same widget has a **cards** layout: a directory rather than a spreadsheet, one card per
     feature with a heading and a few fields under it. Useful for the datasets people look things
@@ -120,6 +155,15 @@ There are three channels, and they behave differently on purpose.
 Filters combine with **AND**. A selector and a map selection both active narrow the result; they do
 not replace one another. Everything currently narrowing the page appears as a chip in the filter
 bar at the bottom, and each chip can clear itself.
+
+A *new* selection from the same widget **replaces** its previous one rather than adding to it —
+drawing a box after clicking a feature does not ask for the features that are both, which is a
+question with no answer. Selections from *different* widgets still combine, which is the point.
+
+**Zooming to what was chosen.** Clicking a bar or a pie slice can also fly the map to the extent of
+what it selected, so the filter and the view agree. It is on by default for chart clicks and can be
+turned off per widget; map clicks and drawn areas never move the camera, because the visitor is
+already looking at the place they clicked.
 
 ### Why geometry crosses layers and attributes do not
 
@@ -260,6 +304,19 @@ A pinned widget is sized in pixels rather than grid columns, and can **start col
 one button that opens when clicked and closes on <kbd>Esc</kbd>. That is usually what a search box
 wants: needed for a few seconds, in the way for the rest of the time. While collapsed the widget is
 hidden rather than destroyed, so it keeps its results and any filter it published.
+
+---
+
+## Filling the screen
+
+By default every grid row is exactly the row height you set, so the board is as tall as its content
+and no taller — a board laid out on a laptop leaves empty space below it on a large monitor.
+
+**Fill the screen** makes the rows share the height of the window instead. The proportions hold: a
+widget two rows tall still gets twice one row. It stretches but never squeezes — your row height
+stays the floor — so a phone, a portrait display, or simply a board with many widgets scrolls
+exactly as it does now. No single setting can be right for every screen a portal is opened on, so
+it is worth looking at the board at the sizes your readers actually use.
 
 ---
 

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Read your GeoDeploy layers from QGIS, Python and R over open standards: OGC API - Features, STAC, vector tiles, Cloud-Optimized GeoTIFF, GeoParquet and PMTiles.
+---
+
 # Accessing your data from other tools
 
 **QGIS · GeoLibre · DuckDB · Python · R · anything that speaks HTTP.**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Install GeoDeploy on a Linux server with one command: the Docker Compose stack, PostGIS, object storage and the setup wizard that takes you from a bare VPS to your first published map.
+---
+
 # Getting Started
 
 ## What you need

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
 ---
+title: Self-hosted geoportal builder and spatial data platform
+description: >-
+  GeoDeploy is an open-source, self-hosted geoportal builder and spatial data platform. Publish web maps, dashboards, story maps and catalogs from your own server with PostGIS, MapLibre and Docker Compose.
 hide:
   - navigation
   - toc
@@ -16,7 +19,7 @@ own storage, and no per-seat pricing.
 
 [Try the demo](https://geodeploy-demo.kndev.org){ .md-button .md-button--primary }
 [Get started](getting-started.md){ .md-button }
-[See what it publishes](#three-kinds-of-portal){ .md-button }
+[See what it publishes](#four-kinds-of-portal){ .md-button }
 
 <p class="gd-demo-note" markdown>
 No sign-up — join with a name and you can upload, style and publish. Everything is wiped hourly.

--- a/docs/licence.md
+++ b/docs/licence.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  GeoDeploy is open source under the Apache License 2.0 — what that permits and what the third-party components are licensed under.
+---
+
 # Licence
 
 GeoDeploy is **open source under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)**.

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Tune a GeoDeploy instance for large data: choosing PostGIS or GeoParquet per layer, tile caching, aggregate caching, and what a small server can actually carry.
+---
+
 # Performance tuning (heavy layers & tiling)
 
 GeoDeploy runs on a small server with sensible defaults, and **a normal install needs no tuning at

--- a/docs/portals.md
+++ b/docs/portals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The four portal experiences GeoDeploy publishes — web map, story map, catalog and dashboard — how each is built, who can see it, and how to embed one in another site.
+---
+
 # Portals and experiences
 
 A **portal** is a published map with its own URL. You pick the layers, arrange them, choose how the

--- a/docs/qgis.md
+++ b/docs/qgis.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The GeoDeploy QGIS plugin: browse an instance from inside QGIS, load layers, and push styled layers back up to publish them.
+---
+
 # The QGIS plugin
 
 Browse a GeoDeploy instance from inside QGIS, add its layers, restyle them, and publish back —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,11 @@
+---
+description: >-
+  What GeoDeploy has shipped, release by release, and what is being built next.
+---
+
 # Roadmap
 
-GeoDeploy is at **v1.4.1**. Everything under *In v1.0* and in the releases after it is built and
+GeoDeploy is at **v1.5.1**. Everything under *In v1.0* and in the releases after it is built and
 running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
@@ -266,6 +271,40 @@ filters — for the questions a reader asks of the DATA rather than of the geogr
 - [x] **The map narrows every layer it draws**, each by its own filters — and a linked filter can
       narrow it too, behind a per-map opt-in with a chosen key limit and an on-map notice when it
       passes that limit rather than a map that looks narrowed and is not
+
+</div>
+
+<div class="gd-rel done" markdown>
+### v1.5.1 — a dashboard you can actually author
+<span class="gd-when">Shipped · 31 Aug 2026</span>
+
+<p class="gd-goal">v1.5 shipped the dashboard; this is a fortnight of building real ones with it.
+Almost every item here is something that could not be said, sized or read until someone tried —
+which is the only way this list could have been written.</p>
+
+- [x] **Wide data plots** — let the COLUMNS be the X axis, for data stored one column per year,
+      with the tick labels trimmed and shifted (`gdp1` + 1959 reads as `1960`) and an overall line
+      across the current selection
+- [x] **Words the author chooses** — axis titles, widget subtitles, and a card heading that follows
+      them. A column name is what the data is called, not what it measures
+- [x] **Charts that fit their card** — the legend takes its room before the plot does, on the
+      multi-series line, the grouped bars *and* the pie, with **Plot size** to overrule the split
+- [x] **Readable axes** — gridlines and ticks at intervals on line and scatter plots, a gauge that
+      no longer clips its own arc, and a histogram that names the range it covers
+- [x] **A scatter that says which feature a dot is** — hover labels from columns you nominate, and
+      a point size that suits twelve features or five thousand
+- [x] **Several table rows at once** — <kbd>Ctrl</kbd> and <kbd>Shift</kbd> as every desktop list
+      uses them, with the map fitting the whole selection and the selection surviving a page turn
+- [x] **A new selection replaces the last** rather than compounding with it — drawing a box after
+      clicking a feature was asking for the features that are both, and getting none
+- [x] **Fill the screen**, per dashboard: the rows share the window instead of each being the row
+      height, stretching where there is room and scrolling where there is not
+- [x] **Zoom to what a chart selected**, so the filter and the view agree
+- [x] **Basemaps that are free without an account** — CARTO out, OpenStreetMap first
+- [x] **A card thumbnail of the whole dashboard**, not of the map cell inside it
+- [x] **On the map itself** — draw tools you can drag clear of whatever they overlap, a coordinate
+      readout that names its CRS and shares one line with the scale bar and the attribution, and
+      both legible in dark mode
 
 </div>
 

--- a/docs/story-maps.md
+++ b/docs/story-maps.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build a scrollytelling story map where scrolling drives the camera — narrative sections bound to map views, published from your own server.
+---
+
 # Story maps
 
 A **story map** is scrollytelling. The page is a column of written sections, each pinned to a map

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update a self-hosted GeoDeploy instance from the browser or the command line, what the preflight checks, and how to pin or change the release channel.
+---
+
 # Updating
 
 GeoDeploy checks for new versions and can update itself from the dashboard. Everything lives under

--- a/docs/uploading.md
+++ b/docs/uploading.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Upload Shapefile, GeoPackage, GeoJSON, KML, CSV, GeoParquet and GeoTIFF data into GeoDeploy, including multi-gigabyte files that go straight to object storage.
+---
+
 # Uploading data
 
 **My Data** holds everything you have brought in. Vector layers and rasters are listed separately,

--- a/docs/users-and-sharing.md
+++ b/docs/users-and-sharing.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Roles from viewer to owner, per-layer visibility, invitation links, scoped API tokens and an audit log — how access works in a self-hosted GeoDeploy instance.
+---
+
 # Users, roles and sharing
 
 GeoDeploy is a **shared workspace**: everyone signed in sees the same catalog of layers and portals,

--- a/docs/web-maps.md
+++ b/docs/web-maps.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build a self-hosted web map: choose a basemap, order and style layers, add a legend, search and identify tools, and publish it at its own URL.
+---
+
 # Web maps
 
 A **web map** is the default experience and the right one when the map itself is the point: a

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,6 +248,13 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-31 (**a multi-series chart's key gets its room before the plot does.** `.gd-chart` is
+`height: 100%` and the legend is its sibling, so the plot claimed the whole body and pushed the key
+into the body's scrollbar — and making the widget taller grew the plot by exactly as much. The
+legend is now appended and measured first, and the plot is built for the remainder. `chartBox()`
+also reports the CONTENT box (it was returning `clientHeight`, 20px of padding included), because
+subtracting a legend from a figure that is already too big still overflows.)
+
 2026-08-31 (**the camera follows the whole selection.** `shared/dashboard.js`'s table/card widget
 holds `picked` as a Map of key -> bbox rather than a set of keys, and fits the map to the UNION on
 every selection change — ctrl-clicking a second row widens the view to hold both, removing one

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,6 +248,12 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-31 (`shared/portal.css`: the coordinate readout moves to **bottom-centre** of the map — the
+one stretch of the map edge nothing else claims, with the scale bar at bottom-left and the
+attribution at bottom-right. It had been pushed UP off the credit rather than sideways off it, so it
+can now share their line; below 640px it goes back to riding above them, where the scale bar reaches
+the middle.)
+
 2026-08-31 (**`grid.fit: "screen"` fills the viewport.** `placeAll` counts the rows the layout
 actually reaches (per breakpoint — the phone cursor and the desktop max are different numbers) and
 `applyRowTemplate` writes `grid-template-rows: repeat(N, minmax(var(--dash-row), 1fr))`. The author's

--- a/templates/README.md
+++ b/templates/README.md
@@ -255,7 +255,8 @@ layer indistinguishable. The SVG is loaded in the restricted mode images use and
 `collectCss()` inlines every readable rule (rewriting each selector's leading `html` / `body` /
 `:root` onto a wrapper that stands in for both, or every `body[data-archetype="dashboard"]` rule
 would miss), the WebGL canvas is swapped for a WebP still, and same-origin `<img>` are inlined. Any
-failure falls back to the map-only shot.)
+failure falls back to the map-only shot. Also: `shared/dashboard.js` scatter dots default to
+r=3.5 and honour `style.pointSize` — 2px read as dust on a small card.)
 
 2026-08-24 (**dashboard first-use round**, `shared/dashboard.{js,css}` + the four presets.
 `drawLine` now takes `selected` + `onPick`, so line and area charts are filter sources like bars and

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,12 +248,16 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
-2026-08-31 (**a multi-series chart's key gets its room before the plot does.** `.gd-chart` is
-`height: 100%` and the legend is its sibling, so the plot claimed the whole body and pushed the key
-into the body's scrollbar — and making the widget taller grew the plot by exactly as much. The
-legend is now appended and measured first, and the plot is built for the remainder. `chartBox()`
-also reports the CONTENT box (it was returning `clientHeight`, 20px of padding included), because
-subtracting a legend from a figure that is already too big still overflows.)
+2026-08-31 (**every plot shares its card with its key the same way.** `.gd-chart` is `height: 100%`
+and the key is its sibling, so the plot claimed the whole body and pushed the key into the
+scrollbar — and making the widget taller grew the plot by exactly as much. `plotHeight` /
+`capToRoom` / `fixPlotHeight` in `shared/dashboard.js` now serve the multi-series line, the grouped
+bars AND the pie, which all had the bug for the same reason. AUTO (`plotSize` unset or 100) measures
+the key and gives the plot the rest; a share below 100 hands the plot a fixed fraction and lets a
+long key scroll in the remainder. The key is capped either way, so a key taller than the whole card
+scrolls itself instead of pushing the plot out. `chartBox()` also reports the CONTENT box (it was
+returning `clientHeight`, 20px of padding included), because subtracting a key's height from a
+figure that is already too big still overflows.)
 
 2026-08-31 (**the camera follows the whole selection.** `shared/dashboard.js`'s table/card widget
 holds `picked` as a Map of key -> bbox rather than a set of keys, and fits the map to the UNION on

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,6 +248,12 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-31 (**the camera follows the whole selection.** `shared/dashboard.js`'s table/card widget
+holds `picked` as a Map of key -> bbox rather than a set of keys, and fits the map to the UNION on
+every selection change — ctrl-clicking a second row widens the view to hold both, removing one
+narrows it back. The bbox is remembered at pick time because a row scrolls off as soon as the
+visitor turns the page, so a set spanning two pages would otherwise fit only the last.)
+
 2026-08-31 (**a dashboard is photographed whole.** `shared/portal.js::snapshotDashboard()` renders
 the live page into a `<foreignObject>` and rasterises it, so a dashboard's card thumbnail shows the
 charts and tables rather than only the map cell — the map alone made two dashboards over the same

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,6 +248,14 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-31 (**`grid.fit: "screen"` fills the viewport.** `placeAll` counts the rows the layout
+actually reaches (per breakpoint — the phone cursor and the desktop max are different numbers) and
+`applyRowTemplate` writes `grid-template-rows: repeat(N, minmax(var(--dash-row), 1fr))`. The author's
+row height becomes a FLOOR rather than the height, so the board stretches where there is room and
+scrolls where there is not, with no media query having to guess the boundary; uniform rows mean a
+widget spanning four still gets four times one, so proportions survive. Default is `"rows"`, the
+existing behaviour, so no published board changes. `body[data-dash-fit]` publishes the mode.)
+
 2026-08-31 (**every plot shares its card with its key the same way.** `.gd-chart` is `height: 100%`
 and the key is its sibling, so the plot claimed the whole body and pushed the key into the
 scrollbar — and making the widget taller grew the plot by exactly as much. `plotHeight` /

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,11 +248,12 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
-2026-08-31 (`shared/portal.css`: the coordinate readout moves to **bottom-centre** of the map — the
-one stretch of the map edge nothing else claims, with the scale bar at bottom-left and the
-attribution at bottom-right. It had been pushed UP off the credit rather than sideways off it, so it
-can now share their line; below 640px it goes back to riding above them, where the scale bar reaches
-the middle.)
+2026-08-31 (`shared/portal.css`: the map's bottom chrome — scale bar, **bottom-centre** coordinate
+readout, attribution — sits on ONE line, on every archetype. `.maplibregl-ctrl-bottom-left` had
+carried `bottom: 24px` since the first shared-runtime refactor while `-bottom-right` kept MapLibre's
+0, so the scale bar floated above the credit everywhere. All three now hang off `--map-chrome-b`
+(the readout adds MapLibre's own 10px control margin, having none of its own), so the phone gutter
+and the storymap's lift over its narrative strip move the whole line instead of one corner each.)
 
 2026-08-31 (**`grid.fit: "screen"` fills the viewport.** `placeAll` counts the rows the layout
 actually reaches (per breakpoint — the phone cursor and the desktop max are different numbers) and

--- a/templates/README.md
+++ b/templates/README.md
@@ -248,6 +248,15 @@ AFTER portal.css so it overrides), `{{STYLE_JSON}}`, `{{POPUP_CONFIG}}`, `{{ACCE
   per portal (theming is already variable-based). Tracked as roadmap `V-10` (template gallery & branding).
 
 ## Last updated
+2026-08-31 (**a dashboard is photographed whole.** `shared/portal.js::snapshotDashboard()` renders
+the live page into a `<foreignObject>` and rasterises it, so a dashboard's card thumbnail shows the
+charts and tables rather than only the map cell — the map alone made two dashboards over the same
+layer indistinguishable. The SVG is loaded in the restricted mode images use and fetches NOTHING, so
+`collectCss()` inlines every readable rule (rewriting each selector's leading `html` / `body` /
+`:root` onto a wrapper that stands in for both, or every `body[data-archetype="dashboard"]` rule
+would miss), the WebGL canvas is swapped for a WebP still, and same-origin `<img>` are inlined. Any
+failure falls back to the map-only shot.)
+
 2026-08-24 (**dashboard first-use round**, `shared/dashboard.{js,css}` + the four presets.
 `drawLine` now takes `selected` + `onPick`, so line and area charts are filter sources like bars and
 pies — with a transparent 9px hit circle, because a 2.6px dot on a 30-point series is unaimable. The

--- a/templates/official/dashboard-assets/style.json
+++ b/templates/official/dashboard-assets/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/dashboard-directory/style.json
+++ b/templates/official/dashboard-directory/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/dashboard-explorer/style.json
+++ b/templates/official/dashboard-explorer/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/dashboard-monitoring/style.json
+++ b/templates/official/dashboard-monitoring/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/dashboard-regional/style.json
+++ b/templates/official/dashboard-regional/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/dashboard-zonal/style.json
+++ b/templates/official/dashboard-zonal/style.json
@@ -3,13 +3,11 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© Esri, HERE, Garmin, © OpenStreetMap contributors"
     }
   },
   "layers": [
@@ -17,7 +15,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/editorial/style.json
+++ b/templates/official/editorial/style.json
@@ -3,13 +3,13 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png"
+        "https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© OpenStreetMap contributors | Tiles: Humanitarian OSM Team, hosted by OpenStreetMap France"
     }
   },
   "layers": [
@@ -17,7 +17,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/minimal/style.json
+++ b/templates/official/minimal/style.json
@@ -3,13 +3,12 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
     }
   },
   "layers": [
@@ -17,7 +16,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/minimal/template.json
+++ b/templates/official/minimal/template.json
@@ -8,7 +8,7 @@
     "official"
   ],
   "language": "en",
-  "basemap": "osm-bright",
+  "basemap": "osm",
   "preview": "preview.png",
   "version": "1.0.0",
   "license": "Apache-2.0",

--- a/templates/official/story/style.json
+++ b/templates/official/story/style.json
@@ -3,13 +3,13 @@
     "basemap": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png"
+        "https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/attributions'>CARTO</a>"
+      "attribution": "© OpenStreetMap contributors | Tiles: Humanitarian OSM Team, hosted by OpenStreetMap France"
     }
   },
   "layers": [
@@ -17,7 +17,9 @@
       "id": "basemap",
       "type": "raster",
       "source": "basemap",
-      "paint": { "raster-opacity": 1 }
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }

--- a/templates/official/west-africa-fr/template.json
+++ b/templates/official/west-africa-fr/template.json
@@ -9,7 +9,7 @@
     "official"
   ],
   "language": "fr",
-  "basemap": "osm-bright",
+  "basemap": "osm",
   "preview": "preview.png",
   "version": "1.0.0",
   "license": "Apache-2.0",

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -37,6 +37,17 @@ body[data-archetype="dashboard"] #sidebar {
   z-index: 40; border: 1px solid var(--border); border-radius: var(--radius);
   box-shadow: var(--shadow-lg); overflow: hidden;
 }
+/* …and BECAUSE it is always an overlay, collapsed means the same thing in both modes: gone, with
+   the map's toggle to bring it back.
+   ─────────────────────────────────────────────────────────────────────────────────────────────
+   A DOCKED list collapses by going to `width: 0` (`#sidebar.collapsed`, specificity (1,1,0)),
+   which works because a docked list is a column whose width is the whole of its presence. The rule
+   above is (1,1,1) and sets a width unconditionally, so on a dashboard it outranked that and the
+   list stayed exactly as wide as before — the "start collapsed" checkbox did nothing at all in
+   docked mode, while floating collapsed fine because its own rule is (1,2,1).
+   Zero width would be the wrong repair anyway: this is an absolutely positioned overlay, so a
+   zero-width box is not a column that has closed, it is a sliver of border floating over a widget. */
+body[data-archetype="dashboard"] #sidebar.collapsed { display: none; }
 
 /* ── the card ─────────────────────────────────────────────────────────────── */
 body[data-archetype="dashboard"] .gd-w {
@@ -519,6 +530,12 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
      how the collapsed drawer broke in the first place. */
   body[data-archetype="dashboard"] #layout > #sidebar {
     position: fixed; top: var(--header-h); bottom: 0; z-index: 60;
+    /* Full width, and both edges pinned. Inherited from the desktop rules it would keep
+       `left: 52px` (the offset that clears the control column) and `width: 85vw` — which together
+       run off the right-hand edge of a phone. There is no control column to clear here, because
+       the panel is over the whole screen rather than over the map. */
+    left: 8px; right: 8px; width: auto; max-width: none;
+    border-radius: var(--radius);
   }
 }
 

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -470,8 +470,34 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
 @media (max-width: 1024px) {
   body[data-archetype="dashboard"] #layout { gap: 8px; padding: 8px; }
 }
-@media (max-width: 720px) {
+/* The layer list on a TABLET only — 641px up to the tablet breakpoint.
+   The upper bound is the whole point: below 640px portal.css restyles #sidebar as a full-height
+   drawer, and this rule's `left`/`right`/`width` fought that geometry. Both selectors weigh (1,1,1),
+   so which one won was decided by nothing better than file order. */
+@media (min-width: 641px) and (max-width: 720px) {
   body[data-archetype="dashboard"] #sidebar { left: 8px; right: 8px; width: auto; }
+}
+
+/* A COLLAPSED layer list on a dashboard phone is an ICON, not a slid-away drawer.
+   ─────────────────────────────────────────────────────────────────────────────
+   Everywhere else, collapsing a floating list sets `display: none` and the on-map toggle — a real
+   MapLibre control — is what you press to bring it back. At phone width portal.css deliberately
+   turns that into `display: flex` plus `translateX(-100%)`: a drawer that slides off the edge
+   rather than vanishing. On a WEB MAP that is right, because the map fills the screen and its
+   control cluster (with the toggle) is always in view.
+
+   A dashboard is not that shape. Its map is ONE CELL in a tall scrolling stack, so a drawer pinned
+   `top: 0; bottom: 0` hangs over the widgets, and the toggle that would dismiss it is inside a map
+   that may be scrolled entirely off-screen. What the visitor gets is a panel they cannot put away.
+
+   So a dashboard keeps the behaviour it has at every other width: collapsed means gone, and the
+   icon in the map's controls is how it comes back. Specificity (1,3,1) to clear the phone rule's
+   (1,2,1) — the extra attribute is doing real work here, not decoration. */
+@media (max-width: 640px) {
+  body[data-archetype="dashboard"][data-layerlist="floating"] #sidebar.collapsed { display: none; }
+}
+
+@media (max-width: 720px) {
   .gd-ind-value { font-size: clamp(20px, 9vw, 34px); }
   .gd-table td { max-width: 140px; }
   /* The filter bar is fixed to the foot of the window (a grid row for it would push every widget

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -448,6 +448,13 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
 
 /* The active-filter bar. It is the answer to "why is this number small?", so it names every filter
    currently narrowing the page and offers to clear them — individually and all at once. */
+/* Room for the filter bar, only while there is one.
+   It is fixed to the foot of the window, so on a dashboard tall enough to scroll it covered the
+   last row — and what sits at the bottom of a chart is its x-axis, the part that says what you are
+   looking at. The grid gets a footer instead: ~40px of bar plus its 14px offset and a margin.
+   Reserved only when a filter is live, because otherwise every dashboard ends in dead space. */
+body[data-archetype="dashboard"][data-dash-filtered="1"] #layout { padding-bottom: 68px; }
+
 #gd-dash-bar {
   position: fixed; left: 50%; transform: translateX(-50%); bottom: 14px; z-index: 60;
   max-width: min(92vw, 900px);
@@ -598,7 +605,9 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
   /* The filter bar is fixed to the foot of the window (a grid row for it would push every widget
      down the moment a filter went live). On a phone that lands it ON TOP of the last card, so the
      grid gets a matching footer of empty space — the bar is ~40px plus its own 14px offset. */
-  body[data-archetype="dashboard"] #layout { padding-bottom: 66px; }
+  /* Only while filtered, matching the desktop rule — an unfiltered phone dashboard should not end
+     in a band of empty space either. */
+  body[data-archetype="dashboard"][data-dash-filtered="1"] #layout { padding-bottom: 66px; }
   #gd-dash-bar {
     left: 8px; right: 8px; bottom: 8px; transform: none; max-width: none;
     border-radius: 14px; justify-content: flex-start; padding: 5px 6px 5px 10px;

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -495,6 +495,31 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
    (1,2,1) — the extra attribute is doing real work here, not decoration. */
 @media (max-width: 640px) {
   body[data-archetype="dashboard"][data-layerlist="floating"] #sidebar.collapsed { display: none; }
+
+  /* OPENED, it pins to the viewport — and therefore covers the map.
+     ────────────────────────────────────────────────────────────────
+     `#sidebar` lives inside `#layout`, which on a dashboard is `position: fixed` AND
+     `overflow-y: auto`. An absolutely positioned child of a scrolling box anchors to its scrolled
+     CONTENT, so `top: 0` means the top of the widget stack, not the top of the screen. The toggle
+     that opens the list is a map control, and the map is somewhere down that stack — so tapping it
+     opened the legend above you and you had to scroll back up to read it, away from the map it
+     describes.
+
+     `fixed` anchors it to the viewport instead, so it opens over whatever you are looking at.
+     That covers the map, which on a desktop would be the wrong trade — there the list sits beside
+     the map precisely so you can read both — but on a phone there is no beside. A legend you can
+     see over the map beats a legend somewhere off-screen that is technically not covering it.
+
+     Below the header, not over it: the header is how you know which portal you are in, and a panel
+     that swallows it reads as a new page rather than an overlay on this one.
+
+     `#layout > #sidebar` rather than a bare `#sidebar`: it names the containing block that causes
+     the problem, and at (2,1,1) it wins outright instead of tying portal.css's (1,1,1) and being
+     settled by which file happens to be included second. A rule that depends on source order is
+     how the collapsed drawer broke in the first place. */
+  body[data-archetype="dashboard"] #layout > #sidebar {
+    position: fixed; top: var(--header-h); bottom: 0; z-index: 60;
+  }
 }
 
 @media (max-width: 720px) {

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -132,6 +132,11 @@ html[data-theme="dark"] .gd-ind-delta.down { color: #f87171; }
 /* Tick marks inside the dial, and the target line across it. The target is deliberately the
    strongest mark on the gauge after the needle: it is the number the reading is being judged
    against, and a gauge without it makes the reader do that comparison from memory. */
+/* The histogram's own scale line. Outside the SVG because that one stretches. */
+.gd-rs-hist-scale {
+  display: flex; justify-content: space-between; margin-top: 2px;
+  font-size: 9px; color: var(--text-muted); font-variant-numeric: tabular-nums;
+}
 .gd-gauge-tick { stroke: var(--text-muted); opacity: .55; stroke-width: 1.5; }
 .gd-gauge-target { stroke: var(--text); opacity: .85; stroke-width: 2; stroke-linecap: round; }
 .gd-gauge-cap { font-size: 8px; fill: var(--text-muted); }

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -419,6 +419,15 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
   cursor: pointer; color: var(--text-muted); display: flex; align-items: center; justify-content: center;
 }
 .gd-dash-tools button:hover { background: var(--surface); color: var(--text); }
+/* The drag grip. `touch-action: none` is what makes this work on a phone at all: without it the
+   browser claims the gesture as a scroll before a single pointermove is delivered. */
+.gd-dash-tools-grip {
+  cursor: grab; touch-action: none; color: var(--text-muted); opacity: .65;
+  border-right: 1px solid var(--border); border-radius: 4px 0 0 4px;
+}
+.gd-dash-tools-grip:hover { opacity: 1; }
+.gd-dash-tools[data-dragging] { cursor: grabbing; box-shadow: var(--shadow-lg); }
+.gd-dash-tools[data-dragging] .gd-dash-tools-grip { cursor: grabbing; opacity: 1; }
 .gd-dash-tools button[aria-pressed="true"] { background: var(--accent); color: #fff; }
 .gd-dash-tools svg { width: 15px; height: 15px; }
 

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -474,6 +474,24 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
   font-size: 11px; line-height: 1.4; text-align: center;
 }
 
+/* The layer list's own close button. Present only where the list can cover the thing that would
+   otherwise dismiss it: a dashboard, on a phone. Everywhere else the map's toggle is in view and a
+   second control would be clutter. Positioned against the panel, not the page, so it is wherever
+   the panel is. */
+.gd-list-close {
+  display: none; position: absolute; top: 6px; right: 8px; z-index: 2;
+  width: 30px; height: 30px; padding: 0; line-height: 1;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--bg); color: var(--text-muted);
+  font-size: 18px; cursor: pointer;
+}
+.gd-list-close:hover { color: var(--text); }
+@media (max-width: 640px) {
+  body[data-archetype="dashboard"] .gd-list-close { display: block; }
+  /* Room for it, so it never lands on the "Layers" heading. */
+  body[data-archetype="dashboard"] #sidebar .sidebar-section-title { padding-right: 38px; }
+}
+
 /* ── responsive ───────────────────────────────────────────────────────────
    The column count is set by dashboard.js (it rewrites every widget's placement, because mapping a
    12-column layout onto 6 or 1 is arithmetic a media query cannot do). These rules only handle the
@@ -543,13 +561,11 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
     border-radius: var(--radius);
   }
 
-  /* …and a way out that is not hidden behind the panel.
-     The header hamburger is hidden everywhere by default, because the on-map toggle replaced it.
-     That toggle is a MAP control, so an open panel covering the map covers the only means of
-     closing it — "I don't even see how to close it". The header stays above the panel, so its
-     button is the one control that cannot be swallowed by what it dismisses. Only here: only a
-     dashboard puts the map somewhere a panel can cover completely. */
-  body[data-archetype="dashboard"] #sidebar-toggle { display: flex; }
+  /* The way out is INSIDE the panel — see `.gd-list-close`. Bringing the header hamburger back was
+     the first attempt and it was wrong: a dashboard's header already carries the portal's own logo,
+     so a second stack-of-layers icon appeared beside it, and the map is not the page here, so the
+     header button was a control for a panel nowhere near it. One layer icon, on the map, where the
+     panel is. */
 }
 
 @media (max-width: 720px) {

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -129,6 +129,11 @@ html[data-theme="dark"] .gd-ind-delta.down { color: #f87171; }
 .gd-gauge { width: 100%; height: 100%; display: block; }
 .gd-gauge-track { stroke: var(--border); }
 .gd-gauge-value { font-size: 15px; font-weight: 650; fill: var(--text); }
+/* Tick marks inside the dial, and the target line across it. The target is deliberately the
+   strongest mark on the gauge after the needle: it is the number the reading is being judged
+   against, and a gauge without it makes the reader do that comparison from memory. */
+.gd-gauge-tick { stroke: var(--text-muted); opacity: .55; stroke-width: 1.5; }
+.gd-gauge-target { stroke: var(--text); opacity: .85; stroke-width: 2; stroke-linecap: round; }
 .gd-gauge-cap { font-size: 8px; fill: var(--text-muted); }
 
 /* ── chart ────────────────────────────────────────────────────────────────── */
@@ -138,6 +143,11 @@ html[data-theme="dark"] .gd-ind-delta.down { color: #f87171; }
 .gd-chart .axis { stroke: var(--border); }
 .gd-chart .tick { font-size: 9px; fill: var(--text-muted); }
 .gd-chart .glabel { font-size: 9px; fill: var(--text-muted); }
+/* The rules behind the plot. Faint on purpose: they are there to be measured against, not read —
+   a gridline as strong as the data competes with it. */
+.gd-chart .gridline { stroke: var(--border); opacity: .45; stroke-width: 1; }
+/* Which columns a scatter is plotting, on the axes themselves. */
+.gd-chart .gd-axis-title { font-size: 9px; fill: var(--text-muted); opacity: .9; }
 /* Printed bar values. `vlabel-in` sits ON the bar, so it takes a light fill and a soft shadow to
    stay legible over any palette colour; the outside variant sits on the card and takes the normal
    muted text colour. Both are pointer-events:none so the label never steals the bar's click. */

--- a/templates/shared/dashboard.css
+++ b/templates/shared/dashboard.css
@@ -529,14 +529,27 @@ body[data-dash-mapctrl="0"] .gd-overlay-bottom-right { right: 10px; }
      settled by which file happens to be included second. A rule that depends on source order is
      how the collapsed drawer broke in the first place. */
   body[data-archetype="dashboard"] #layout > #sidebar {
-    position: fixed; top: var(--header-h); bottom: 0; z-index: 60;
-    /* Full width, and both edges pinned. Inherited from the desktop rules it would keep
+    position: fixed; top: calc(var(--header-h) + 8px); z-index: 60;
+    /* Both edges pinned, width follows. Inherited from the desktop rules it would keep
        `left: 52px` (the offset that clears the control column) and `width: 85vw` — which together
        run off the right-hand edge of a phone. There is no control column to clear here, because
-       the panel is over the whole screen rather than over the map. */
+       the panel is over the screen rather than over the map. */
     left: 8px; right: 8px; width: auto; max-width: none;
+    /* AS TALL AS ITS CONTENT, no taller. `bottom: 0` made a five-class legend fill the whole phone —
+       a screen of empty panel with the dashboard hidden behind it — where the same legend on a
+       desktop takes the few centimetres it needs. A panel is only worth the room it uses.
+       Capped so a long layer list still scrolls inside rather than running off the bottom. */
+    bottom: auto; height: auto; max-height: calc(100vh - var(--header-h) - 16px);
     border-radius: var(--radius);
   }
+
+  /* …and a way out that is not hidden behind the panel.
+     The header hamburger is hidden everywhere by default, because the on-map toggle replaced it.
+     That toggle is a MAP control, so an open panel covering the map covers the only means of
+     closing it — "I don't even see how to close it". The header stays above the panel, so its
+     button is the one control that cannot be swallowed by what it dismisses. Only here: only a
+     dashboard puts the map somewhere a panel can cover completely. */
+  body[data-archetype="dashboard"] #sidebar-toggle { display: flex; }
 }
 
 @media (max-width: 720px) {

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -689,6 +689,38 @@ window.GD_DASHBOARD = (function () {
   const RENDERERS = {};
 
   // INDICATOR — one number, optionally against a target, optionally clickable as a filter source.
+  //: The floor a fitted number will not go below. Under this it stops being the thing the card is
+  //: for and becomes small print that happens to be bold.
+  const FIT_MIN_PX = 13;
+
+  //: Shrink a number until it fits the width of its card.
+  //:
+  //: `.gd-ind-value` is sized in `vw`, which is the VIEWPORT's width and not the card's — so a
+  //: three-column indicator on a wide screen gets the same 40px as a full-width one, and a count in
+  //: the millions simply ran past the edge. Nothing in CSS can size type to a box the author
+  //: resizes at will: container queries would need a container the flex-centred body does not
+  //: establish, and clamp() cannot see the card at all.
+  //:
+  //: One measurement, one ratio: text width is very nearly linear in font size, so scaling by
+  //: `available / measured` lands within a pixel. The second pass is only there for the rounding.
+  function fitValue(node) {
+    const host = node.parentNode;
+    if (!host) return;
+    node.style.fontSize = '';                 // start from the stylesheet's own size every time
+    const avail = host.clientWidth;
+    if (!avail) return;                       // detached, or a card with no width yet
+    let size = parseFloat(getComputedStyle(node).fontSize) || 32;
+    for (let pass = 0; pass < 2; pass++) {
+      const wide = node.scrollWidth;
+      if (wide <= avail) return;
+      // 0.98 keeps a hair of margin: scrollWidth rounds up, and a number that exactly fills its box
+      // reads as though it is about to overflow even when it is not.
+      size = Math.max(FIT_MIN_PX, Math.floor(size * (avail / wide) * 0.98));
+      node.style.fontSize = size + 'px';
+      if (size === FIT_MIN_PX) return;        // as small as it is allowed to get
+    }
+  }
+
   RENDERERS.indicator = function (w, env) {
     const c = card(w, { bodyClass: 'gd-w-center' });
     const ds = w.dataSource;
@@ -713,12 +745,31 @@ window.GD_DASHBOARD = (function () {
       });
     }
 
+    // Re-fit when the CARD changes size, not only when the number does. Widening a card should let
+    // a number that had been shrunk grow back, and narrowing one must shrink it — a fit computed
+    // once at first paint is wrong the moment the author drags a corner.
+    let lastValue = null;
+    try {
+      if (typeof ResizeObserver === 'function') {
+        let last = 0;
+        new ResizeObserver(function () {
+          // Only a real change in integer width: the observer also fires for the font-size change
+          // `fitValue` itself makes, and re-fitting on that would be a loop.
+          const now = c.body.clientWidth | 0;
+          if (now === last) return;
+          last = now;
+          if (lastValue) fitValue(lastValue);
+        }).observe(c.body);
+      }
+    } catch (e) { /* no ResizeObserver: the number keeps its first-paint size */ }
+
     function refresh() {
       busy(c.root, true);
       env.api.aggregate(w.id, ds.layerId, specFor(w, env.store, { op: ds.op, field: ds.field }))
         .then(function (data) {
           busy(c.root, false);
           clear(c.body);
+          lastValue = null;
           const value = data ? data.value : null;
           const v = el('div', 'gd-ind-value', fmtNumber(value, w.style));
           if (w.style && w.style.unit) {
@@ -727,6 +778,8 @@ window.GD_DASHBOARD = (function () {
           }
           if (w.style && w.style.color) v.style.color = w.style.color;
           c.body.appendChild(v);
+          fitValue(v);                        // after the append: it has no width before it
+          lastValue = v;
           if (ds.field && ds.op !== 'count') c.body.appendChild(el('div', 'gd-ind-label', ds.field));
           const target = w.style && w.style.target;
           if (target != null && value != null && (w.style.compareMode || 'delta') !== 'none') {

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -215,6 +215,12 @@ window.GD_DASHBOARD = (function () {
       });
     }
     return {
+      //: How many requests are still open. The loading gate reads it to decide when the first round
+      //: of widget queries has settled — see `whenSettled`. Counting the client's own in-flight map
+      //: rather than threading a promise back out of every renderer: `refresh()` returns nothing on
+      //: all thirteen of them, and changing that contract to answer one question would be a wide
+      //: change for a narrow need.
+      pending: function () { return Object.keys(inflight).length; },
       aggregate: function (key, layerId, spec) {
         return post(key, '/api/data/vector/' + layerId + '/aggregate', spec);
       },
@@ -2688,14 +2694,51 @@ window.GD_DASHBOARD = (function () {
   }
 
   // ── setup ──────────────────────────────────────────────────────────────────
+  //: How long the loading cover will wait for the widgets before giving up on them.
+  //:
+  //: Under portal.js's own 15s backstop, deliberately: that one exists for a piece that never calls
+  //: back at all and logs a warning when it fires, so this must resolve first in the ordinary
+  //: slow-connection case and leave the backstop as a genuine backstop.
+  const DATA_GATE_MAX = 10000;
+
+  //: Call `done` once the widgets' first questions have all been answered — or once `DATA_GATE_MAX`
+  //: has passed, whichever comes first. Never twice.
+  //:
+  //: Quiet is checked TWICE, an interval apart, because zero in-flight requests is also true for the
+  //: instant between one widget's answer arriving and its follow-up going out. One reading would
+  //: call a gap in the traffic the end of it.
+  function whenSettled(api, done) {
+    let fired = false;
+    const finish = function () { if (!fired) { fired = true; try { done(); } catch (e) {} } };
+    const cap = setTimeout(finish, DATA_GATE_MAX);
+    let quiet = 0;
+    const tick = function () {
+      if (fired) return;
+      quiet = api.pending() === 0 ? quiet + 1 : 0;
+      if (quiet >= 2) { clearTimeout(cap); finish(); return; }
+      setTimeout(tick, 80);
+    };
+    setTimeout(tick, 80);
+  }
+
   function setup(ctx) {
+    // ARMED FIRST, before anything below can return early or throw. The cover is only safe to make
+    // conditional on the widgets if the signal that lifts it cannot be skipped: `setup` returns
+    // early for a dashboard with no widgets and again for one whose host element is missing, and a
+    // gate cleared on neither path is a portal that never appears. Same rule the gates in portal.js
+    // are written to — clear unconditionally — applied on this side of the call.
+    const dataReady = (function (fn) {
+      let sent = false;
+      return function () { if (!sent) { sent = true; try { fn && fn(); } catch (e) {} } };
+    })(ctx.onDataReady);
+    setTimeout(dataReady, DATA_GATE_MAX);
     const cfg = ctx.style && ctx.style.geodeploy && ctx.style.geodeploy.dashboard;
-    if (!cfg || !cfg.widgets || !cfg.widgets.length) return;
+    if (!cfg || !cfg.widgets || !cfg.widgets.length) { dataReady(); return; }
 
     const host = document.getElementById('dashboard-panel');
     const layoutEl = document.getElementById('layout');
     const mapWrap = document.getElementById('map-wrap');
-    if (!host || !layoutEl) return;
+    if (!host || !layoutEl) { dataReady(); return; }
 
     const grid = cfg.grid || {};
     const baseRow = grid.rowHeight || 90;      // `--dash-row` is written per breakpoint by placeAll
@@ -2910,6 +2953,19 @@ window.GD_DASHBOARD = (function () {
     // need asking too — otherwise a search box on the map would sit empty until the first
     // filter change.
     overlays.forEach(function (o) { try { o.refresh(); } catch (e) { console.warn('[geodeploy] overlay refresh failed', e); } });
+
+    // Every first question is now IN FLIGHT — each `refresh()` above issues its fetch synchronously
+    // — so the client's pending count is a complete picture from here, and waiting for it to reach
+    // zero is waiting for the answers. Checked after the loop for exactly that reason: asking
+    // earlier would find a client that had not been given the questions yet.
+    //
+    // Widgets that ask the server nothing (legend, details) never enter the count and so never hold
+    // the cover; a widget whose request FAILS clears itself in the client's `finally`, so a broken
+    // panel delays the page by its own timeout rather than indefinitely.
+    if (ctx.onDataReady) {
+      ctx.note && ctx.note('Loading widgets…');
+      whenSettled(api, dataReady);
+    }
 
     // AUTO-REFRESH, for a near-real-time layer. It re-asks every widget the question it is already
     // asking, which is deliberately NOT the same as clearing the filters: a wall-mounted board must

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -83,11 +83,38 @@ window.GD_DASHBOARD = (function () {
   //: has rather than an assumed 300. Falls back to the old numbers when the card has not been laid
   //: out yet (first paint), and `render()` runs again on resize.
   const CHART_MIN_W = 160, CHART_MIN_H = 90;
+  //: The space a chart actually has, in px — the body's CONTENT box, padding excluded.
+  //:
+  //: `clientHeight` includes padding, and the card body has 10px of it on every side. That was
+  //: harmless while the SVG was `height: 100%` (the browser resolved it against the content box and
+  //: `preserveAspectRatio: meet` quietly scaled the 20px-too-tall viewBox down to fit), but it is
+  //: not harmless the moment anything does arithmetic with the number: subtracting a legend's
+  //: height from a figure that is 20px too big still overflows the card. Reporting the real box
+  //: also makes the label-density calculations honest, since they budget px against this width.
   function chartBox(host) {
     let w = 0, h = 0;
-    try { w = host.clientWidth || 0; h = host.clientHeight || 0; } catch (e) { /* detached */ }
+    try {
+      w = host.clientWidth || 0;
+      h = host.clientHeight || 0;
+      const cs = getComputedStyle(host);
+      w -= (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+      h -= (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+    } catch (e) { /* detached */ }
     return { W: Math.max(CHART_MIN_W, Math.round(w) || 300),
              H: Math.max(CHART_MIN_H, Math.round(h) || 170) };
+  }
+
+  //: An element's height INCLUDING the margin that separates it from its sibling — the space it
+  //: costs the box it shares, which is what has to be taken off the plot.
+  function outerHeight(node) {
+    if (!node) return 0;
+    let h = 0;
+    try {
+      h = node.getBoundingClientRect().height || node.offsetHeight || 0;
+      const cs = getComputedStyle(node);
+      h += (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
+    } catch (e) { h = node.offsetHeight || 0; }
+    return Math.ceil(h);
   }
 
   //: Per-bar colour. Default stays SINGLE — an x-axis that already names the category does not need
@@ -1143,12 +1170,29 @@ window.GD_DASHBOARD = (function () {
       // has no whole to be parts of — it would draw a shape that means nothing.
       if (multi.length > 1 && kind !== 'pie' && kind !== 'donut') {
         const colours = multi.map(function (_, i) { return PALETTE[i % PALETTE.length]; });
-        c.body.appendChild((kind === 'line' || kind === 'area')
-          ? drawMultiLine(groups, ds, w.style, multi, kind === 'area', bx.W, bx.H)
-          : drawGroupedBars(groups, ds, w.style, multi, bx.W, bx.H));
-        if (!(w.style && w.style.legend === false)) {
-          c.body.appendChild(seriesLegend(multi, colours));
-        }
+        //: THE LEGEND GETS ITS ROOM FIRST, and the plot takes what is left.
+        //:
+        //: `.gd-chart` is `height: 100%` and the legend is its sibling in a block body, so the plot
+        //: claimed the card's full height and pushed the key out of sight into the body's
+        //: scrollbar. Making the widget taller did not help — it grew the plot by exactly as much,
+        //: which is the same trap the pie hit and why `plotSize` exists there.
+        //:
+        //: A slider is the wrong answer for a series key, though: unlike a pie's, it wraps to
+        //: however many lines its labels need, so its height is a MEASURABLE fact rather than a
+        //: judgement call. So it is appended first, measured, and the plot is built for the
+        //: remainder. A taller card now grows the plot and leaves the key where it is, which is
+        //: what someone reaching for the resize handle was asking for.
+        const legend = (w.style && w.style.legend === false)
+          ? null : seriesLegend(multi, colours);
+        if (legend) c.body.appendChild(legend);
+        const plotH = Math.max(CHART_MIN_H, bx.H - outerHeight(legend));
+        const node = (kind === 'line' || kind === 'area')
+          ? drawMultiLine(groups, ds, w.style, multi, kind === 'area', bx.W, plotH)
+          : drawGroupedBars(groups, ds, w.style, multi, bx.W, plotH);
+        // The viewBox is already `plotH` tall; this stops the CSS `height: 100%` scaling it back up
+        // to the full body and undoing the whole calculation.
+        node.style.height = plotH + 'px';
+        c.body.insertBefore(node, legend);      // a null second argument appends, which is correct
         return;
       }
       const node = (kind === 'pie' || kind === 'donut')

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -929,6 +929,26 @@ window.GD_DASHBOARD = (function () {
   //: empty, and a single column keeps its full name because one label shares everything with itself.
   function trimColumnLabels(names) {
     if (!names || names.length < 2) return (names || []).slice();
+    // FIRST, the trailing number — which is what actually distinguishes a set of wide columns, and
+    // does not depend on their prefixes agreeing.
+    //
+    // A shapefile truncates field names to ten characters, so one variable across 56 years arrives
+    // as GDP_PerC_1 … GDP_PerC_9 and then GDP_Per_10 … GDP_Per_56: the prefix CHANGES partway
+    // through, as the number grows and the truncation eats another letter. There is no common
+    // prefix to strip, and affix-trimming correctly concludes there is nothing to do — leaving the
+    // axis reading GDP_PerC_1, GDP_Per_10 when the reader wanted 1, 10.
+    //
+    // Only when EVERY name ends in digits and those digits are all different: identical tails mean
+    // the number is not what tells the columns apart (q1_2020, q2_2020) and the shared-affix rule
+    // below is the one that finds the 1 and the 2.
+    const tails = names.map(function (n) {
+      const m = String(n).match(/(\d+)$/);
+      return m ? m[1] : null;
+    });
+    if (tails.every(Boolean) && new Set(tails).size === names.length) {
+      // Through Number, so 01 and 1 do not sit on the same axis looking like different years.
+      return tails.map(function (t) { return String(Number(t)); });
+    }
     let pre = names[0], suf = names[0];
     for (let i = 1; i < names.length; i++) {
       const n = names[i];

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1235,7 +1235,9 @@ window.GD_DASHBOARD = (function () {
   function drawMultiLine(groups, ds, style, series, filled, boxW, boxH) {
     // padB 34, not 26: a rotated label hangs below its tick, and 26 clipped it. Same as the grouped
     // bars, which have always rotated.
-    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 34;
+    const tp = titlePads(style);
+    const W = boxW || 300, H = boxH || 170, padR = 8, padT = 8;
+    const padL = 34 + tp.y, padB = 34 + tp.x;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const n = groups.length, m = series.length;
@@ -1276,7 +1278,41 @@ window.GD_DASHBOARD = (function () {
       axisLabels(svg, i, n, g, ds, x(i), H - padB + 11, false);
     });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, ext.lo, ext.hi, style));
+    axisTitles(svg, style, W, H, padL, padB);
     return svg;
+  }
+
+  //: How much room an axis title needs, or none when there is no title.
+  //:
+  //: Charged only when there is something to charge for: an axis title costs plot height or width,
+  //: and a chart that reserved it always would give up that space on every chart that has none.
+  const TITLE_PAD = 13;
+  function titlePads(style) {
+    return { x: (style && style.xTitle) ? TITLE_PAD : 0,
+             y: (style && style.yTitle) ? TITLE_PAD : 0 };
+  }
+
+  //: The axis titles themselves.
+  //:
+  //: A column name is not a label. `GDP_PerC_1` is what the data is called; "GDP per capita (USD)"
+  //: is what the reader needs, and the two are rarely the same string — especially after a
+  //: shapefile has truncated the first to ten characters. Tick labels say WHERE a point is; the
+  //: title says WHAT is being measured, and no amount of tick formatting supplies it.
+  function axisTitles(svg, style, W, H, padL, padB) {
+    if (!style) return;
+    if (style.xTitle) {
+      const t = svgEl('text', { x: (padL + W - 8) / 2, y: H - 2, 'text-anchor': 'middle',
+                                class: 'gd-axis-title' });
+      t.textContent = style.xTitle;
+      svg.appendChild(t);
+    }
+    if (style.yTitle) {
+      const cy = (8 + H - padB) / 2;
+      const t = svgEl('text', { x: 9, y: cy, 'text-anchor': 'middle', class: 'gd-axis-title',
+                                transform: 'rotate(-90 9 ' + cy.toFixed(1) + ')' });
+      t.textContent = style.yTitle;
+      svg.appendChild(t);
+    }
   }
 
   //: The category labels under a vertical bar chart: how many fit, and where each one sits.
@@ -1307,7 +1343,9 @@ window.GD_DASHBOARD = (function () {
   }
 
   function drawGroupedBars(groups, ds, style, series, boxW, boxH) {
-    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 34;
+    const tp = titlePads(style);
+    const W = boxW || 300, H = boxH || 170, padR = 8, padT = 8;
+    const padL = 34 + tp.y, padB = 34 + tp.x;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const n = groups.length, m = series.length;
@@ -1336,6 +1374,7 @@ window.GD_DASHBOARD = (function () {
       axisLabels(svg, i, n, g, ds, padL + i * colW + colW / 2, H - padB + 11, false);
     });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, ext.lo, ext.hi, style));
+    axisTitles(svg, style, W, H, padL, padB);
     return svg;
   }
 
@@ -1343,8 +1382,9 @@ window.GD_DASHBOARD = (function () {
     const W = boxW || 300, H = boxH || 170;
     // Label gutter scales with the box now that units are pixels: 28% of the width for a horizontal
     // chart's category names, floored so a narrow card still leaves room to read one.
-    const padL = horizontal ? Math.max(60, Math.min(140, Math.round(W * 0.28))) : 34;
-    const padR = 8, padT = 8, padB = horizontal ? 20 : 34;
+    const tp = titlePads(style);
+    const padL = (horizontal ? Math.max(60, Math.min(140, Math.round(W * 0.28))) : 34) + tp.y;
+    const padR = 8, padT = 8, padB = (horizontal ? 20 : 34) + tp.x;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const values = groups.map(function (g) { return g.value == null ? 0 : g.value; });
@@ -1423,6 +1463,7 @@ window.GD_DASHBOARD = (function () {
       axisLabels(svg, i, n, g, ds, padL + i * colW + colW / 2, H - padB + 11, false);
     });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, minV, maxV, style));
+    axisTitles(svg, style, W, H, padL, padB);
     return svg;
   }
 
@@ -1486,7 +1527,9 @@ window.GD_DASHBOARD = (function () {
   //: 2.6px dot: on a 30-point series the dots are ~9px apart and aiming at the dot itself is a test
   //: of the mouse, not an interaction.
   function drawLine(groups, ds, style, filled, selected, onPick, boxW, boxH) {
-    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 34;
+    const tp = titlePads(style);
+    const W = boxW || 300, H = boxH || 170, padR = 8, padT = 8;
+    const padL = 34 + tp.y, padB = 34 + tp.x;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const values = groups.map(function (g) { return g.value == null ? 0 : g.value; });
@@ -1533,6 +1576,7 @@ window.GD_DASHBOARD = (function () {
       axisLabels(svg, i, n, g, ds, x(i), H - padB + 11, false);
     });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, minV, maxV, style));
+    axisTitles(svg, style, W, H, padL, padB);
     return svg;
   }
 
@@ -1877,17 +1921,22 @@ window.GD_DASHBOARD = (function () {
       });
       // WHICH COLUMNS. Two axes of bare numbers describe a relationship between things the reader
       // has to remember; the card's subtitle names them, but the axes are where they are read.
-      if (ds.xField) {
+      // The author's title if there is one, the column name if not. A column name is a usable
+      // default and a poor label: it is what the data is called, not what it measures.
+      const xTitle = (w.style && w.style.xTitle) || ds.xField;
+      const yTitle = (w.style && w.style.yTitle) || ds.yField;
+      if (xTitle) {
         const xt = svgEl('text', { x: (padL + W - padR) / 2, y: H - 2,
                                    'text-anchor': 'middle', class: 'gd-axis-title' });
-        xt.textContent = ds.xField;
+        xt.textContent = xTitle;
         svg.appendChild(xt);
       }
-      if (ds.yField) {
-        const yt = svgEl('text', { x: 9, y: (padT + H - padB) / 2, 'text-anchor': 'middle',
+      if (yTitle) {
+        const cy = (padT + H - padB) / 2;
+        const yt = svgEl('text', { x: 9, y: cy, 'text-anchor': 'middle',
                                    class: 'gd-axis-title',
-                                   transform: 'rotate(-90 9 ' + ((padT + H - padB) / 2) + ')' });
-        yt.textContent = ds.yField;
+                                   transform: 'rotate(-90 9 ' + cy + ')' });
+        yt.textContent = yTitle;
         svg.appendChild(yt);
       }
       c.body.appendChild(svg);

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -918,6 +918,79 @@ window.GD_DASHBOARD = (function () {
     return svg;
   }
 
+  //: Column names as axis labels, with the part they all share removed.
+  //:
+  //: `gdp_1990 … gdp_2020` are twenty ticks that agree on eleven characters and differ in four. The
+  //: shared part is the variable's name — true of every tick, and therefore telling the reader
+  //: nothing about which one they are looking at, while eating the width that would let the rest be
+  //: read. Trimmed, they say 1990 … 2020, which is what the axis is.
+  //:
+  //: Only when a difference SURVIVES: a common prefix is not stripped if doing so leaves a label
+  //: empty, and a single column keeps its full name because one label shares everything with itself.
+  function trimColumnLabels(names) {
+    if (!names || names.length < 2) return (names || []).slice();
+    let pre = names[0], suf = names[0];
+    for (let i = 1; i < names.length; i++) {
+      const n = names[i];
+      let p = 0;
+      while (p < pre.length && p < n.length && pre[p] === n[p]) p++;
+      pre = pre.slice(0, p);
+      let q = 0;
+      while (q < suf.length && q < n.length && suf[suf.length - 1 - q] === n[n.length - 1 - q]) q++;
+      suf = suf.slice(suf.length - q);
+    }
+    // NEVER SPLIT A TOKEN. What two labels happen to share is not the same as the part that tells
+    // the reader nothing. `gdp_1990, gdp_2000, gdp_2010` share a trailing `0` — the last digit of
+    // every year — and trimming it leaves 199, 200, 201. `y.2019, y.2020` share a leading `y.20`,
+    // leaving 19 and 20. `alpha, beta` share a trailing `a`, leaving alph and bet. Three versions of
+    // one mistake: a boundary drawn inside a word or a number.
+    //
+    // So an affix is first backed out of any digit run it lands in, and then only accepted if it
+    // ends (or begins) at a SEPARATOR. `gdp_` and `_est` qualify; `y.20`, `0_est` and `a` do not.
+    // One exception, because it is unambiguous and common: a prefix of letters followed everywhere
+    // by digits — `gdp1990` — is a boundary even with no separator to mark it.
+    const D = /[0-9]/, SEP = /[_\-. ]/;
+    while (pre.length && D.test(pre[pre.length - 1])
+           && names.some(function (n) { return D.test(n[pre.length] || ''); })) {
+      pre = pre.slice(0, -1);
+    }
+    while (suf.length && D.test(suf[0])
+           && names.some(function (n) { return D.test(n[n.length - suf.length - 1] || ''); })) {
+      suf = suf.slice(1);
+    }
+    const preOk = !pre.length || SEP.test(pre[pre.length - 1])
+      || (!D.test(pre[pre.length - 1])
+          && names.every(function (n) { return D.test(n[pre.length] || ''); }));
+    if (!preOk) pre = '';
+    if (suf.length && !SEP.test(suf[0])) suf = '';
+    const out = names.map(function (n) {
+      const cut = n.slice(pre.length, n.length - suf.length);
+      // Separators next to the affix belong with it in spirit if not in characters: `gdp_1990`
+      // against the prefix `gdp` leaves `_1990`.
+      return cut.replace(/^[_\-. ]+|[_\-. ]+$/g, '');
+    });
+    return out.every(function (v) { return v.length; }) ? out : names.slice();
+  }
+
+  //: Turn a measures-by-group answer into a groups-by-measure one.
+  //:
+  //: The server returns rows = groups, columns = measures — right for "mean height and mean age per
+  //: district", where the district is the axis. Wide data is the same matrix read the other way:
+  //: the COLUMNS are the axis (one per year) and each group becomes a line across them. Nothing is
+  //: recomputed; the numbers are the numbers, and this only decides which way round they are drawn.
+  function transposeSeries(groups, series, labels) {
+    const rows = (labels || series.map(function (s) { return s.label; })).map(function (lab, i) {
+      return { key: lab, values: groups.map(function (g) { return (g.values || [])[i]; }),
+               value: (groups[0] && (groups[0].values || [])[i]), count: 0 };
+    });
+    // With no grouping the server answers one row whose key is null: one line, and calling its
+    // legend entry "null" would be worse than not drawing a legend at all.
+    const cols = groups.map(function (g, i) {
+      return { label: g.key == null ? 'Value' : String(g.key), op: null, field: null, __i: i };
+    });
+    return { groups: rows, series: cols };
+  }
+
   // CHART — bar / hbar / line / area / pie / donut over a grouped aggregation. Segments are filter
   // SOURCES: clicking one publishes `groupBy IN (key)` to this widget's targets, clicking it again
   // clears. That is the interaction the whole archetype is named for, so it is not optional chrome.
@@ -982,9 +1055,17 @@ window.GD_DASHBOARD = (function () {
     }
     function refresh() {
       busy(c.root, true);
+      // WIDE DATA: each chosen column becomes one measure. That is the whole of the request side —
+      // the server already answers N aggregates over one grouping in a single scan, and this is
+      // that, with the columns supplying the N.
+      const xcols = (ds.xColumns || []).filter(Boolean);
+      const series = xcols.length
+        ? xcols.map(function (c) { return { op: ds.op && ds.op !== 'count' ? ds.op : 'sum',
+                                            field: c, label: c }; })
+        : ds.series;
       env.api.aggregate(w.id, ds.layerId, specFor(w, env.store, {
         op: ds.op, field: ds.field, groupBy: ds.groupBy, timeBucket: ds.timeBucket,
-        limit: ds.limit, sort: ds.sort, series: ds.series,
+        limit: ds.limit, sort: xcols.length ? 'key_asc' : ds.sort, series: series,
       })).then(function (data) {
         busy(c.root, false);
         groups = (data && data.groups) || [];
@@ -992,6 +1073,14 @@ window.GD_DASHBOARD = (function () {
         // rather than the request — a measure the server dropped (a field the layer lost) then
         // disappears from the legend too, instead of labelling someone else's line.
         multi = (data && data.series) || [];
+        if (xcols.length && multi.length) {
+          // Labels come from the ANSWER's series, not the request's columns, for the same reason:
+          // a column the server dropped must not leave its name on another column's ticks.
+          const t = transposeSeries(groups, multi,
+            trimColumnLabels(multi.map(function (m) { return m.field || m.label; })));
+          groups = t.groups;
+          multi = t.series;
+        }
         render();
       }).catch(function (err) { busy(c.root, false); showError(c.body, err); });
     }

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -972,6 +972,27 @@ window.GD_DASHBOARD = (function () {
     return out.every(function (v) { return v.length; }) ? out : names.slice();
   }
 
+  //: The axis labels an author asked for, from the ones the column names gave.
+  //:
+  //: `gdp60 … gdp99` trim to `60 … 99`, which is what the columns say and not what they mean. The
+  //: offset does the arithmetic (60 + 1900) and the pattern does the text (`19{}`); either reaches
+  //: 1960, and together they handle the cases neither does alone.
+  //:
+  //: A label that is not a number is left alone by the offset rather than becoming NaN — a column
+  //: set can mix `q1` with `2020` and the axis should not go blank over it.
+  function formatColumnLabels(labels, pattern, offset) {
+    const off = Number(offset) || 0;
+    const pat = (pattern && pattern.indexOf('{}') >= 0) ? pattern : null;
+    return labels.map(function (lab) {
+      let v = String(lab == null ? '' : lab);
+      if (off) {
+        const n = Number(v);
+        if (v !== '' && isFinite(n)) v = String(n + off);
+      }
+      return pat ? pat.split('{}').join(v) : v;
+    });
+  }
+
   //: Turn a measures-by-group answer into a groups-by-measure one.
   //:
   //: The server returns rows = groups, columns = measures — right for "mean height and mean age per
@@ -1076,8 +1097,9 @@ window.GD_DASHBOARD = (function () {
         if (xcols.length && multi.length) {
           // Labels come from the ANSWER's series, not the request's columns, for the same reason:
           // a column the server dropped must not leave its name on another column's ticks.
-          const t = transposeSeries(groups, multi,
-            trimColumnLabels(multi.map(function (m) { return m.field || m.label; })));
+          const t = transposeSeries(groups, multi, formatColumnLabels(
+            trimColumnLabels(multi.map(function (m) { return m.field || m.label; })),
+            ds.xLabelPattern, ds.xLabelOffset));
           groups = t.groups;
           multi = t.series;
         }

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1709,6 +1709,11 @@ window.GD_DASHBOARD = (function () {
       tr.classList.add('sel');
       // Zoom + highlight: the bbox came with the row precisely so this needs no round trip.
       if (row.bbox) env.fitBbox(row.bbox);
+      // Same rule the map follows: a new row REPLACES the last selection on every channel it used.
+      // Publishing the filter is conditional -- a row whose key column is null cannot name itself --
+      // so selecting such a row after one that could left the earlier row's filter narrowing
+      // everything, with the details panel showing a different feature entirely.
+      env.store.clearAttr(w.id, true);
       env.store.publishSelection(w.id, row.props, row.bbox,
         String(row.props[ds.keyField] == null ? '' : row.props[ds.keyField]));
       if (ds.keyField && row.props[ds.keyField] != null) {
@@ -2048,6 +2053,11 @@ window.GD_DASHBOARD = (function () {
       selectedEl = node;
       node.classList.add('sel');
       if (row.bbox) env.fitBbox(row.bbox);
+      // Same rule the map follows: a new row REPLACES the last selection on every channel it used.
+      // Publishing the filter is conditional -- a row whose key column is null cannot name itself --
+      // so selecting such a row after one that could left the earlier row's filter narrowing
+      // everything, with the details panel showing a different feature entirely.
+      env.store.clearAttr(w.id, true);
       env.store.publishSelection(w.id, row.props, row.bbox,
         String(row.props[titleField] == null ? '' : row.props[titleField]));
       const kf = ds.keyField;
@@ -3061,6 +3071,11 @@ window.GD_DASHBOARD = (function () {
     clearBtn.innerHTML = TOOL_ICONS.clear;
     clearBtn.addEventListener('click', function () {
       setMode(null);
+      // The attribute filter too. `env.clearSelection` drops the geometry and the details panel —
+      // it is generic, and knows nothing about this widget — so pressing Clear used to leave the
+      // chip a click had published sitting in the filter bar, still narrowing everything, with no
+      // outline on the map to explain it.
+      env.store.clearAttr(w.id);
       env.clearSelection();
     });
     bar.appendChild(clearBtn);
@@ -3076,6 +3091,19 @@ window.GD_DASHBOARD = (function () {
       setData(map, SEL_SRC, geometry);
       setData(map, DRAW_SRC, null);
       const bbox = bboxOf(geometry);
+      // A NEW SELECTION REPLACES THE LAST, on every channel the last one used.
+      //
+      // A click publishes up to three things: the feature's geometry, its attributes for the
+      // details panel, and — when the author named a field — an attribute FILTER. Drawing a box
+      // afterwards published only a geometry, so the attribute filter from the click survived and
+      // the two ANDed: `Country_Na = Niger` intersected with a box somewhere else matches nothing,
+      // and the dashboard emptied while its filter bar showed two chips that each looked reasonable.
+      //
+      // Cleared before the geometry goes out, and quietly, because `publishGeom` notifies the same
+      // targets a line later — two notifications would fire two requests, the first of them
+      // immediately aborted. The click path re-publishes its attribute straight after this, so
+      // clicking still filters; only the STALE one goes.
+      env.store.clearAttr(w.id, true);
       env.store.publishGeom(w.id, geometry, label, bbox);
       if (props) env.store.publishSelection(w.id, props, bbox, label);
     }

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -653,6 +653,29 @@ window.GD_DASHBOARD = (function () {
     return host;
   }
 
+  //: "screen" makes the board fill the viewport; "rows" (the default) keeps every row at the
+  //: height the author set. Written by init from `grid.fit`, read by placeAll on every breakpoint.
+  let fitMode = 'rows';
+
+  //: FILLING THE SCREEN, without promising something the screen may not allow.
+  //:
+  //: The rows become `minmax(--dash-row, 1fr)`: at least the height the author chose, sharing
+  //: whatever is left over. On a monitor taller than the board that spreads the widgets down the
+  //: whole page instead of leaving a third of it empty; on a screen too short — a phone, a portrait
+  //: display, a board of thirty rows — the minimum wins and it scrolls exactly as it does today.
+  //: One declaration covers both because that is what minmax means, and no media query has to guess
+  //: where the boundary is.
+  //:
+  //: Uniform rows are what make this safe: a widget spanning four of them still gets four times a
+  //: widget spanning one, so the author's proportions survive the stretch untouched.
+  function applyRowTemplate(rows) {
+    const layoutEl = document.getElementById('layout');
+    if (!layoutEl) return;
+    layoutEl.style.gridTemplateRows = (fitMode === 'screen' && rows > 0)
+      ? 'repeat(' + rows + ', minmax(var(--dash-row), 1fr))'
+      : '';
+  }
+
   function placeAll(cards, cols, baseRow) {
     document.documentElement.style.setProperty('--dash-cols', String(cols));
     document.documentElement.style.setProperty(
@@ -672,9 +695,11 @@ window.GD_DASHBOARD = (function () {
         c.el.style.gridRow = row + ' / span ' + h;
         row += h;
       });
+      applyRowTemplate(row - 1);
       return;
     }
     const scale = cols / 12;
+    let used = 0;               // the last row any widget reaches, for the fit-to-screen template
     cards.forEach(function (c) {
       // Scale the EDGES, not the origin and the width separately. Rounding each independently is
       // what makes a row of four 3-wide widgets collide at 6 columns: x=3 rounds up to 2 and w=3
@@ -684,8 +709,11 @@ window.GD_DASHBOARD = (function () {
       const x = Math.max(0, Math.min(cols - 1, Math.round(c.layout.x * scale)));
       const right = Math.max(x + 1, Math.min(cols, Math.round((c.layout.x + c.layout.w) * scale)));
       c.el.style.gridColumn = (x + 1) + ' / span ' + (right - x);
-      c.el.style.gridRow = (Math.max(0, c.layout.y) + 1) + ' / span ' + Math.max(2, c.layout.h);
+      const y = Math.max(0, c.layout.y), h = Math.max(2, c.layout.h);
+      c.el.style.gridRow = (y + 1) + ' / span ' + h;
+      if (y + h > used) used = y + h;
     });
+    applyRowTemplate(used);
   }
 
   // ── widget chrome ──────────────────────────────────────────────────────────
@@ -3514,6 +3542,9 @@ window.GD_DASHBOARD = (function () {
     const grid = cfg.grid || {};
     const baseRow = grid.rowHeight || 90;      // `--dash-row` is written per breakpoint by placeAll
     document.documentElement.style.setProperty('--dash-gap', (grid.gap || 10) + 'px');
+    fitMode = grid.fit === 'screen' ? 'screen' : 'rows';
+    // Published for CSS and for anyone reading the DOM to see which mode a board is in.
+    document.body.dataset.dashFit = fitMode;
 
     const store = createStore(cfg.widgets, cfg.relations || []);
     const api = createApi();

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1157,6 +1157,27 @@ window.GD_DASHBOARD = (function () {
         // rather than the request — a measure the server dropped (a field the layer lost) then
         // disappears from the legend too, instead of labelling someone else's line.
         multi = (data && data.series) || [];
+        // THE OVERALL LINE, asked as its own question rather than derived from the answer above.
+        //
+        // Averaging the plotted series would average the groups that SURVIVED `limit` — the top 12,
+        // or 100 — and label the result as the average of everything. Asking the same aggregation
+        // with no grouping gives the real figure over the current filters, whatever the group cap.
+        // One extra request, and only when it is switched on.
+        if (xcols.length && ds.meanLine && ds.groupBy) {
+          env.api.aggregate(w.id + ':mean', ds.layerId, specFor(w, env.store, {
+            op: ds.op, series: series, limit: 2, sort: 'key_asc',
+          })).then(function (mean) {
+            const row = (mean && mean.groups && mean.groups[0]) || null;
+            const vals = row ? (row.values || [row.value]) : (mean ? [mean.value] : null);
+            if (!vals || !groups.length) return;
+            // Appended AFTER the transpose, as one more value on each tick — the same shape every
+            // other series has, so nothing downstream needs to know it is special except the marker
+            // that draws it thicker.
+            groups.forEach(function (g, i) { g.values = (g.values || []).concat([vals[i]]); });
+            multi = multi.concat([{ label: 'Average', __mean: true }]);
+            render();
+          }).catch(function () { /* the per-group lines are still a chart without it */ });
+        }
         if (xcols.length && multi.length) {
           // Labels come from the ANSWER's series, not the request's columns, for the same reason:
           // a column the server dropped must not leave its name on another column's ticks.
@@ -1247,7 +1268,11 @@ window.GD_DASHBOARD = (function () {
     const y = function (v) { return H - padB - ((v - ext.lo) / span) * (H - padT - padB); };
 
     for (let s = 0; s < m; s++) {
-      const colour = PALETTE[s % PALETTE.length];
+      // The overall line is drawn in the theme's own accent and twice as thick: it is not one more
+      // country, and a reader scanning fifty lines of palette colour needs to find it without
+      // consulting the legend.
+      const mean = !!(series[s] && series[s].__mean);
+      const colour = mean ? accent() : PALETTE[s % PALETTE.length];
       const pts = groups.map(function (g, i) { return x(i) + ',' + y(seriesValues(g, m)[s]); });
       if (filled && m === 1) {
         // Only a SINGLE series is ever area-filled: stacked translucent fills over each other read
@@ -1258,7 +1283,7 @@ window.GD_DASHBOARD = (function () {
         }));
       }
       svg.appendChild(svgEl('polyline', { points: pts.join(' '), fill: 'none',
-                                          stroke: colour, 'stroke-width': 1.8,
+                                          stroke: colour, 'stroke-width': mean ? 3.4 : 1.8,
                                           'stroke-linejoin': 'round', 'stroke-linecap': 'round' }));
       groups.forEach(function (g, i) {
         const v = seriesValues(g, m)[s];

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1715,29 +1715,75 @@ window.GD_DASHBOARD = (function () {
     foot.appendChild(nav);
     c.root.appendChild(foot);
 
-    let sort = ds.sort || null, dir = ds.dir || 'asc', offset = 0, selectedRow = null;
+    let sort = ds.sort || null, dir = ds.dir || 'asc', offset = 0;
+    //: SEVERAL ROWS AT ONCE. Held as the selected KEY VALUES rather than as DOM nodes, because the
+    //: rows are rebuilt on every page turn, sort and filter change — a node reference would be
+    //: stale the moment anything moved, and the highlight would vanish while the filter it
+    //: published stayed live. Keys survive the rebuild and the highlight is re-applied from them.
+    const picked = new Set();
+    let anchor = null;          // index the last plain click landed on, for shift-ranges
+    let onScreen = [];          // the rows currently rendered, so a range knows what lies between
+    function keyOf(row) {
+      const k = ds.keyField ? row.props[ds.keyField] : null;
+      return k == null ? null : String(k);
+    }
     env.store.subscribeSelf(w.id, function () {
-      if (!env.store.attrOf(w.id) && selectedRow) { selectedRow.classList.remove('sel'); selectedRow = null; }
+      // The filter bar's × and Reset both clear the attribute; the rows must stop looking selected.
+      if (!env.store.attrOf(w.id) && picked.size) { picked.clear(); paintSelection(); }
     });
+    function paintSelection() {
+      onScreen.forEach(function (r) {
+        const on = picked.has(keyOf(r.row));
+        r.el.classList.toggle('sel', on);
+        r.el.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+    }
     prev.addEventListener('click', function () { offset = Math.max(0, offset - ds.pageSize); refresh(); });
     next.addEventListener('click', function () { offset += ds.pageSize; refresh(); });
 
-    function onRow(row, tr) {
-      if (selectedRow) selectedRow.classList.remove('sel');
-      selectedRow = tr;
-      tr.classList.add('sel');
-      // Zoom + highlight: the bbox came with the row precisely so this needs no round trip.
-      if (row.bbox) env.fitBbox(row.bbox);
-      // Same rule the map follows: a new row REPLACES the last selection on every channel it used.
-      // Publishing the filter is conditional -- a row whose key column is null cannot name itself --
-      // so selecting such a row after one that could left the earlier row's filter narrowing
-      // everything, with the details panel showing a different feature entirely.
+    //: A click selects one row; ctrl/cmd adds or removes one; shift takes the run between.
+    //:
+    //: The conventions every list in every desktop application uses, and worth following exactly:
+    //: a visitor who has to learn a list widget's own idea of multi-select will not discover it. A
+    //: plain click still REPLACES, so nothing changes for anyone not reaching for a modifier.
+    function onRow(row, tr, ev, idx) {
+      const add = !!(ev && (ev.ctrlKey || ev.metaKey));
+      const range = !!(ev && ev.shiftKey) && anchor != null;
+      const key = keyOf(row);
+
+      if (range) {
+        const lo = Math.min(anchor, idx), hi = Math.max(anchor, idx);
+        picked.clear();
+        for (let i = lo; i <= hi; i++) {
+          const k = keyOf(onScreen[i].row);
+          if (k != null) picked.add(k);
+        }
+      } else if (add) {
+        if (key != null) { if (picked.has(key)) picked.delete(key); else picked.add(key); }
+        anchor = idx;
+      } else {
+        picked.clear();
+        if (key != null) picked.add(key);
+        anchor = idx;
+      }
+      paintSelection();
+
+      // Zoom + highlight: the bbox came with the row precisely so this needs no round trip. Only on
+      // a SINGLE pick — flying the camera on every ctrl-click, while someone is building a
+      // selection, moves the map out from under the rows they are still choosing.
+      if (!add && !range && row.bbox) env.fitBbox(row.bbox);
+
+      // A new selection REPLACES the last on every channel it used. The details panel shows the row
+      // just clicked even when several are selected: it holds one feature by definition, and the
+      // most recently touched is the one the visitor is looking at.
       env.store.clearAttr(w.id, true);
       env.store.publishSelection(w.id, row.props, row.bbox,
         String(row.props[ds.keyField] == null ? '' : row.props[ds.keyField]));
-      if (ds.keyField && row.props[ds.keyField] != null) {
-        env.store.publishAttr(w.id, { field: ds.keyField, op: 'in', values: [row.props[ds.keyField]] },
-          (w.title || defaultTitle(w)) + ': ' + truncate(row.props[ds.keyField], 24));
+      if (picked.size) {
+        const values = Array.from(picked);
+        env.store.publishAttr(w.id, { field: ds.keyField, op: 'in', values: values },
+          (w.title || defaultTitle(w)) + ': '
+            + (values.length === 1 ? truncate(values[0], 24) : values.length + ' selected'));
       }
     }
     function refresh() {
@@ -1747,6 +1793,9 @@ window.GD_DASHBOARD = (function () {
       })).then(function (data) {
         busy(c.root, false);
         clear(c.body);
+        // Emptied per render: these are DOM nodes, and holding the ones just discarded would leak
+        // a page's worth on every page turn and let a shift-range address rows nobody can see.
+        onScreen = [];
         const rows = (data && data.rows) || [];
         const fields = (data && data.fields) || ds.fields || [];
         if (!rows.length) {
@@ -1762,7 +1811,7 @@ window.GD_DASHBOARD = (function () {
         if (w.style && w.style.layout === 'cards') {
           const titleField = ds.titleField || ds.keyField || fields[0];
           const list = el('div', 'gd-cards');
-          rows.forEach(function (row) {
+          rows.forEach(function (row, idx) {
             const item = el('div', 'gd-card-item');
             const head = el('div', 'gd-card-title',
                             fmtCell(row.props[titleField]) || '—');
@@ -1780,15 +1829,17 @@ window.GD_DASHBOARD = (function () {
               line.appendChild(val);
               item.appendChild(line);
             });
-            item.addEventListener('click', function () { onRow(row, item); });
+            item.addEventListener('click', function (ev) { onRow(row, item, ev, idx); });
             // Reachable without a mouse: the table gives its rows to the pointer only, but a card is
             // the primary control in a directory layout.
             item.tabIndex = 0;
             item.addEventListener('keydown', function (e) {
-              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRow(row, item); }
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRow(row, item, e, idx); }
             });
+            onScreen.push({ row: row, el: item });
             list.appendChild(item);
           });
+          paintSelection();
           c.body.appendChild(list);
           const totalC = data.total || rows.length;
           count.textContent = (offset + 1) + '–' + (offset + rows.length) + ' of ' + totalC.toLocaleString();
@@ -1813,16 +1864,20 @@ window.GD_DASHBOARD = (function () {
         thead.appendChild(hr);
         table.appendChild(thead);
         const tbody = el('tbody');
-        rows.forEach(function (row) {
+        rows.forEach(function (row, idx) {
           const tr = el('tr');
           fields.forEach(function (f) {
             const td = el('td', null, fmtCell(row.props[f]));
             td.title = row.props[f] == null ? '' : String(row.props[f]);
             tr.appendChild(td);
           });
-          tr.addEventListener('click', function () { onRow(row, tr); });
+          tr.addEventListener('click', function (ev) { onRow(row, tr, ev, idx); });
+          onScreen.push({ row: row, el: tr });
           tbody.appendChild(tr);
         });
+        // The highlight, restored from the KEYS after the rebuild — a page turn or a re-sort must
+        // not make a live selection look like nothing is selected.
+        paintSelection();
         table.appendChild(tbody);
         c.body.appendChild(table);
         const total = data.total || rows.length;

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1890,7 +1890,12 @@ window.GD_DASHBOARD = (function () {
       unbound(c.body, 'Pick a layer and the two numeric columns to plot against each other.');
       return { el: c.root, refresh: function () {} };
     }
-    c.sub.textContent = truncate(ds.yField + ' ~ ' + ds.xField, 26);
+    // The author's axis titles, if they wrote any — the same names the axes carry, so the card's
+    // heading and its axes cannot disagree about what is plotted. Naming a column "GDP per capita"
+    // on the axis and leaving `GDP_PerC_1` in the heading is the field name showing through in the
+    // one place the reader looks first.
+    c.sub.textContent = truncate(((w.style && w.style.yTitle) || ds.yField) + ' ~ '
+                               + ((w.style && w.style.xTitle) || ds.xField), 26);
 
     function draw(data) {
       clear(c.body);

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -2508,6 +2508,93 @@ window.GD_DASHBOARD = (function () {
                         bbox: 'Drag a box', extent: 'Filter to what is on screen',
                         clear: 'Clear the selection' };
 
+  //: Let the visitor MOVE the selection tools around the map.
+  //:
+  //: Not an author setting, because the collision it fixes is not one an author can see coming: the
+  //: control cluster's corner is configurable, the layer list opens from a side, a widget can be
+  //: pinned to the map, and the tools sit at a fixed top-left through all of it. Whichever corner
+  //: were chosen at publish would be wrong for some other combination — so the person actually
+  //: looking at the overlap is the one who gets to resolve it.
+  //:
+  //: Stored as FRACTIONS of the map box rather than pixels: a dashboard's map cell changes size
+  //: with the breakpoint and with every drag of the widget's corner, and a bar pinned at "412px
+  //: from the left" ends up off a narrower map. Fractions survive that, and are clamped on the way
+  //: back in regardless.
+  function makeToolsMovable(bar, wrap, key) {
+    let pos = null;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) pos = JSON.parse(raw);
+    } catch (e) { /* private mode throws on read; the default position is a fine answer */ }
+
+    function apply() {
+      if (!pos) return;
+      const W = wrap.clientWidth - bar.offsetWidth, H = wrap.clientHeight - bar.offsetHeight;
+      if (W <= 0 || H <= 0) return;
+      bar.style.left = Math.round(Math.max(0, Math.min(1, pos.fx)) * W) + 'px';
+      bar.style.top = Math.round(Math.max(0, Math.min(1, pos.fy)) * H) + 'px';
+      bar.style.right = 'auto';
+      bar.style.bottom = 'auto';
+    }
+
+    const grip = el('button', 'gd-dash-tools-grip');
+    grip.type = 'button';
+    grip.title = 'Drag to move these tools';
+    grip.setAttribute('aria-label', 'Move the selection tools');
+    grip.innerHTML = '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor">'
+      + '<circle cx="9" cy="6" r="1.6"/><circle cx="15" cy="6" r="1.6"/>'
+      + '<circle cx="9" cy="12" r="1.6"/><circle cx="15" cy="12" r="1.6"/>'
+      + '<circle cx="9" cy="18" r="1.6"/><circle cx="15" cy="18" r="1.6"/></svg>';
+    bar.insertBefore(grip, bar.firstChild);
+
+    let drag = null;
+    grip.addEventListener('pointerdown', function (ev) {
+      if (ev.button !== 0 && ev.pointerType === 'mouse') return;
+      ev.preventDefault();
+      ev.stopPropagation();               // never let the map read this as a pan
+      const b = bar.getBoundingClientRect(), m = wrap.getBoundingClientRect();
+      drag = { dx: ev.clientX - b.left, dy: ev.clientY - b.top, m: m };
+      try { grip.setPointerCapture(ev.pointerId); } catch (e) {}
+      bar.dataset.dragging = '1';
+    });
+    grip.addEventListener('pointermove', function (ev) {
+      if (!drag) return;
+      ev.preventDefault();
+      const W = wrap.clientWidth - bar.offsetWidth, H = wrap.clientHeight - bar.offsetHeight;
+      if (W <= 0 || H <= 0) return;
+      // Clamped to the map, so the bar cannot be dragged somewhere it can never be grabbed back
+      // from. The fraction is what gets stored; the pixels are just this frame.
+      const x = Math.max(0, Math.min(W, ev.clientX - drag.m.left - drag.dx));
+      const y = Math.max(0, Math.min(H, ev.clientY - drag.m.top - drag.dy));
+      pos = { fx: x / W, fy: y / H };
+      apply();
+    });
+    function end(ev) {
+      if (!drag) return;
+      drag = null;
+      delete bar.dataset.dragging;
+      try { grip.releasePointerCapture(ev.pointerId); } catch (e) {}
+      try { window.localStorage.setItem(key, JSON.stringify(pos)); } catch (e) { /* see above */ }
+    }
+    grip.addEventListener('pointerup', end);
+    grip.addEventListener('pointercancel', end);
+    // Back to where it started. The only way out of a position that turned out to be worse than
+    // the default, short of clearing site data.
+    grip.addEventListener('dblclick', function (ev) {
+      ev.preventDefault();
+      pos = null;
+      bar.style.left = bar.style.top = bar.style.right = bar.style.bottom = '';
+      try { window.localStorage.removeItem(key); } catch (e) {}
+    });
+
+    apply();
+    // The map cell resizes with the breakpoint and with the widget's own corner; re-clamp so a bar
+    // parked near an edge does not end up outside a smaller map.
+    try {
+      if (typeof ResizeObserver === 'function') new ResizeObserver(apply).observe(wrap);
+    } catch (e) { /* no observer: the position is still right until something resizes */ }
+  }
+
   function mountSelectionTools(w, ds, env, wrap) {
     const map = env.map;
     const tools = ds.tools || ['click', 'polygon', 'bbox'];
@@ -2617,6 +2704,9 @@ window.GD_DASHBOARD = (function () {
     });
     bar.appendChild(clearBtn);
     wrap.appendChild(bar);
+    // Keyed by PORTAL and widget: one visitor may have several portals open over time, and a
+    // position chosen on one says nothing about where the tools are in the way on another.
+    makeToolsMovable(bar, wrap, 'gd-tools:' + (location.pathname || '') + ':' + w.id);
     // Tell the overlay layer that this corner is taken. Set here rather than assumed in CSS, so a
     // map that renders no tool bar keeps its overlays tight to the corner.
     try { wrap.dataset.dashTools = '1'; } catch (e) {}

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -104,17 +104,24 @@ window.GD_DASHBOARD = (function () {
              H: Math.max(CHART_MIN_H, Math.round(h) || 170) };
   }
 
+  //: The vertical margin an element costs the box it shares — separate from its height, because
+  //: capping how tall the legend may GROW has to leave room for the gap above it too.
+  function marginY(node) {
+    if (!node) return 0;
+    try {
+      const cs = getComputedStyle(node);
+      return (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
+    } catch (e) { return 0; }
+  }
+
   //: An element's height INCLUDING the margin that separates it from its sibling — the space it
   //: costs the box it shares, which is what has to be taken off the plot.
   function outerHeight(node) {
     if (!node) return 0;
     let h = 0;
-    try {
-      h = node.getBoundingClientRect().height || node.offsetHeight || 0;
-      const cs = getComputedStyle(node);
-      h += (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
-    } catch (e) { h = node.offsetHeight || 0; }
-    return Math.ceil(h);
+    try { h = node.getBoundingClientRect().height || node.offsetHeight || 0; }
+    catch (e) { h = node.offsetHeight || 0; }
+    return Math.ceil(h + marginY(node));
   }
 
   //: Per-bar colour. Default stays SINGLE — an x-axis that already names the category does not need
@@ -1185,25 +1192,31 @@ window.GD_DASHBOARD = (function () {
         const legend = (w.style && w.style.legend === false)
           ? null : seriesLegend(multi, colours);
         if (legend) c.body.appendChild(legend);
-        const plotH = Math.max(CHART_MIN_H, bx.H - outerHeight(legend));
+        const plotH = plotHeight(bx, w.style, [legend]);
         const node = (kind === 'line' || kind === 'area')
           ? drawMultiLine(groups, ds, w.style, multi, kind === 'area', bx.W, plotH)
           : drawGroupedBars(groups, ds, w.style, multi, bx.W, plotH);
-        // The viewBox is already `plotH` tall; this stops the CSS `height: 100%` scaling it back up
-        // to the full body and undoing the whole calculation.
-        node.style.height = plotH + 'px';
+        fixPlotHeight(node, plotH);
+        capToRoom(legend, bx, plotH);
         c.body.insertBefore(node, legend);      // a null second argument appends, which is correct
         return;
       }
+      // A pie's key had the same problem as a line chart's and for the same reason — the circle is
+      // `height: 100%` and the key is its sibling — so it is measured first here too. `plotSize`
+      // still overrules, which is what it always did on a pie; it just no longer has to be reached
+      // for to make the key visible at all.
+      const key = (w.style && w.style.legend !== false && (kind === 'pie' || kind === 'donut'))
+        ? pieLegend(groups, selectedKey(), onPick) : null;
+      if (key) c.body.appendChild(key);
+      const plotH = plotHeight(bx, w.style, [key]);
       const node = (kind === 'pie' || kind === 'donut')
         ? drawPie(groups, ds, w.style, selectedKey(), onPick, kind === 'donut')
         : (kind === 'line' || kind === 'area')
-          ? drawLine(groups, ds, w.style, kind === 'area', selectedKey(), onPick, bx.W, bx.H)
-          : drawBars(groups, ds, w.style, selectedKey(), onPick, kind === 'hbar', bx.W, bx.H);
-      c.body.appendChild(node);
-      if (w.style && w.style.legend !== false && (kind === 'pie' || kind === 'donut')) {
-        c.body.appendChild(pieLegend(groups, selectedKey(), onPick));
-      }
+          ? drawLine(groups, ds, w.style, kind === 'area', selectedKey(), onPick, bx.W, plotH)
+          : drawBars(groups, ds, w.style, selectedKey(), onPick, kind === 'hbar', bx.W, plotH);
+      fixPlotHeight(node, plotH);
+      capToRoom(key, bx, plotH);
+      c.body.insertBefore(node, key);
     }
     function refresh() {
       busy(c.root, true);
@@ -1673,30 +1686,56 @@ window.GD_DASHBOARD = (function () {
     return svg;
   }
 
-  //: How much of the card's HEIGHT the pie itself takes, as a percentage. Default 100, which is
-  //: what every dashboard published so far draws.
+  //: SHARING THE CARD between a plot and the key that explains it.
   //:
-  //: The pie is `height: 100%` and the legend is its sibling, so on a card with many categories the
-  //: circle claimed the whole body and pushed the legend into a scrollbar — a chart you cannot read
-  //: the key to. Resizing the WIDGET does not help: a taller card grows the pie by exactly as much.
-  //: The two need to be separately adjustable, so this caps the plot and leaves the rest to the key.
+  //: Every plot in here is `height: 100%` and every key is its sibling in a body that scrolls, so
+  //: by default the plot claimed the whole card and pushed the key out of sight — and making the
+  //: widget taller grew the plot by exactly as much, which is why resizing never fixed it. The
+  //: three functions below are the fix, and they are shared because the pie, the multi-series line
+  //: and the grouped bars all had the same bug for the same reason.
+
+  //: The plot's share of the card's height, 30-100. Default 100, which means AUTO: take everything
+  //: the key does not need. Below 100 it is a fixed fraction and the key scrolls in the remainder,
+  //: for the case where twelve series wrap to four lines and the shape matters more than the names.
   function plotShare(style) {
     const v = style && style.plotSize;
     return (typeof v === 'number' && v >= 30 && v <= 100) ? v : 100;
+  }
+
+  //: How tall the plot may be, once everything else sharing the body has had its room. Measuring
+  //: is the right default because only the key knows how many lines its labels wrap to.
+  function plotHeight(bx, style, companions) {
+    const share = plotShare(style);
+    if (share < 100) return Math.max(CHART_MIN_H, Math.round(bx.H * share / 100));
+    const cost = (companions || []).reduce(function (a, n) { return a + outerHeight(n); }, 0);
+    return Math.max(CHART_MIN_H, bx.H - cost);
+  }
+
+  //: Keep a companion inside the room the plot left it, scrolling rather than pushing the pair out
+  //: of the card. Bites whenever the author fixed the share, and in AUTO only when the key alone is
+  //: taller than the whole card — where the plot has hit its floor and something has to give. The
+  //: key scrolling is a better outcome than the card scrolling: the plot at least stays visible.
+  function capToRoom(node, bx, plotH) {
+    if (!node) return;
+    const room = Math.max(0, bx.H - plotH - marginY(node));
+    if (outerHeight(node) - marginY(node) > room) {
+      node.style.maxHeight = room + 'px';
+      node.style.overflowY = 'auto';
+    }
+  }
+
+  //: Pin the plot to the height it was measured for. `.gd-chart` is `height: 100%`, which would
+  //: otherwise scale it straight back up to the whole body and undo the calculation; `flex: none`
+  //: covers the bodies that are flex columns, where a set height is only a starting size.
+  function fixPlotHeight(node, h) {
+    node.style.height = h + 'px';
+    node.style.flex = 'none';
   }
 
   function drawPie(groups, ds, style, selected, onPick, donut) {
     const S = 170, cx = S / 2, cy = S / 2, r = S / 2 - 8, inner = donut ? r * 0.58 : 0;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + S + ' ' + S,
                                preserveAspectRatio: 'xMidYMid meet' });
-    const share = plotShare(style);
-    if (share < 100) {
-      // `flex: none` alongside the height: the body is a block box today, where the height alone
-      // is enough, but `.gd-w-center` turns it into a flex column — and a flex child grows past a
-      // set height unless told not to, handing the pie back exactly the space this takes away.
-      svg.style.height = share + '%';
-      svg.style.flex = 'none';
-    }
     const total = groups.reduce(function (a, g) { return a + Math.max(0, g.value || 0); }, 0);
     if (total <= 0) return svg;
     let angle = -Math.PI / 2;

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1725,7 +1725,10 @@ window.GD_DASHBOARD = (function () {
     //: rows are rebuilt on every page turn, sort and filter change — a node reference would be
     //: stale the moment anything moved, and the highlight would vanish while the filter it
     //: published stayed live. Keys survive the rebuild and the highlight is re-applied from them.
-    const picked = new Set();
+    //: A MAP of key -> bbox, not a set of keys. The camera follows the whole selection, and a row
+    //: scrolls off the page as soon as the visitor turns it — so the extent has to be remembered
+    //: when the row is picked, or selecting page 1 and page 2 would fit only page 2.
+    const picked = new Map();
     let anchor = null;          // index the last plain click landed on, for shift-ranges
     let onScreen = [];          // the rows currently rendered, so a range knows what lies between
     function keyOf(row) {
@@ -1736,6 +1739,19 @@ window.GD_DASHBOARD = (function () {
       // The filter bar's × and Reset both clear the attribute; the rows must stop looking selected.
       if (!env.store.attrOf(w.id) && picked.size) { picked.clear(); paintSelection(); }
     });
+    //: The extent of every selected row, or null when not one of them carries a bbox — an
+    //: aggregate row and a feature with no geometry both come back without one, and moving the
+    //: camera to a guess is worse than leaving it where the visitor put it.
+    function unionBbox() {
+      let out = null;
+      picked.forEach(function (b) {
+        if (!b || b.length !== 4) return;
+        if (!out) { out = [b[0], b[1], b[2], b[3]]; return; }
+        out[0] = Math.min(out[0], b[0]); out[1] = Math.min(out[1], b[1]);
+        out[2] = Math.max(out[2], b[2]); out[3] = Math.max(out[3], b[3]);
+      });
+      return out;
+    }
     function paintSelection() {
       onScreen.forEach(function (r) {
         const on = picked.has(keyOf(r.row));
@@ -1761,22 +1777,25 @@ window.GD_DASHBOARD = (function () {
         picked.clear();
         for (let i = lo; i <= hi; i++) {
           const k = keyOf(onScreen[i].row);
-          if (k != null) picked.add(k);
+          if (k != null) picked.set(k, onScreen[i].row.bbox || null);
         }
       } else if (add) {
-        if (key != null) { if (picked.has(key)) picked.delete(key); else picked.add(key); }
+        if (key != null) { if (picked.has(key)) picked.delete(key); else picked.set(key, row.bbox || null); }
         anchor = idx;
       } else {
         picked.clear();
-        if (key != null) picked.add(key);
+        if (key != null) picked.set(key, row.bbox || null);
         anchor = idx;
       }
       paintSelection();
 
-      // Zoom + highlight: the bbox came with the row precisely so this needs no round trip. Only on
-      // a SINGLE pick — flying the camera on every ctrl-click, while someone is building a
-      // selection, moves the map out from under the rows they are still choosing.
-      if (!add && !range && row.bbox) env.fitBbox(row.bbox);
+      // Zoom to EVERYTHING selected, not to the row just clicked. The bboxes came with the rows
+      // precisely so this needs no round trip, and taking their union is what makes the camera
+      // follow the selection rather than chase the last click: ctrl-clicking a second row widens
+      // the view to hold both, and removing one narrows it back. Fitting the newest row alone
+      // would hide the others the visitor had just chosen.
+      const box = unionBbox();
+      if (box) env.fitBbox(box);
 
       // A new selection REPLACES the last on every channel it used. The details panel shows the row
       // just clicked even when several are selected: it holds one feature by definition, and the
@@ -1785,7 +1804,7 @@ window.GD_DASHBOARD = (function () {
       env.store.publishSelection(w.id, row.props, row.bbox,
         String(row.props[ds.keyField] == null ? '' : row.props[ds.keyField]));
       if (picked.size) {
-        const values = Array.from(picked);
+        const values = Array.from(picked.keys());
         env.store.publishAttr(w.id, { field: ds.keyField, op: 'in', values: values },
           (w.title || defaultTitle(w)) + ': '
             + (values.length === 1 ? truncate(values[0], 24) : values.length + ' selected'));

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -746,7 +746,7 @@ window.GD_DASHBOARD = (function () {
       return { el: c.root, refresh: function () {} };
     }
     const source = env.sources[layerKeyOf(w)];
-    c.sub.textContent = opLabel(ds, source);
+    setSub(c, w, opLabel(ds, source));
 
     if (ds.filterField && ds.filterValue != null) {
       c.root.dataset.clickable = '1';
@@ -825,9 +825,28 @@ window.GD_DASHBOARD = (function () {
     return el('div', 'gd-ind-delta ' + cls, text + ' vs ' + fmtNumber(target, style));
   }
 
+  //: The line under a widget's title: the author's words if they wrote any, otherwise what the
+  //: widget can work out about itself.
+  //:
+  //: The automatic one names the layer and the aggregation, which is the right DEFAULT and a poor
+  //: caption — "GDP_per_capita_1960_2016_… · count" describes the query, and the reader wants the
+  //: subject. The title has always been editable; this line was not, and it is the one carrying the
+  //: field name.
+  function setSub(c, w, fallback) {
+    const custom = w.style && w.style.subtitle;
+    c.sub.textContent = custom ? truncate(custom, 40) : fallback;
+  }
+
   function opLabel(ds, source) {
     const name = source ? source.name : ('layer ' + ds.layerId);
-    const op = { count: 'count', sum: 'sum', avg: 'average', min: 'minimum', max: 'maximum' }[ds.op] || ds.op;
+    // The EFFECTIVE aggregation. With columns as the axis the runtime substitutes `sum` for
+    // `count`, because counting rows reads none of the chosen columns — so a chart saved before
+    // that promotion existed said "count" in its subtitle while plotting sums.
+    // `|| 'count'` at the end because an absent op used to fall through the lookup and print the
+    // word "undefined" in the subtitle. The schema fills it in on every widget it normalises, so
+    // this is for the one that arrives without — an older manifest, a hand-edited config.
+    const raw = ((ds.xColumns || []).length && (!ds.op || ds.op === 'count')) ? 'sum' : (ds.op || 'count');
+    const op = { count: 'count', sum: 'sum', avg: 'average', min: 'minimum', max: 'maximum' }[raw] || raw;
     return truncate(name, 26) + ' · ' + op;
   }
 
@@ -839,7 +858,7 @@ window.GD_DASHBOARD = (function () {
       unbound(c.body, 'Pick a layer and an aggregation for this gauge.');
       return { el: c.root, refresh: function () {} };
     }
-    c.sub.textContent = opLabel(ds, env.sources[layerKeyOf(w)]);
+    setSub(c, w, opLabel(ds, env.sources[layerKeyOf(w)]));
     if (ds.filterField && ds.filterValue != null) {
       c.root.dataset.clickable = '1';
       c.root.addEventListener('click', function () {
@@ -1085,7 +1104,7 @@ window.GD_DASHBOARD = (function () {
       unbound(c.body, 'Pick a layer, an aggregation and a grouping field for this chart.');
       return { el: c.root, refresh: function () {} };
     }
-    c.sub.textContent = opLabel(ds, env.sources[layerKeyOf(w)]);
+    setSub(c, w, opLabel(ds, env.sources[layerKeyOf(w)]));
     let groups = [];
     let multi = [];      // the series the server answered; length > 1 selects the multi-series draw
 
@@ -1685,7 +1704,7 @@ window.GD_DASHBOARD = (function () {
       return { el: c.root, refresh: function () {} };
     }
     const source = env.sources[layerKeyOf(w)];
-    c.sub.textContent = truncate(source ? source.name : ('layer ' + ds.layerId), 26);
+    setSub(c, w, truncate(source ? source.name : ('layer ' + ds.layerId), 26));
     const foot = el('div', 'gd-table-foot');
     const prev = el('button', null, '‹');
     const next = el('button', null, '›');
@@ -1899,8 +1918,8 @@ window.GD_DASHBOARD = (function () {
     // heading and its axes cannot disagree about what is plotted. Naming a column "GDP per capita"
     // on the axis and leaving `GDP_PerC_1` in the heading is the field name showing through in the
     // one place the reader looks first.
-    c.sub.textContent = truncate(((w.style && w.style.yTitle) || ds.yField) + ' ~ '
-                               + ((w.style && w.style.xTitle) || ds.xField), 26);
+    setSub(c, w, truncate(((w.style && w.style.yTitle) || ds.yField) + ' ~ '
+                        + ((w.style && w.style.xTitle) || ds.xField), 26));
 
     function draw(data) {
       clear(c.body);
@@ -2145,7 +2164,7 @@ window.GD_DASHBOARD = (function () {
       return { el: c.root, refresh: function () {} };
     }
     const source = env.sources[layerKeyOf(w)];
-    c.sub.textContent = truncate(source ? source.name : ('layer ' + ds.layerId), 26);
+    setSub(c, w, truncate(source ? source.name : ('layer ' + ds.layerId), 26));
 
     function fieldBlock(f, total) {
       const box = el('div', 'gd-prof-f');
@@ -2227,7 +2246,7 @@ window.GD_DASHBOARD = (function () {
       unbound(c.body, 'Pick a layer and a field for this filter control.');
       return { el: c.root, refresh: function () {} };
     }
-    c.sub.textContent = ds.field;
+    setSub(c, w, ds.field);
     const chosen = {};
 
     function publish() {
@@ -2356,7 +2375,7 @@ window.GD_DASHBOARD = (function () {
     function refresh() {
       const sel = env.store.selectionFor(w);
       clear(c.body);
-      c.sub.textContent = sel && sel.title ? truncate(sel.title, 22) : '';
+      setSub(c, w, sel && sel.title ? truncate(sel.title, 22) : '');
       if (!sel) {
         c.body.appendChild(el('div', 'gd-w-empty',
           'Select a feature on the map, or a row in a table, to see its attributes here.'));
@@ -2389,7 +2408,7 @@ window.GD_DASHBOARD = (function () {
       return { el: c.root, refresh: function () {} };
     }
     const source = env.sources[layerKeyOf(w)];
-    c.sub.textContent = truncate(source ? source.name : ('raster ' + ds.layerId), 24);
+    setSub(c, w, truncate(source ? source.name : ('raster ' + ds.layerId), 24));
 
     function refresh() {
       const f = env.store.filtersFor(w);

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -2312,6 +2312,18 @@ window.GD_DASHBOARD = (function () {
           if ((ds.stats || []).indexOf('histogram') >= 0) {
             if (stats.histogram && stats.histogram.counts && stats.histogram.counts.length) {
               c.body.appendChild(drawHistogram(stats.histogram, w.style));
+              // WHAT RANGE it covers. The bars alone show a shape over an interval the reader has
+              // no way to name — the edges were reachable only by hovering a bar, which is not a
+              // thing anyone does to find out what a chart is about. As HTML rather than inside the
+              // SVG: the histogram is drawn with `preserveAspectRatio: none` so it can stretch to
+              // the card, and text in there would stretch with it.
+              const edges = stats.histogram.edges || [];
+              if (edges.length > 1) {
+                const scale = el('div', 'gd-rs-hist-scale');
+                scale.appendChild(el('span', null, fmtNumber(edges[0], w.style)));
+                scale.appendChild(el('span', null, fmtNumber(edges[edges.length - 1], w.style)));
+                c.body.appendChild(scale);
+              }
             } else {
               c.body.appendChild(el('div', 'gd-w-empty', 'No histogram for this area.'));
             }

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -285,7 +285,8 @@ window.GD_DASHBOARD = (function () {
     widgets.forEach(function (w) { byId[w.id] = w; });
     // `geomPinned` = the geometry came from a deliberate act (a click, a drawn polygon, a dragged
     // box) rather than from the map moving. See `publishGeom`.
-    const state = { attr: {}, geom: null, geomPinned: false, selection: null };
+    const state = { attr: {}, geom: null, geomPinned: false, selection: null,
+                    lastAttr: null };
     const listeners = {};      // widgetId → refresh fn (a TARGET re-queries)
     const selfListeners = {};  // widgetId → fn (a SOURCE redraws its own active state, no query)
     const barListeners = [];
@@ -365,12 +366,18 @@ window.GD_DASHBOARD = (function () {
         state.attr[sourceId] = { layerKey: layerKeyOf(byId[sourceId]),
                                  layerId: layerIdOf(byId[sourceId]), targets: targets,
                                  expr: expr, label: label };
+        // WHO published last. Only the map reads it, to decide whether the newest filter was a
+        // chart click worth framing the camera on; targets otherwise see a set, not an order.
+        state.lastAttr = sourceId;
         notify(affected(prev && prev.targets, targets));
         notifySelf(sourceId);
       },
       clearAttr: function (sourceId, quiet) {
         const prev = state.attr[sourceId];
         if (!prev) return;
+        // Clearing is not publishing: un-selecting a bar must not fly the camera to what was just
+        // let go of. Only forget it if the source being cleared IS the last publisher.
+        if (state.lastAttr === sourceId) state.lastAttr = null;
         delete state.attr[sourceId];
         if (!quiet) { notify(prev.targets); notifySelf(sourceId); }
       },
@@ -448,6 +455,16 @@ window.GD_DASHBOARD = (function () {
           (out[f.layerId] || (out[f.layerId] = [])).push(f.expr);
         }
         return out;
+      },
+      //: The attribute filter published MOST RECENTLY, with the type of the widget that published
+      //: it — everything the map needs to decide whether this was a chart click worth framing.
+      //: Tracked here because the store is the only place that sees the publications in order; a
+      //: target only ever sees the resulting set.
+      lastAttrSource: function () {
+        const id = state.lastAttr;
+        if (!id || !state.attr[id]) return null;
+        const f = state.attr[id], w = byId[id];
+        return { id: id, type: w && w.type, layerId: f.layerId, expr: f.expr };
       },
       selectionFor: function (w) {
         const sel = state.selection;
@@ -2112,6 +2129,7 @@ window.GD_DASHBOARD = (function () {
       // The map as a TARGET: an attribute filter pointed at it is applied to the MapLibre layers
       // drawing its selection layer, so filtering the dashboard visibly narrows the map too.
       applyMapFilter(w, env);
+      zoomToFilter(w, env);
     }
     return { el: wrap, refresh: refresh, isMap: true };
   };
@@ -2268,6 +2286,31 @@ window.GD_DASHBOARD = (function () {
 
   //: The distinct data layers the style draws, in style order. An external layer is skipped for the
   //: same reason it always was: its features are somebody else's and carry none of our columns.
+  //: Frame what a CHART just selected.
+  //:
+  //: Charts only, deliberately. A selector or a search box is a control the visitor is working in —
+  //: moving the camera under someone adjusting a slider is the map arguing with the hand using it —
+  //: and a table row already flies to its own feature. A chart segment is the one case where the
+  //: selection IS a set of features with an extent and clicking it says "show me these".
+  //:
+  //: The extent comes from the server (`op: 'bounds'`), because the browser only holds the tiles it
+  //: has drawn: computing it client-side would frame the part of the selection that happens to be
+  //: on screen, which is the answer least worth having.
+  function zoomToFilter(w, env) {
+    if (!(w.dataSource && w.dataSource.zoomToFilter)) return;
+    if (!env.fitBbox) return;
+    const src = env.store.lastAttrSource && env.store.lastAttrSource();
+    if (!src || src.type !== 'chart' || src.layerId == null) return;
+    env.api.aggregate('mapfit:' + w.id, src.layerId,
+      { op: 'bounds', filters: [src.expr], geometry: null })
+      .then(function (r) {
+        // `null` is a real answer — a filter that matches nothing has no extent — and moving the
+        // camera to a rectangle invented for that case is worse than not moving at all.
+        if (r && r.bounds) env.fitBbox(r.bounds);
+      })
+      .catch(function () { /* a camera move is never worth an error in front of the visitor */ });
+  }
+
   function drawnLayerIds(env) {
     const seen = {}, out = [];
     (env.style.layers || []).forEach(function (lyr) {

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1917,12 +1917,23 @@ window.GD_DASHBOARD = (function () {
       const colour = (w.style && w.style.color) || accent();
       // Opacity rather than a smaller dot: overlapping points then READ as density, which is the
       // information a scatter of a few thousand features actually carries.
-      pts.forEach(function (p) {
-        svg.appendChild(svgEl('circle', {
+      // NAMES ON HOVER, when the author nominated columns for them. A dot is a pair of numbers
+      // until something says whose they are; an outlier is the point of a scatter and the one thing
+      // it could not tell you about. A native `<title>` rather than a custom tooltip: it is what the
+      // bars and lines already use, it survives touch and keyboard focus, and it costs one element.
+      const names = data.labels || [];
+      pts.forEach(function (p, i) {
+        const dot = svgEl('circle', {
           cx: padL + ((p[0] - x0) / sx) * (W - padL - padR),
           cy: H - padB - ((p[1] - y0) / sy) * (H - padT - padB),
           r: 2, fill: colour, opacity: 0.45,
-        }));
+        });
+        const label = names[i];
+        const coords = fmtNumber(p[0], w.style) + ', ' + fmtNumber(p[1], w.style);
+        const t = svgEl('title');
+        t.textContent = label ? label + ' — ' + coords : coords;
+        dot.appendChild(t);
+        svg.appendChild(dot);
       });
       svg.appendChild(svgEl('line', { class: 'axis', x1: padL, y1: H - padB, x2: W - padR, y2: H - padB }));
       svg.appendChild(svgEl('line', { class: 'axis', x1: padL, y1: padT, x2: padL, y2: H - padB }));
@@ -1983,6 +1994,7 @@ window.GD_DASHBOARD = (function () {
       busy(c.root, true);
       env.api.scatter(w.id, ds.layerId, specFor(w, env.store, {
         xField: ds.xField, yField: ds.yField, limit: ds.limit,
+        labelFields: ds.labelFields,
       })).then(function (data) {
         busy(c.root, false);
         draw(data);

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -1233,7 +1233,9 @@ window.GD_DASHBOARD = (function () {
   }
 
   function drawMultiLine(groups, ds, style, series, filled, boxW, boxH) {
-    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 26;
+    // padB 34, not 26: a rotated label hangs below its tick, and 26 clipped it. Same as the grouped
+    // bars, which have always rotated.
+    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 34;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const n = groups.length, m = series.length;
@@ -1265,6 +1267,14 @@ window.GD_DASHBOARD = (function () {
         svg.appendChild(dot);
       });
     }
+    // THE X AXIS. This drew none at all: a chart of one line per country across 56 year-columns
+    // showed the lines and never said which year any point was. Selecting a single country dropped
+    // to `drawLine`, which does label its axis — so the labels appeared and disappeared with the
+    // number of series, which is not a distinction the axis has any business making.
+    axisLabels.room = W - padL - padR;
+    groups.forEach(function (g, i) {
+      axisLabels(svg, i, n, g, ds, x(i), H - padB + 11, false);
+    });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, ext.lo, ext.hi, style));
     return svg;
   }
@@ -1476,7 +1486,7 @@ window.GD_DASHBOARD = (function () {
   //: 2.6px dot: on a 30-point series the dots are ~9px apart and aiming at the dot itself is a test
   //: of the mouse, not an interaction.
   function drawLine(groups, ds, style, filled, selected, onPick, boxW, boxH) {
-    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 26;
+    const W = boxW || 300, H = boxH || 170, padL = 34, padR = 8, padT = 8, padB = 34;
     const svg = svgEl('svg', { class: 'gd-chart', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
     const values = groups.map(function (g) { return g.value == null ? 0 : g.value; });
@@ -1513,12 +1523,14 @@ window.GD_DASHBOARD = (function () {
       }
       svg.appendChild(hit);
     });
-    const every = Math.ceil(n / 6);
+    // The SAME helper the bars use, rather than this renderer's own rule of "six, upright, always".
+    // Six was a count with no relation to the card's width — too many in a narrow cell, and a waste
+    // of a wide one — and upright labels cannot rotate out of each other's way, so long category
+    // names simply overlapped. Sharing it also means a chart's axis does not change character when
+    // a filter takes it from several lines down to one.
+    axisLabels.room = W - padL - padR;
     groups.forEach(function (g, i) {
-      if (i % every) return;
-      const lab = svgEl('text', { x: x(i), y: H - padB + 12, 'text-anchor': 'middle', class: 'glabel' });
-      lab.textContent = truncate(groupLabel(g, ds), 12);
-      svg.appendChild(lab);
+      axisLabels(svg, i, n, g, ds, x(i), H - padB + 11, false);
     });
     svg.appendChild(axis(padL, padT, W - padR, H - padB, minV, maxV, style));
     return svg;
@@ -3099,6 +3111,13 @@ window.GD_DASHBOARD = (function () {
     function render() {
       clear(bar);
       const chips = store.chips();
+      // The GRID makes room for the bar, rather than the bar covering the grid. It is fixed to the
+      // foot of the window, so at the bottom of a scrolled dashboard it sat over the last row —
+      // over a chart's x-axis labels, which is the part of a chart that says what you are looking
+      // at. A flag on the body rather than a measured height: the bar is one line by construction
+      // (its chips scroll sideways instead of wrapping), so the space it needs is a constant, and
+      // the reservation appears only while there is something to reserve it for.
+      try { document.body.dataset.dashFiltered = chips.length ? '1' : '0'; } catch (e) {}
       if (!chips.length) { bar.style.display = 'none'; return; }
       bar.style.display = '';
       bar.appendChild(el('span', 'gd-fbar-label', 'Filtered by'));

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -870,13 +870,27 @@ window.GD_DASHBOARD = (function () {
   function drawGauge(value, style) {
     const min = style.min == null ? 0 : style.min;
     const max = style.max == null ? 100 : style.max;
-    const W = 180, H = 116, cx = 90, cy = 96, r = 68;
+    //: GEOMETRY THAT FITS. The arc sweeps 240 degrees from -210, so its two ends sit at 30 degrees
+    //: BELOW the centre — `cy + r*sin(30) = cy + r/2`, lower than the widest point of the circle.
+    //: The old box was 116 tall with the centre at 96, which put both ends at y=130 and cut 20px
+    //: off the bottom of the dial: the arc appeared to stop dead just before each cap, and the
+    //: min/max labels sat over the gap where its ends should have been.
+    //:
+    //: Derived rather than guessed, so it stays right if the radius or the sweep changes:
+    //:   top    = cy - r - halfStroke   (must be >= 0)
+    //:   bottom = cy + r*sin(30) + halfStroke
+    //:   labels sit below that, and H covers the lot.
+    const r = 68, SW = 12, HALF = SW / 2, W = 180, cx = 90;
     const START = -210, SWEEP = 240;
+    const endDrop = r * Math.sin((START + SWEEP) * Math.PI / 180);   // + r/2
+    const cy = r + HALF;
+    const H = Math.ceil(cy + endDrop + HALF + 16);                   // + room for the cap labels
     const svg = svgEl('svg', { class: 'gd-gauge', viewBox: '0 0 ' + W + ' ' + H,
                                preserveAspectRatio: 'xMidYMid meet' });
-    function pt(frac) {
+    function pt(frac, radius) {
       const a = (START + SWEEP * frac) * Math.PI / 180;
-      return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+      const rr = radius == null ? r : radius;
+      return [cx + rr * Math.cos(a), cy + rr * Math.sin(a)];
     }
     function arc(f0, f1, colour, width) {
       const p0 = pt(f0), p1 = pt(f1);
@@ -887,32 +901,61 @@ window.GD_DASHBOARD = (function () {
         fill: 'none', stroke: colour, 'stroke-width': width, 'stroke-linecap': 'round',
       });
     }
-    const track = arc(0, 1, 'currentColor', 12);
+    const span = (max - min) || 1;
+    const fracOf = function (v) { return Math.max(0, Math.min(1, (v - min) / span)); };
+
+    const track = arc(0, 1, 'currentColor', SW);
     track.setAttribute('class', 'gd-gauge-track');
     track.removeAttribute('stroke');
     svg.appendChild(track);
 
-    const span = (max - min) || 1;
     const bands = (style.bands || []).slice();
     bands.forEach(function (b, i) {
-      const from = Math.max(0, Math.min(1, (b.from - min) / span));
-      const to = i + 1 < bands.length ? Math.max(0, Math.min(1, (bands[i + 1].from - min) / span)) : 1;
-      if (to > from) svg.appendChild(arc(from, to, b.color, 12));
+      const from = fracOf(b.from);
+      const to = i + 1 < bands.length ? fracOf(bands[i + 1].from) : 1;
+      if (to > from) svg.appendChild(arc(from, to, b.color, SW));
     });
 
+    //: TICKS. A dial labelled only at its two ends says how far it goes and not where anything
+    //: sits along it — the same fault the value axis had. Short marks just inside the track, at the
+    //: round numbers `niceTicks` picks, so a needle two thirds along can be read as a number.
+    niceTicks(min, max, 4).forEach(function (v) {
+      if (v < min || v > max) return;
+      const f = fracOf(v);
+      const a = pt(f, r - HALF - 1), b = pt(f, r - HALF - 5);
+      svg.appendChild(svgEl('line', { class: 'gd-gauge-tick',
+                                      x1: a[0].toFixed(2), y1: a[1].toFixed(2),
+                                      x2: b[0].toFixed(2), y2: b[1].toFixed(2) }));
+    });
+
+    //: The TARGET, when there is one. A gauge exists to answer "are we there yet", and a dial with
+    //: a number on it but no mark for the number that matters leaves the reader doing the
+    //: comparison in their head.
+    if (style.target != null && isFinite(style.target)) {
+      const f = fracOf(style.target);
+      const a = pt(f, r + HALF + 1), b = pt(f, r - HALF - 1);
+      svg.appendChild(svgEl('line', { class: 'gd-gauge-target',
+                                      x1: a[0].toFixed(2), y1: a[1].toFixed(2),
+                                      x2: b[0].toFixed(2), y2: b[1].toFixed(2) }));
+    }
+
     if (value != null && isFinite(value)) {
-      const frac = Math.max(0, Math.min(1, (value - min) / span));
+      const frac = fracOf(value);
       svg.appendChild(arc(0, Math.max(frac, 0.001), style.color || accent(), 6));
       const p = pt(frac);
       svg.appendChild(svgEl('circle', { cx: p[0].toFixed(2), cy: p[1].toFixed(2), r: 5,
                                         fill: style.color || accent() }));
     }
-    const label = svgEl('text', { x: cx, y: cy - 8, 'text-anchor': 'middle', class: 'gd-gauge-value' });
+    const label = svgEl('text', { x: cx, y: cy - 6, 'text-anchor': 'middle', class: 'gd-gauge-value' });
     label.textContent = fmtNumber(value, style) + (style.unit ? ' ' + style.unit : '');
     svg.appendChild(label);
-    const lo = svgEl('text', { x: pt(0)[0], y: cy + 16, 'text-anchor': 'middle', class: 'gd-gauge-cap' });
+    // Under the arc's ENDS, wherever the geometry puts them.
+    const capY = cy + endDrop + HALF + 12;
+    const lo = svgEl('text', { x: pt(0)[0].toFixed(2), y: capY, 'text-anchor': 'middle',
+                               class: 'gd-gauge-cap' });
     lo.textContent = fmtNumber(min, style);
-    const hi = svgEl('text', { x: pt(1)[0], y: cy + 16, 'text-anchor': 'middle', class: 'gd-gauge-cap' });
+    const hi = svgEl('text', { x: pt(1)[0].toFixed(2), y: capY, 'text-anchor': 'middle',
+                               class: 'gd-gauge-cap' });
     hi.textContent = fmtNumber(max, style);
     svg.appendChild(lo); svg.appendChild(hi);
     return svg;
@@ -1373,14 +1416,57 @@ window.GD_DASHBOARD = (function () {
     return svg;
   }
 
+  //: Round numbers to put an axis's ticks on.
+  //:
+  //: The ends of a range are almost never the numbers a reader wants to see: an axis labelled
+  //: 0 and 25413 says how far it goes and nothing about where anything sits along it. Ticks at
+  //: 0 / 5000 / 10000 / … let a value be read off the chart, which is what an axis is for.
+  //:
+  //: Steps are 1, 2 or 5 times a power of ten — the intervals people count in. Snapping the step
+  //: rather than dividing the span evenly is the difference between 0, 5000, 10000 and 0, 6353.25,
+  //: 12706.5, both of which have five ticks and only one of which can be read at a glance.
+  function niceTicks(min, max, count) {
+    if (!isFinite(min) || !isFinite(max)) return [];
+    if (min === max) return [min];
+    const raw = (max - min) / Math.max(1, count);
+    const mag = Math.pow(10, Math.floor(Math.log(raw) / Math.LN10));
+    const norm = raw / mag;
+    // Thresholds at the MIDPOINTS between the candidate steps, not at the steps themselves. Snapping
+    // 2.5 up to 5 (norm <= 2 ? 2 : 5) doubles the interval and halves the ticks: a chart from 12 to
+    // 913 came out with a step of 500 and therefore exactly ONE gridline, at 500. Choosing the
+    // nearest candidate instead of the next one up keeps the count near what was asked for.
+    const step = (norm < 1.5 ? 1 : norm < 3 ? 2 : norm < 7 ? 5 : 10) * mag;
+    // How many decimals the step itself carries; ticks are rounded to it so a 0.2 step does not
+    // produce 0.6000000000000001 for a label to render.
+    const dp = Math.max(0, Math.min(12, -Math.floor(Math.log(step) / Math.LN10)));
+    const out = [];
+    // The epsilon is for binary floating point, not for tolerance: 0.1 + 0.2 lands a hair past 0.3
+    // and the last tick of a decimal range would otherwise be dropped.
+    for (let v = Math.ceil(min / step) * step; v <= max + step * 1e-9; v += step) {
+      out.push(Math.abs(v) < step * 1e-9 ? 0 : Number(v.toFixed(dp)));   // -0 prints as "-0"
+      if (out.length > 40) break;                    // a guard, never reached by a sane range
+    }
+    return out;
+  }
+
+  //: The value axis: a baseline, ticks at readable intervals, and a faint rule across the plot at
+  //: each one so a bar's height can be compared with the number beside it rather than guessed.
   function axis(x0, y0, x1, y1, minV, maxV, style) {
     const g = svgEl('g');
     g.appendChild(svgEl('line', { class: 'axis', x1: x0, y1: y1, x2: x1, y2: y1 }));
-    const hi = svgEl('text', { x: x0 - 4, y: y0 + 8, 'text-anchor': 'end', class: 'tick' });
-    hi.textContent = fmtNumber(maxV, style);
-    const lo = svgEl('text', { x: x0 - 4, y: y1, 'text-anchor': 'end', class: 'tick' });
-    lo.textContent = fmtNumber(minV, style);
-    g.appendChild(hi); g.appendChild(lo);
+    const span = (maxV - minV) || 1;
+    const ticks = niceTicks(minV, maxV, 4);
+    ticks.forEach(function (v) {
+      const y = y1 - ((v - minV) / span) * (y1 - y0);
+      if (y < y0 - 0.5 || y > y1 + 0.5) return;      // outside the plot after rounding
+      // Not over the baseline, which is already a line.
+      if (Math.abs(y - y1) > 0.5) {
+        g.appendChild(svgEl('line', { class: 'gridline', x1: x0, y1: y, x2: x1, y2: y }));
+      }
+      const t = svgEl('text', { x: x0 - 4, y: y + 3, 'text-anchor': 'end', class: 'tick' });
+      t.textContent = fmtNumber(v, style);
+      g.appendChild(t);
+    });
     return g;
   }
 
@@ -1759,10 +1845,39 @@ window.GD_DASHBOARD = (function () {
         t.textContent = text;
         return t;
       };
-      svg.appendChild(tick(padL, H - padB + 11, fmtNumber(x0, w.style), 'start'));
-      svg.appendChild(tick(W - padR, H - padB + 11, fmtNumber(x1, w.style), 'end'));
-      svg.appendChild(tick(padL - 4, H - padB, fmtNumber(y0, w.style), 'end'));
-      svg.appendChild(tick(padL - 4, padT + 8, fmtNumber(y1, w.style), 'end'));
+      // Ticks at readable intervals on BOTH axes, not just the two ends. A scatter labelled only
+      // with its extremes shows the shape of a relationship and refuses to say what any point on
+      // it is worth.
+      // `sx`/`sy` above are the SPANS; these map a value to a coordinate.
+      const toX = function (v) { return padL + ((v - x0) / sx) * (W - padL - padR); };
+      const toY = function (v) { return (H - padB) - ((v - y0) / sy) * (H - padT - padB); };
+      niceTicks(x0, x1, 4).forEach(function (v) {
+        const cx = toX(v);
+        if (cx < padL - 0.5 || cx > W - padR + 0.5) return;
+        svg.appendChild(svgEl('line', { class: 'gridline', x1: cx, y1: padT, x2: cx, y2: H - padB }));
+        svg.appendChild(tick(cx, H - padB + 11, fmtNumber(v, w.style), 'middle'));
+      });
+      niceTicks(y0, y1, 4).forEach(function (v) {
+        const cy = toY(v);
+        if (cy < padT - 0.5 || cy > H - padB + 0.5) return;
+        svg.appendChild(svgEl('line', { class: 'gridline', x1: padL, y1: cy, x2: W - padR, y2: cy }));
+        svg.appendChild(tick(padL - 4, cy + 3, fmtNumber(v, w.style), 'end'));
+      });
+      // WHICH COLUMNS. Two axes of bare numbers describe a relationship between things the reader
+      // has to remember; the card's subtitle names them, but the axes are where they are read.
+      if (ds.xField) {
+        const xt = svgEl('text', { x: (padL + W - padR) / 2, y: H - 2,
+                                   'text-anchor': 'middle', class: 'gd-axis-title' });
+        xt.textContent = ds.xField;
+        svg.appendChild(xt);
+      }
+      if (ds.yField) {
+        const yt = svgEl('text', { x: 9, y: (padT + H - padB) / 2, 'text-anchor': 'middle',
+                                   class: 'gd-axis-title',
+                                   transform: 'rotate(-90 9 ' + ((padT + H - padB) / 2) + ')' });
+        yt.textContent = ds.yField;
+        svg.appendChild(yt);
+      }
       c.body.appendChild(svg);
       // Say when the plot is a SAMPLE. A scatter silently drawn from 1500 of 3.4M features looks
       // exactly like a scatter of everything, and the reader would have no way to tell.

--- a/templates/shared/dashboard.js
+++ b/templates/shared/dashboard.js
@@ -837,6 +837,11 @@ window.GD_DASHBOARD = (function () {
     c.sub.textContent = custom ? truncate(custom, 40) : fallback;
   }
 
+  function pointRadius(w) {
+    const r = Number(w.style && w.style.pointSize);
+    return r > 0 ? Math.max(1.5, Math.min(8, r)) : 3.5;
+  }
+
   function opLabel(ds, source) {
     const name = source ? source.name : ('layer ' + ds.layerId);
     // The EFFECTIVE aggregation. With columns as the axis the runtime substitutes `sum` for
@@ -2001,11 +2006,19 @@ window.GD_DASHBOARD = (function () {
       // it could not tell you about. A native `<title>` rather than a custom tooltip: it is what the
       // bars and lines already use, it survives touch and keyboard focus, and it costs one element.
       const names = data.labels || [];
+      // HOW BIG A DOT IS. 2 px was too small to read as a mark: on a card a few hundred pixels
+      // wide, a scatter of a dozen features looked like dust on the screen rather than data, and
+      // hovering one to read its name meant hunting for it. 3.5 is a dot you can see and aim at
+      // while still being small enough that a few thousand of them overlap into a shape.
+      //
+      // Settable because the right size depends on how many points there are, which the renderer
+      // cannot know at author time: 12 features want a mark, 5 000 want a grain.
+      const r = pointRadius(w);
       pts.forEach(function (p, i) {
         const dot = svgEl('circle', {
           cx: padL + ((p[0] - x0) / sx) * (W - padL - padR),
           cy: H - padB - ((p[1] - y0) / sy) * (H - padT - padB),
-          r: 2, fill: colour, opacity: 0.45,
+          r: r, fill: colour, opacity: 0.45,
         });
         const label = names[i];
         const coords = fmtNumber(p[0], w.style) + ', ' + fmtNumber(p[1], w.style);

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -742,15 +742,24 @@
        already `var(--text)` but the background was a hardcoded white, so in dark mode it was pale
        text on a white slab — the one combination neither theme ever intends. A readout that takes
        one colour from the theme and one from nowhere is unreadable in exactly half of them. */
-    /* ABOVE the attribution, not on top of it. Both sat at bottom-right; while the readout had a
-       translucent white background the collision merely looked untidy, and giving it a solid one
-       and a border — so it would be legible in dark mode — turned it into one box covering
-       another. The scale bar owns bottom-left, so up is the direction with room in it. */
+    /* BOTTOM CENTRE, which is the one part of the map edge nothing else claims: the scale bar owns
+       bottom-left and the attribution bottom-right, and those two are what the readout used to
+       collide with — it sat at bottom-right on top of the credit, and was moved up out of the way
+       rather than sideways out of it. Centred, it can sit on the same line as both. It also puts
+       the numbers under the pointer's usual path rather than off in a corner. */
     #coords {
-      position: absolute; right: 8px; bottom: 26px; z-index: 20; pointer-events: none;
+      position: absolute; left: 50%; transform: translateX(-50%); bottom: 8px;
+      z-index: 20; pointer-events: none; white-space: nowrap;
       font-size: 11px; font-variant-numeric: tabular-nums; color: var(--text);
       background: var(--bg); padding: 2px 7px; border-radius: 4px;
       border: 1px solid var(--border); box-shadow: var(--shadow); min-height: 18px;
+    }
+    /* On a narrow map the three no longer fit on one line — the scale bar reaches the middle — so
+       the readout goes back to riding above them. `mousemove` is a pointer affordance and a phone
+       rarely raises it at all, but a tap does synthesise one, and a chip landing on the scale bar
+       is exactly the collision this move was meant to end. */
+    @media (max-width: 640px) {
+      #coords { bottom: 26px; }
     }
     /* The CRS, muted and a size down: it does not change while you move the mouse, so it should not
        compete with the numbers that do. */

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -742,8 +742,12 @@
        already `var(--text)` but the background was a hardcoded white, so in dark mode it was pale
        text on a white slab — the one combination neither theme ever intends. A readout that takes
        one colour from the theme and one from nowhere is unreadable in exactly half of them. */
+    /* ABOVE the attribution, not on top of it. Both sat at bottom-right; while the readout had a
+       translucent white background the collision merely looked untidy, and giving it a solid one
+       and a border — so it would be legible in dark mode — turned it into one box covering
+       another. The scale bar owns bottom-left, so up is the direction with room in it. */
     #coords {
-      position: absolute; right: 8px; bottom: 4px; z-index: 20; pointer-events: none;
+      position: absolute; right: 8px; bottom: 26px; z-index: 20; pointer-events: none;
       font-size: 11px; font-variant-numeric: tabular-nums; color: var(--text);
       background: var(--bg); padding: 2px 7px; border-radius: 4px;
       border: 1px solid var(--border); box-shadow: var(--shadow); min-height: 18px;
@@ -751,6 +755,11 @@
     /* The CRS, muted and a size down: it does not change while you move the mouse, so it should not
        compete with the numbers that do. */
     #coords .gd-crs { color: var(--text-muted); font-size: 10px; margin-left: 5px; }
+    /* NOTHING when there is nothing to say. The readout is empty until the pointer is over the map
+       and empty again the moment it leaves, and `min-height` plus a solid background and a border —
+       both added so it would be legible in dark mode — turned that empty state into a visible blank
+       chip sitting in the corner. A readout with no reading should not be on screen. */
+    #coords:empty { display: none; }
 
     /* ── Mobile ──────────────────────────────────────────── */
     /* ── Phone: the map is the page ────────────────────────────────────────────────────────

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -539,7 +539,22 @@
     #map { position: absolute; inset: 0; }
 
     /* ── MapLibre overrides ──────────────────────────────── */
-    .maplibregl-ctrl-bottom-left { bottom: 24px; }
+    /* ONE LINE for everything pinned to the bottom of the map: the scale bar at the left, the
+       coordinate readout in the middle, the attribution at the right.
+
+       They were at two different heights on every archetype. `.maplibregl-ctrl-bottom-left` carried
+       `bottom: 24px` from the first shared-runtime refactor — no comment, and nothing at the bottom
+       left to clear — while `.maplibregl-ctrl-bottom-right` kept MapLibre's own 0, so the scale bar
+       floated a finger's width above the credit.
+
+       A token rather than three matching numbers, because the number MOVES: the storymap lifts this
+       chrome over its narrative strip and the phone tightens the gutter, and both used to nudge one
+       corner at a time. Anything that shifts the line now shifts all three together and they cannot
+       drift apart again. The readout adds MapLibre's own 10px control margin to land on the same
+       line, since it is ours and has no such margin of its own. */
+    :root { --map-chrome-b: 0px; }
+    .maplibregl-ctrl-bottom-left,
+    .maplibregl-ctrl-bottom-right { bottom: var(--map-chrome-b); }
     .maplibregl-ctrl-attrib { font-size: 10px; }
     .maplibregl-ctrl-top-right { top: 10px; right: 10px; }
 
@@ -748,18 +763,12 @@
        rather than sideways out of it. Centred, it can sit on the same line as both. It also puts
        the numbers under the pointer's usual path rather than off in a corner. */
     #coords {
-      position: absolute; left: 50%; transform: translateX(-50%); bottom: 8px;
+      position: absolute; left: 50%; transform: translateX(-50%);
+      bottom: calc(var(--map-chrome-b) + 10px);
       z-index: 20; pointer-events: none; white-space: nowrap;
       font-size: 11px; font-variant-numeric: tabular-nums; color: var(--text);
       background: var(--bg); padding: 2px 7px; border-radius: 4px;
       border: 1px solid var(--border); box-shadow: var(--shadow); min-height: 18px;
-    }
-    /* On a narrow map the three no longer fit on one line — the scale bar reaches the middle — so
-       the readout goes back to riding above them. `mousemove` is a pointer affordance and a phone
-       rarely raises it at all, but a tap does synthesise one, and a chip landing on the scale bar
-       is exactly the collision this move was meant to end. */
-    @media (max-width: 640px) {
-      #coords { bottom: 26px; }
     }
     /* The CRS, muted and a size down: it does not change while you move the mouse, so it should not
        compete with the numbers that do. */
@@ -802,8 +811,10 @@
       .maplibregl-ctrl-top-right, .maplibregl-ctrl-top-left { top: 6px; }
       .maplibregl-ctrl-top-right { right: 6px; }
       .maplibregl-ctrl-top-left { left: 6px; }
-      .maplibregl-ctrl-bottom-right { right: 6px; bottom: 6px; }
-      .maplibregl-ctrl-bottom-left { left: 6px; bottom: 6px; }
+      /* The gutter tightens for all three at once — see --map-chrome-b. */
+      :root { --map-chrome-b: 6px; }
+      .maplibregl-ctrl-bottom-right { right: 6px; }
+      .maplibregl-ctrl-bottom-left { left: 6px; }
       .gd-basemap-menu, .gd-tools-menu, .gd-sym-pop {
         max-width: calc(100vw - 24px); max-height: 60vh; overflow-y: auto;
       }
@@ -1431,9 +1442,9 @@
       body[data-archetype="storymap"] .gd-story-more { left: auto; right: auto; }
       body[data-archetype="storymap"] .gd-story-up { top: auto; bottom: calc(44vh / 2 - 21px); left: 8px; }
       body[data-archetype="storymap"] .gd-story-down { bottom: calc(44vh / 2 - 21px); right: 8px; }
-      /* Keep the map's own controls above the strip rather than behind it. */
-      body[data-archetype="storymap"] .maplibregl-ctrl-bottom-right,
-      body[data-archetype="storymap"] .maplibregl-ctrl-bottom-left { bottom: calc(44vh + 6px); }
+      /* Keep the map's own bottom chrome above the strip rather than behind it — the readout
+         rides up with the scale bar and the credit, because they share the line. */
+      body[data-archetype="storymap"] { --map-chrome-b: calc(44vh + 6px); }
     }
 
     /* LANDSCAPE on a phone (~360px tall): the control cluster is a single vertical stack and simply

--- a/templates/shared/portal.css
+++ b/templates/shared/portal.css
@@ -721,16 +721,36 @@
     html[data-theme="dark"] .maplibregl-ctrl button .maplibregl-ctrl-icon {
       filter: invert(1) hue-rotate(180deg) brightness(1.05);
     }
-    html[data-theme="dark"] .maplibregl-ctrl-attrib { background: rgba(0,0,0,.4); }
+    /* Attribution in dark mode. The background alone was being set, and the TEXT was left to
+       MapLibre's own near-black — dark on dark — while the compact pill and its toggle button kept
+       their white. Every part of the control is named here, because a control is only as legible as
+       the piece that was forgotten. */
+    html[data-theme="dark"] .maplibregl-ctrl-attrib,
+    html[data-theme="dark"] .maplibregl-ctrl-attrib.maplibregl-compact {
+      background: var(--bg); color: var(--text-muted);
+    }
     html[data-theme="dark"] .maplibregl-ctrl-attrib a { color: var(--text-muted); }
+    html[data-theme="dark"] .maplibregl-ctrl-attrib-button {
+      background-color: var(--bg);
+      /* The chevron is a background IMAGE, so it cannot inherit a colour — inverting it is the only
+         way to turn a black glyph light without shipping a second asset. */
+      filter: invert(1) opacity(.75);
+    }
 
     /* ── Coordinate readout ──────────────────────────────── */
+    /* The coordinate readout. Both colours come from TOKENS, which is the whole fix: the text was
+       already `var(--text)` but the background was a hardcoded white, so in dark mode it was pale
+       text on a white slab — the one combination neither theme ever intends. A readout that takes
+       one colour from the theme and one from nowhere is unreadable in exactly half of them. */
     #coords {
       position: absolute; right: 8px; bottom: 4px; z-index: 20; pointer-events: none;
       font-size: 11px; font-variant-numeric: tabular-nums; color: var(--text);
-      background: rgba(255,255,255,.85); padding: 2px 7px; border-radius: 4px;
-      box-shadow: var(--shadow); min-height: 18px;
+      background: var(--bg); padding: 2px 7px; border-radius: 4px;
+      border: 1px solid var(--border); box-shadow: var(--shadow); min-height: 18px;
     }
+    /* The CRS, muted and a size down: it does not change while you move the mouse, so it should not
+       compete with the numbers that do. */
+    #coords .gd-crs { color: var(--text-muted); font-size: 10px; margin-left: 5px; }
 
     /* ── Mobile ──────────────────────────────────────────── */
     /* ── Phone: the map is the page ────────────────────────────────────────────────────────

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -321,6 +321,15 @@
       ready: ready,
       hide: hide,
       waiting: function () { return Object.keys(gates); },
+      //: Re-label the cover. A dashboard waits for its widgets' first answers as well as the map,
+      //: which on a heavy one is a visibly longer wait than any other archetype asks for — and a
+      //: cover that sits there saying the same thing throughout reads as a page that has hung.
+      //: Saying which part is outstanding costs nothing and is the difference between "slow" and
+      //: "broken".
+      note: function (text) {
+        const sub = document.getElementById('gd-loading-sub');
+        if (sub && !released) sub.textContent = text;
+      },
     };
   })();
   // The access gate is its OWN full-window surface and sits above this one; a visitor who has to
@@ -333,7 +342,14 @@
   loading.need('render');    // MapLibre has finished drawing the opening view
   if (LAYOUT.archetype === 'catalog') loading.need('catalog');
   if (LAYOUT.archetype === 'storymap') loading.need('story');
-  if (LAYOUT.archetype === 'dashboard') loading.need('dashboard');
+  if (LAYOUT.archetype === 'dashboard') {
+    loading.need('dashboard');   // the widgets are MOUNTED
+    // …and a second gate for their first ANSWERS. Mounting a dashboard only puts empty cards on the
+    // screen: the numbers, bars and rows arrive one request later, so clearing the cover at mount
+    // revealed the very assembling-in-front-of-the-visitor this whole mechanism exists to prevent —
+    // worse here than anywhere else, because a dashboard is mostly widgets and the map is one cell.
+    loading.need('widgets');
+  }
   // Backstop. NOT the mechanism — the gates above are — but a portal must never be held hostage by
   // one piece that fails in a way that skips its own clear (a hard error inside MapLibre, a style
   // that never finishes). Generous enough that a slow connection reaches readiness first.
@@ -1360,6 +1376,11 @@
             // `deckState`, which lives here. The dashboard needs the live answer because it tells
             // the visitor which layers a filter is NOT narrowing, and naming a layer that is not
             // even on screen would be worse than saying nothing.
+            // Cleared when the widgets' first questions have all been answered. The dashboard
+            // runtime guarantees this fires — on its early returns, on a throw, and behind its own
+            // cap — so the gate cannot outlive the thing it is waiting for.
+            onDataReady: function () { loading.ready('widgets'); },
+            note: function (text) { loading.note(text); },
             deckVisible: function (layerId) {
               const st = deckState[layerId];
               return st ? !!st.visible : null;      // null = not a deck layer
@@ -1439,8 +1460,16 @@
           });
         } else {
           console.warn('[geodeploy] dashboard runtime missing');
+          // Nothing will ever answer for the widgets, so nothing must be waiting on them. Also
+          // covers a runtime older than `onDataReady`, which would ignore the callback entirely.
+          loading.ready('widgets');
         }
-      } catch (e) { console.warn('[geodeploy] dashboard failed', e); }
+      } catch (e) {
+        console.warn('[geodeploy] dashboard failed', e);
+        // A throw BEFORE the runtime armed its own signal would strand the data gate; releasing it
+        // here is harmless if the runtime already owns it, because a gate only clears once.
+        loading.ready('widgets');
+      }
       loading.ready('dashboard');   // outside the catch, for the same reason as the story panel
     }
     // R2: when rendered as the editor's preview (?edit=1), open the postMessage channel + click-to-place.

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -3503,7 +3503,7 @@
     deckHit = false;
   });
 
-  // ── Coordinate readout (bottom-right) ───────────────────
+  // ── Coordinate readout (bottom-centre) ──────────────────
   const coordsEl = document.getElementById('coords');
   if (coordsEl) {
     // WITH the CRS. Two numbers alone are ambiguous — 47.37, 8.54 is a lat/lon pair, a metre

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -4052,6 +4052,160 @@
       return out;
     }
 
+    //: THE WHOLE DASHBOARD, not the map inside it.
+    //:
+    //: A card thumbnail is a photograph of the portal, and for three archetypes the portal IS the
+    //: map. A dashboard is not: the map is one cell of a grid, and a picture of it alone shows none
+    //: of the charts, tables and figures that are the reason the dashboard exists — two dashboards
+    //: over the same layer got the same picture.
+    //:
+    //: There is no browser API for "photograph this element". The one mechanism that exists is a
+    //: `<foreignObject>` holding the markup, rasterised by loading the SVG as an image, and it comes
+    //: with real constraints: the SVG is loaded in the restricted mode images use, so it fetches
+    //: NOTHING — no stylesheet, no webfont, no tile. Everything the picture needs must be inside the
+    //: string. Hence the three passes below: the CSS is collected from the live stylesheets, the
+    //: WebGL canvas is swapped for a still of itself, and same-origin images are inlined.
+    //:
+    //: The rewrite pass is the subtle one. Most dashboard rules are written `body[data-archetype=
+    //: "dashboard"] #layout`, and the clone has no <body> ancestor, so every one of them would miss
+    //: and the grid would render as a column of unstyled divs. The wrapper therefore STANDS IN for
+    //: both <html> and <body> — it carries their classes and data attributes — and each selector's
+    //: leading `html` / `body` / `:root` is rewritten to match it.
+    //:
+    //: Every failure falls back to the map alone, which is what this did before. A thumbnail is
+    //: decoration; it must never be the reason a publish reports an error.
+    function snapshotDashboard(done) {
+      let settled = false;
+      const finish = function (url) { if (!settled) { settled = true; done(url); } };
+      try {
+        const W = document.documentElement.clientWidth || 1200;
+        const H = document.documentElement.clientHeight || 800;
+        const html = document.documentElement, body = document.body;
+
+        // No explicit xmlns: the wrapper is already in the XHTML namespace (it was made by an HTML
+        // document), and XMLSerializer declares that itself. Writing the attribute by hand only
+        // risks a second, conflicting declaration.
+        const wrap = document.createElement('div');
+        [html, body].forEach(function (el) {
+          Array.prototype.forEach.call(el.attributes, function (a) {
+            if (a.name === 'class' || a.name === 'style') return;   // merged / ours, below
+            if (a.name === 'xmlns') return;
+            wrap.setAttribute(a.name, a.value);
+          });
+        });
+        wrap.setAttribute('class', ('gd-snap-root ' + html.className + ' ' + body.className).trim());
+        wrap.setAttribute('style', 'position:relative;overflow:hidden;width:' + W + 'px;height:' + H
+          + 'px;background:' + (getComputedStyle(body).backgroundColor || '#fff'));
+
+        // A plain text node, NOT a CDATA section: createCDATASection throws outright in an HTML
+        // document. It round-trips anyway — XMLSerializer escapes `&` and `<` on the way out and
+        // the XML parser turns them back on the way in, so the CSS arrives byte-identical.
+        const style = document.createElement('style');
+        style.textContent = collectCss();
+        wrap.appendChild(style);
+        Array.prototype.forEach.call(body.children, function (child) {
+          wrap.appendChild(child.cloneNode(true));
+        });
+
+        // The canvases, in document order — the clone was made from the same tree, so the two
+        // lists line up. The map's own goes through snapshotCanvas so a globe keeps its backdrop.
+        const live = body.querySelectorAll('canvas');
+        const copies = wrap.querySelectorAll('canvas');
+        for (let i = 0; i < copies.length; i++) {
+          const src = live[i];
+          if (!src) break;
+          let url = null;
+          try {
+            // WebP, not PNG: this string is inlined into the SVG and then percent-encoded, so a
+            // lossless 1200x800 frame would put several megabytes into a data URL for a picture
+            // that ends up a card thumbnail.
+            url = (src === map.getCanvas() ? snapshotCanvas() : src).toDataURL('image/webp', 0.8);
+          } catch (e) { url = null; }        // tainted by a tile server that sent no CORS header
+          const img = document.createElement('img');
+          if (url) img.setAttribute('src', url);
+          img.setAttribute('class', copies[i].className || '');
+          img.setAttribute('style', (copies[i].getAttribute('style') || '')
+            + ';width:' + src.clientWidth + 'px;height:' + src.clientHeight + 'px');
+          copies[i].parentNode.replaceChild(img, copies[i]);
+        }
+
+        // Same-origin <img> (a portal logo, a card image): the restricted SVG cannot fetch them, so
+        // they travel as data or not at all. Best effort — a missing logo is not worth a failed
+        // thumbnail.
+        Array.prototype.forEach.call(wrap.querySelectorAll('img'), function (img) {
+          const src = img.getAttribute('src');
+          if (!src || src.indexOf('data:') === 0) return;
+          try {
+            const c = document.createElement('canvas');
+            c.width = img.naturalWidth || img.width || 1;
+            c.height = img.naturalHeight || img.height || 1;
+            c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+            img.setAttribute('src', c.toDataURL('image/png'));
+          } catch (e) { img.removeAttribute('src'); }
+        });
+
+        const markup = new XMLSerializer().serializeToString(wrap);
+        const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + W + '" height="' + H
+          + '" viewBox="0 0 ' + W + ' ' + H + '"><foreignObject x="0" y="0" width="' + W
+          + '" height="' + H + '">' + markup + '</foreignObject></svg>';
+
+        const shot = new Image();
+        shot.onload = function () {
+          try {
+            const out = document.createElement('canvas');
+            out.width = W; out.height = H;
+            const ctx = out.getContext('2d');
+            ctx.fillStyle = getComputedStyle(body).backgroundColor || '#fff';
+            ctx.fillRect(0, 0, W, H);
+            ctx.drawImage(shot, 0, 0);
+            finish(out.toDataURL('image/webp', 0.75));
+          } catch (e) { finish(null); }
+        };
+        shot.onerror = function () { finish(null); };
+        shot.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+        // Rasterising a foreignObject is one of the places a browser can simply never call back.
+        setTimeout(function () { finish(null); }, 4000);
+      } catch (err) {
+        console.warn('[geodeploy] dashboard snapshot failed', err);
+        finish(null);
+      }
+    }
+
+    //: Every rule on the page, with `html` / `body` / `:root` re-pointed at the wrapper.
+    //:
+    //: Cross-origin sheets (a webfont's) throw on `cssRules` and are skipped — nothing in them can
+    //: be honoured by an SVG that cannot fetch the font anyway.
+    function collectCss() {
+      const out = [];
+      const scope = function (sel) {
+        return sel.split(',').map(function (part) {
+          return part.trim().replace(/^(?::root|html|body)\b/, '.gd-snap-root');
+        }).join(', ');
+      };
+      const walk = function (rules) {
+        Array.prototype.forEach.call(rules, function (r) {
+          if (r.selectorText) out.push(scope(r.selectorText) + '{' + r.style.cssText + '}');
+          else if (r.cssRules && r.conditionText != null) {
+            // @media / @supports: keep the condition, rewrite what is inside it.
+            const save = out.length, inner = [];
+            walk(r.cssRules);
+            while (out.length > save) inner.unshift(out.pop());
+            out.push('@' + (r.type === 12 ? 'supports' : 'media') + ' ' + r.conditionText
+                     + '{' + inner.join('') + '}');
+          } else if (r.cssText) out.push(r.cssText);   // @font-face, @keyframes
+        });
+      };
+      Array.prototype.forEach.call(document.styleSheets, function (sheet) {
+        let rules = null;
+        try { rules = sheet.cssRules; } catch (e) { return; }
+        if (rules) walk(rules);
+      });
+      // #layout is `position: fixed`, whose containing block inside a foreignObject is not something
+      // to rely on. Pinned to the wrapper instead, which is exactly the viewport's size.
+      out.push('.gd-snap-root #layout{position:absolute;}');
+      return out.join('\n');
+    }
+
     function sendSnapshot(requestId) {
       // The reason travels WITH the reply. Discarding it made every failure look identical from the
       // dashboard — a tainted canvas (SecurityError, from a tile server that sent no CORS header),
@@ -4064,6 +4218,19 @@
       const grab = function () {
         if (done) return;
         done = true;
+        // On a dashboard the map is one widget of several, so photograph the page. Falls through to
+        // the map alone if that cannot be done — see snapshotDashboard.
+        if (document.body.dataset.archetype === 'dashboard') {
+          try { map.triggerRepaint(); } catch (e) {}
+          snapshotDashboard(function (url) {
+            if (url && url.length > 2048) return reply(url, null);
+            grabMap();
+          });
+          return;
+        }
+        grabMap();
+      };
+      const grabMap = function () {
         try {
           map.triggerRepaint();
           const url = snapshotCanvas().toDataURL('image/webp', 0.75);

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -345,6 +345,25 @@
   // not on the first toggle.
   placeListByMap();
 
+  // A close button INSIDE the panel. CSS shows it only on a dashboard phone, where the panel covers
+  // the map and therefore covers the on-map toggle that would otherwise dismiss it. Built here
+  // rather than in layout.html because it belongs to this behaviour, and a button in the markup
+  // that is hidden in every archetype but one is a thing to wonder about later.
+  (function () {
+    if (!sidebar || sidebar.querySelector('.gd-list-close')) return;
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'gd-list-close';
+    b.setAttribute('aria-label', 'Close the layer list');
+    b.title = 'Close';
+    b.innerHTML = '&times;';
+    b.addEventListener('click', function (e) {
+      e.stopPropagation();          // the phone's tap-outside handler runs on capture
+      sidebar.classList.add('collapsed');
+    });
+    sidebar.appendChild(b);
+  })();
+
   document.addEventListener('click', function (e) {
     if (!window.matchMedia || !window.matchMedia('(max-width: 640px)').matches) return;
     if (sidebar.classList.contains('collapsed')) return;
@@ -3477,8 +3496,16 @@
   // ── Coordinate readout (bottom-right) ───────────────────
   const coordsEl = document.getElementById('coords');
   if (coordsEl) {
+    // WITH the CRS. Two numbers alone are ambiguous — 47.37, 8.54 is a lat/lon pair, a metre
+    // easting/northing and a dozen other things depending on what you assume, and the reader has no
+    // way to tell which from the readout. MapLibre works in WGS84 lon/lat and the map always
+    // reports that, so naming it costs one span and removes the guess.
     map.on('mousemove', e => {
       coordsEl.textContent = e.lngLat.lng.toFixed(5) + ', ' + e.lngLat.lat.toFixed(5);
+      const crs = document.createElement('span');
+      crs.className = 'gd-crs';
+      crs.textContent = 'EPSG:4326';
+      coordsEl.appendChild(crs);
     });
     map.on('mouseout', () => { coordsEl.textContent = ''; });
   }

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -3221,6 +3221,16 @@
 
   map.on('click', async e => {
     if (suppressClick) { suppressClick = false; return; }  // ignore the click that ends a box draw
+    // A tap that is PLACING A VERTEX is not a tap that is asking what is here. A dashboard's polygon
+    // tool builds its shape click by click, and every one of those clicks was also opening the
+    // attribute panel over the map being drawn on — worst on a phone, where the panel covers most
+    // of it and has to be dismissed between vertices.
+    //
+    // `dashDraw` is set by the dashboard's tool bar (`setMode`) and was, until now, written and
+    // never read: the flag existed, and nothing acted on it. Read from the body rather than passed
+    // in, because the tool bar lives in dashboard.js and this handler in portal.js, and one shared
+    // attribute is a smaller seam between them than a callback registry.
+    if (document.body.dataset.dashDraw === '1') return;
     const vectorLayerIds = (STYLE.layers || [])
       .filter(l => l.metadata && l.metadata['geodeploy:type'] === 'vector')
       .map(l => l.id);

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -3489,10 +3489,10 @@
   // The minimal fallback only covers portals published before basemaps were baked in.
   const BASEMAP_CATALOG = (((STYLE.geodeploy || {}).basemaps) || []).length
     ? STYLE.geodeploy.basemaps
-    : [{ id: 'positron', name: 'Positron',
-         tiles: ['https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'],
-         attribution: '© OpenStreetMap © CARTO',
-         thumb: 'https://a.basemaps.cartocdn.com/light_all/4/8/5.png' }];
+    : [{ id: 'osm', name: 'OpenStreetMap',
+         tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+         attribution: '© OpenStreetMap contributors',
+         thumb: 'https://a.tile.openstreetmap.org/4/8/5.png' }];
   const BASEMAPS = BASEMAP_CATALOG;
   // The admin's chosen basemap, baked into the base layer at publish. Portals published BEFORE
   // basemap selection have no defaultBasemap → keep the template's own baked basemap (the '__default__'

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -263,8 +263,65 @@
   // someone is using it (a phone rotating, or a desktop window being dragged narrow).
   const isPhone = window.matchMedia && window.matchMedia('(max-width: 640px)').matches;
   if (LAYOUT.regions.layerList.collapsed || isPhone) sidebar.classList.add('collapsed');
+  //: On a DASHBOARD, the opened list is positioned against the MAP rather than against the page.
+  //:
+  //: Everywhere else the two are the same place — the map is the page. On a dashboard the map is one
+  //: cell in a grid, and the stylesheet's `top: header + 12px; left: 12px` is the corner of the
+  //: DASHBOARD, which can be a long way from the button that was pressed: the toggle is a MapLibre
+  //: control living in the map's own cluster. Pressing a button on the map and having a panel appear
+  //: somewhere else entirely is the complaint, and on a phone it was worse — the map scrolls, so the
+  //: panel could open off-screen.
+  //:
+  //: Fixed coordinates from the map's viewport rect, clamped so the panel is always reachable even
+  //: when the map itself is scrolled out of view. CSS cannot do this: where the map sits depends on
+  //: the widget grid, which is authored, re-flowed per breakpoint and written as inline style.
+  const placeListByMap = (function () {
+    if (LAYOUT.archetype !== 'dashboard') return function () {};
+    const PAD = 8, INSET = 12, CTRL_CLEAR = 52;
+    let raf = 0;
+    function apply() {
+      raf = 0;
+      // The phone has its own treatment — a full-width sheet over everything, in the stylesheet.
+      // Inline styles would outrank it, so they are cleared rather than left behind by a desktop
+      // session that was resized narrow.
+      if (window.matchMedia && window.matchMedia('(max-width: 640px)').matches) {
+        ['position', 'left', 'top', 'right', 'bottom', 'maxHeight']
+          .forEach(function (k) { sidebar.style[k] = ''; });
+        return;
+      }
+      if (sidebar.classList.contains('collapsed')) return;   // nothing to place
+      const wrap = document.getElementById('map-wrap');
+      if (!wrap) return;
+      const m = wrap.getBoundingClientRect();
+      if (!m.width || !m.height) return;                     // parked, or not laid out yet
+      const w = sidebar.offsetWidth || 300, h = sidebar.offsetHeight || 300;
+      const side = (LAYOUT.regions.layerList && LAYOUT.regions.layerList.side) || 'left';
+      const ctrl = (LAYOUT.regions.controls && LAYOUT.regions.controls.position) || 'top-right';
+      // Clear the control column only when the controls are on the same side the list opens from;
+      // otherwise the extra 40px is a gap for no reason.
+      const inset = ctrl.indexOf(side) >= 0 ? CTRL_CLEAR : INSET;
+      const left = side === 'right' ? m.right - w - inset : m.left + inset;
+      const top = m.top + INSET;
+      sidebar.style.position = 'fixed';
+      sidebar.style.right = 'auto';
+      sidebar.style.bottom = 'auto';
+      sidebar.style.left = Math.min(Math.max(left, PAD), window.innerWidth - w - PAD) + 'px';
+      const t = Math.min(Math.max(top, PAD), Math.max(PAD, window.innerHeight - h - PAD));
+      sidebar.style.top = t + 'px';
+      // A tall legend on a short map must not run off the bottom of the window.
+      sidebar.style.maxHeight = Math.max(160, window.innerHeight - t - PAD) + 'px';
+    }
+    function schedule() { if (!raf) raf = requestAnimationFrame(apply); }
+    window.addEventListener('resize', schedule);
+    // The grid scrolls inside #layout, so the map moves under a fixed panel; follow it, clamped.
+    const layoutEl = document.getElementById('layout');
+    if (layoutEl) layoutEl.addEventListener('scroll', schedule, { passive: true });
+    return schedule;
+  })();
+
   document.getElementById('sidebar-toggle').addEventListener('click', () => {
     sidebar.classList.toggle('collapsed');
+    placeListByMap();
     setTimeout(() => map.resize(), 220);
   });
   // On a phone the list is an overlay drawer covering the map, so tapping the map is the natural way
@@ -272,6 +329,10 @@
   // hides the control cluster including its own toggle button. Capture phase, because the map's own
   // handlers stop propagation. Desktop is untouched: there the list sits beside the map, and closing
   // it on any stray click would be hostile.
+  // A dashboard whose author left the list EXPANDED needs it placed before the visitor sees it,
+  // not on the first toggle.
+  placeListByMap();
+
   document.addEventListener('click', function (e) {
     if (!window.matchMedia || !window.matchMedia('(max-width: 640px)').matches) return;
     if (sidebar.classList.contains('collapsed')) return;

--- a/templates/shared/portal.js
+++ b/templates/shared/portal.js
@@ -316,6 +316,18 @@
     // The grid scrolls inside #layout, so the map moves under a fixed panel; follow it, clamped.
     const layoutEl = document.getElementById('layout');
     if (layoutEl) layoutEl.addEventListener('scroll', schedule, { passive: true });
+    // WATCH THE PANEL, do not wire the buttons.
+    //
+    // There are two controls that open this: the header button, and `#gd-list-toggle`, a MapLibre
+    // control created much later and in another scope. Wiring the one that was to hand left the
+    // other — the one actually pressed on a desktop, since it sits on the map — toggling the class
+    // without ever repositioning, so the panel kept its stylesheet corner and opened above the map.
+    // Observing the class covers both, and covers whatever opens it next.
+    if (typeof MutationObserver === 'function') {
+      new MutationObserver(schedule).observe(sidebar, {
+        attributes: true, attributeFilter: ['class'],
+      });
+    }
     return schedule;
   })();
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -37,6 +37,9 @@ Vue 3 single-page dashboard — the browser-only control panel for setup, data u
 - `vite.config.js` dev proxy must stay aligned with `nginx/nginx.conf` (prefix stripping + titiler port 80).
 
 ## Last updated
-2026-08-18 (link previews: `og:`/`twitter:` tags in `index.html`, `public/og-image.png`, and the `__GEODEPLOY_ORIGIN__` → `$public_scheme://$host` `sub_filter` in `nginx.conf`. Because that rule ships **inside this image**, `docker compose build geodeploy-ui` + recreate is enough for the dashboard's card — the outer nginx does not have to be touched.)
+2026-08-31 (`index.html`: the shell's `<title>` names the product, not just the brand. Nothing in
+the app sets `document.title`, so that static string is the whole title of the only page of ours
+search engines had indexed — the demo instance. Meta and og descriptions widened to match.)
+
 2026-08-13 (ramp reverse toggle + swatch strip in `components/portal/LayerPanel.vue`; class-count
 ceiling raised 9 → 12 to match the server; the symbology-twin rounding fix above)

--- a/ui/README.md
+++ b/ui/README.md
@@ -36,7 +36,24 @@ Vue 3 single-page dashboard — the browser-only control panel for setup, data u
   as the contract. **When you touch either file, run the parity check, not just the tests.**
 - `vite.config.js` dev proxy must stay aligned with `nginx/nginx.conf` (prefix stripping + titiler port 80).
 
+## Version
+
+`package.json` tracks the PRODUCT version, alongside `api/geodeploy/main.py`'s `version=`. Bump both
+together when cutting a release. It had been left at 1.4.1 through v1.5.
+
+Two other versions are deliberately NOT in step and must not be swept up by a product release:
+
+- `cli/geodeploy/__init__.py` — the PyPI package's own version. It is what `pip show geodeploy` and
+  the client's user agent report, so raising it without publishing that version to PyPI makes the
+  number disagree with what is actually installed. It moves when the CLI is released, on its own
+  `cli-v*` tag.
+- `integrations/qgis-plugin/geodeploy_qgis/metadata.txt` — the plugin's version in the QGIS plugin
+  repository, on its own cadence.
+
 ## Last updated
+2026-08-31 (`package.json` brought in line with the product at 1.5.1, and a note above on which
+versions track it and which are deliberately independent.)
+
 2026-08-31 (`index.html`: the shell's `<title>` names the product, not just the brand. Nothing in
 the app sets `document.title`, so that static string is the whole title of the only page of ours
 search engines had indexed — the demo instance. Meta and og descriptions widened to match.)

--- a/ui/index.html
+++ b/ui/index.html
@@ -9,8 +9,12 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/logo.png" />
-  <meta name="description" content="Self-hosted spatial data platform and geoportal builder." />
-  <title>GeoDeploy</title>
+  <meta name="description" content="Self-hosted geoportal builder and spatial data platform. Upload, style and publish web maps, dashboards, story maps and data catalogs from your own server." />
+  <!-- The product, not just the name. This shell is the only HTML a crawler ever sees — nothing here
+       sets document.title, and a Vue route could not help a crawler anyway — so a bare "GeoDeploy"
+       was the entire title of the one page of ours that search engines had indexed. Kept short
+       enough to still read as a browser tab on an operator's own instance. -->
+  <title>GeoDeploy — self-hosted geoportal builder</title>
 
   <!-- Link previews (LinkedIn / Slack / X / Discord / Teams). Crawlers do not run JavaScript, so
        everything a card shows has to be in this static shell — a Vue route cannot supply it.
@@ -19,8 +23,8 @@
        domain at build time. Portals inject their own tags per portal (services/portal_generator.py). -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="GeoDeploy" />
-  <meta property="og:title" content="GeoDeploy" />
-  <meta property="og:description" content="Self-hosted spatial data platform and geoportal builder." />
+  <meta property="og:title" content="GeoDeploy — self-hosted geoportal builder" />
+  <meta property="og:description" content="Upload, style and publish web maps, dashboards, story maps and data catalogs from your own server. PostGIS, MapLibre, OGC API and STAC in one Docker Compose stack." />
   <meta property="og:url" content="__GEODEPLOY_ORIGIN__/" />
   <meta property="og:image" content="__GEODEPLOY_ORIGIN__/og-image.png" />
   <meta property="og:image:type" content="image/png" />

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/src/components/README.md
+++ b/ui/src/components/README.md
@@ -107,6 +107,11 @@ All dialogs (`UploadModal`, `AddSourceModal`, `DiscoverModal`, `portal/CreatePor
   icon logic in `views/PortalEditor.vue` + `templates/shared/portal.js` — change all three together.
 
 ## Last updated
+2026-08-31 (`portal/DashboardBuilder.vue`: the **Plot size** slider is no longer pie-only — it is
+offered by `hasLegendToShare()` for any chart whose key competes with its plot for the card, and
+100% now reads "(auto)" because that is what it means: the plot takes everything the key does not
+need.)
+
 2026-08-31 (`portal/DashboardBuilder.vue`: a **Point size** slider on the scatter inspector,
 1.5-8px, default 3.5 — the right dot depends on how many points land on the card, which is a fact
 about the data and so the author's call.)

--- a/ui/src/components/README.md
+++ b/ui/src/components/README.md
@@ -71,6 +71,13 @@ Reusable presentational/interactive widgets used by the views, grouped by featur
   — three surfaces, change together. Changing a widget's LAYER clears every field on it (a column of
   the old table is almost never a column of the new one, and the query would 400).
 - `portal/PortalCard.vue` — portal tile in the builder grid (edit/publish/view/unpublish/delete).
+- `shared/GithubLink.vue` — a link to the repository, in the sidebar, **on the demo instance only**
+  (same `/auth/demo` test `DemoBanner` uses, and the same posture: anything but a clear `demo: true`
+  renders nothing). Someone trying the demo is deciding whether to run it themselves; an operator
+  who already has the source does not need a permanent link out of their own admin panel. The star
+  count is cached in `localStorage` for a day — GitHub allows 60 unauthenticated calls an hour PER
+  IP, so a demo behind one address would spend that in an afternoon if every page load asked. The
+  count is an ornament: when it does not arrive the link renders without it.
 - `shared/InfoHint.vue` — an ⓘ next to a label that opens its explanation on click. Use it for the
   two-or-three-sentence *why* behind a control; keep STATE inline and visible ("Nothing filters this
   yet", "Add a raster layer first"), because a reader will not click an ⓘ to discover a blocking

--- a/ui/src/components/README.md
+++ b/ui/src/components/README.md
@@ -107,6 +107,10 @@ All dialogs (`UploadModal`, `AddSourceModal`, `DiscoverModal`, `portal/CreatePor
   icon logic in `views/PortalEditor.vue` + `templates/shared/portal.js` — change all three together.
 
 ## Last updated
+2026-08-31 (`portal/DashboardBuilder.vue`: a **Fill the screen** checkbox in the board-wide
+settings, writing `grid.fit`. Its hint is deliberate about the limit — it stretches, it does not
+squeeze, so a screen too short still scrolls.)
+
 2026-08-31 (`portal/DashboardBuilder.vue`: the **Plot size** slider is no longer pie-only — it is
 offered by `hasLegendToShare()` for any chart whose key competes with its plot for the card, and
 100% now reads "(auto)" because that is what it means: the plot takes everything the key does not

--- a/ui/src/components/README.md
+++ b/ui/src/components/README.md
@@ -107,6 +107,10 @@ All dialogs (`UploadModal`, `AddSourceModal`, `DiscoverModal`, `portal/CreatePor
   icon logic in `views/PortalEditor.vue` + `templates/shared/portal.js` — change all three together.
 
 ## Last updated
+2026-08-31 (`portal/DashboardBuilder.vue`: a **Point size** slider on the scatter inspector,
+1.5-8px, default 3.5 — the right dot depends on how many points land on the card, which is a fact
+about the data and so the author's call.)
+
 2026-08-29 (`shared/InfoHint.vue` added; DashboardBuilder's ten explanatory paragraphs moved into
 hints on the controls they describe — the map inspector had become a wall of prose. Its map editor
 also gained the `linkedFilter` checkbox.)

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -195,16 +195,27 @@ function numericFields(w) { return fieldsOf(w).filter(c => isNumeric(c.type)) }
 //: How many columns may form the X axis. Mirrors `MAX_X_COLUMNS` in services/dashboard.py.
 const MAX_X_COLUMNS = 120
 function xColumnsOf(w) { return w?.dataSource?.xColumns || [] }
+//: Bars only. `colorMode` colours bars and `valueLabels` prints numbers on them; a line chart takes
+//: neither — its colours come from the series palette and it has no bar to write on. Both were shown
+//: for every chart kind, so choosing Line left two controls on screen that did nothing, and one of
+//: them was called "Bar colours" while no bars were in sight.
+function isBarChart(w) { return ['bar', 'hbar'].includes(w?.style?.chart || 'bar') }
 //: Every numeric column at once. A wide file is wide by nature -- 57 years of GDP is 57 clicks --
 //: and a picker that only takes them one at a time is not a picker for this data.
-function allXColumns(w) {
-  patchWidget(w.id, { dataSource: { xColumns: numericFields(w).map(f => f.name).slice(0, MAX_X_COLUMNS) } })
-}
+function allXColumns(w) { setXColumns(w, numericFields(w).map(f => f.name)) }
 function noXColumns(w) { patchWidget(w.id, { dataSource: { xColumns: [] } }) }
 function toggleXColumn(w, name) {
   const cur = xColumnsOf(w)
   const next = cur.includes(name) ? cur.filter(c => c !== name) : [...cur, name]
-  patchWidget(w.id, { dataSource: { xColumns: next.slice(0, MAX_X_COLUMNS) } })
+  setXColumns(w, next)
+}
+//: Choosing columns implies reading them, so Count -- which reads none -- becomes Sum, the same
+//: promotion the single Field picker makes. Left on Count the runtime would silently use Sum
+//: anyway, and a panel that says one thing while the chart does another is worse than either.
+function setXColumns(w, cols) {
+  const patch = { xColumns: cols.slice(0, MAX_X_COLUMNS) }
+  if (patch.xColumns.length && (w.dataSource?.op || 'count') === 'count') patch.op = 'sum'
+  patchWidget(w.id, { dataSource: patch })
 }
 //: What the trimmed axis will read, shown while choosing so the author can see whether the columns
 //: they picked produce sensible ticks. Same rule as the runtime's `trimColumnLabels`.
@@ -1198,7 +1209,12 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
               <select :value="selected.dataSource?.op || 'count'"
                 @change="setAggOp(selected, $event.target.value)"
                 class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60">
-                <option v-for="o in AGG_OPS" :key="o.id" :value="o.id">{{ o.name }}</option>
+                <!-- Count is dropped once columns form the axis: COUNT(*) does not read the
+                     column at all, so every point on the axis would be the same number — a flat
+                     line saying how many rows are in the group. -->
+                <option v-for="o in AGG_OPS.filter(o => !(selected.type === 'chart'
+                          && xColumnsOf(selected).length && o.id === 'count'))"
+                  :key="o.id" :value="o.id">{{ o.name }}</option>
               </select>
             </label>
             <!-- ALWAYS shown, not only once the aggregation is something other than Count.
@@ -1286,6 +1302,19 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
             <p v-if="xColumnsOf(selected).length === 1" class="text-[10px] text-amber-500/90 mt-1 leading-snug">
               One column is a single point — pick at least two for an axis.
             </p>
+            <label v-if="xColumnsOf(selected).length && selected.dataSource?.groupBy"
+              class="flex items-center gap-1.5 text-[11px] cursor-pointer select-none mt-2">
+              <input type="checkbox" class="accent-primary"
+                :checked="!!selected.dataSource?.meanLine"
+                @change="patchWidget(selected.id, { dataSource: { meanLine: $event.target.checked } })" />
+              Add an overall line
+              <InfoHint label="About the overall line">
+                One more line across the same columns, for everything currently selected rather than
+                for one group — drawn thicker and in the accent colour. It is asked as its own
+                question, so it is the figure over the whole selection and not the average of the
+                lines that happened to fit under “Max groups”.
+              </InfoHint>
+            </label>
           </div>
         </template>
 
@@ -1373,7 +1402,7 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
                 <option v-for="k in CHART_KINDS" :key="k.id" :value="k.id">{{ k.name }}</option>
               </select>
             </label>
-            <label class="block">
+            <label v-if="isBarChart(selected)" class="block">
               <span class="text-[10px] text-muted-foreground block mb-0.5">Bar colours</span>
               <select :value="selected.style?.colorMode || 'single'"
                 @change="patchWidget(selected.id, { style: { colorMode: $event.target.value } })"
@@ -1383,7 +1412,7 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
                 <option value="sequential">Shaded (ordered)</option>
               </select>
             </label>
-            <label class="block">
+            <label v-if="isBarChart(selected)" class="block">
               <span class="text-[10px] text-muted-foreground block mb-0.5">Values on bars</span>
               <select :value="selected.style?.valueLabels == null ? '' : (selected.style.valueLabels ? 'on' : 'off')"
                 @change="patchWidget(selected.id, { style: { valueLabels: $event.target.value === '' ? null : $event.target.value === 'on' } })"

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -1688,6 +1688,34 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           </label>
         </div>
       </template>
+      <!-- Axis titles, for the two widget types that have axes. -->
+      <template v-if="['chart', 'scatter'].includes(selected.type)">
+        <div class="grid grid-cols-2 gap-2">
+          <label class="block">
+            <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+              X axis title
+              <InfoHint label="About axis titles">
+                What the axis measures, in your words. The tick labels say where a point sits; the
+                title says what is being measured — and a column name is what the data is called,
+                which is rarely the same thing. A scatter falls back to the column name; other
+                charts show no title unless you write one.
+              </InfoHint>
+            </span>
+            <input type="text" maxlength="40" placeholder="none"
+              :value="selected.style?.xTitle || ''"
+              @change="patchWidget(selected.id, { style: { xTitle: $event.target.value || undefined } })"
+              class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+          </label>
+          <label class="block">
+            <span class="text-[10px] text-muted-foreground block mb-0.5">Y axis title</span>
+            <input type="text" maxlength="40" placeholder="none"
+              :value="selected.style?.yTitle || ''"
+              @change="patchWidget(selected.id, { style: { yTitle: $event.target.value || undefined } })"
+              class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+          </label>
+        </div>
+      </template>
+
       <template v-if="selected.type === 'indicator'">
         <div class="grid grid-cols-3 gap-2">
           <label class="block">

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -208,6 +208,14 @@ function toggleLabelField(w, name) {
 //: for every chart kind, so choosing Line left two controls on screen that did nothing, and one of
 //: them was called "Bar colours" while no bars were in sight.
 function isBarChart(w) { return ['bar', 'hbar'].includes(w?.style?.chart || 'bar') }
+// Which charts have a plot and a legend competing for the same card, and so something to split. A
+// pie always does; a line or bar chart only once it draws more than one measure, since a single
+// series has no key to make room for.
+function hasLegendToShare(w) {
+  if (w?.style?.legend === false) return false     // nothing to give the space to
+  if (['pie', 'donut'].includes(w?.style?.chart)) return true
+  return Math.max(seriesOf(w).length, xColumnsOf(w).length) > 1
+}
 //: Every numeric column at once. A wide file is wide by nature -- 57 years of GDP is 57 clicks --
 //: and a picker that only takes them one at a time is not a picker for this data.
 function allXColumns(w) { setXColumns(w, numericFields(w).map(f => f.name)) }
@@ -1399,13 +1407,15 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
             <!-- Pie/donut only: the plot and its legend share the card, and only these two have a
                legend that competes with the plot for it. On a bar chart the same control would just
                leave empty space. -->
-          <label v-if="['pie', 'donut'].includes(selected.style?.chart)" class="block">
+          <label v-if="hasLegendToShare(selected)" class="block">
             <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
-              Plot size — {{ selected.style?.plotSize ?? 100 }}%
+              Plot size — {{ selected.style?.plotSize ?? 100 }}%{{ (selected.style?.plotSize ?? 100) === 100 ? ' (auto)' : '' }}
               <InfoHint label="About the plot size">
-                How much of the card the circle takes, leaving the rest to the legend. Making the
-                widget bigger grows both together; this is what shrinks the plot so a long legend
-                has room to be read without scrolling.
+                How much of the card's height the plot takes, leaving the rest to the legend.
+                At 100% the plot takes everything the legend does not need — on a pie that is the
+                whole card, and on a line or bar chart it is what is left once the key has its
+                room. Move it down to hand the plot a fixed share and let a long key scroll
+                instead: twelve series wrap to several lines and can take a third of the card.
               </InfoHint>
             </span>
             <input type="range" min="30" max="100" step="5"

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -228,7 +228,16 @@ function xAxisPreview(w) {
   if (!preOk) pre = ''
   if (suf.length && !SEP.test(suf[0])) suf = ''
   const out = names.map(n => n.slice(pre.length, n.length - suf.length).replace(/^[_\-. ]+|[_\-. ]+$/g, ''))
-  return (out.every(v => v.length) ? out : names).join(', ')
+  const trimmed = out.every(v => v.length) ? out : names
+  //: …then the author's own formatting, exactly as `formatColumnLabels` applies it at runtime.
+  const off = Number(w?.dataSource?.xLabelOffset) || 0
+  const patRaw = w?.dataSource?.xLabelPattern
+  const pat = (patRaw && patRaw.includes('{}')) ? patRaw : null
+  return trimmed.map((lab) => {
+    let v = String(lab)
+    if (off) { const n = Number(v); if (v !== '' && isFinite(n)) v = String(n + off) }
+    return pat ? pat.split('{}').join(v) : v
+  }).join(', ')
 }
 function isNumeric(type) {
   return /int|numeric|decimal|double|real|float|serial|bigint|smallint/i.test(String(type || ''))
@@ -1217,6 +1226,37 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
                 class="px-2 py-0.5 rounded border text-[11px]"
                 :class="xColumnsOf(selected).includes(f.name)
                   ? 'border-primary text-primary bg-primary/10' : 'border-border text-foreground/70'">{{ f.name }}</button>
+            </div>
+            <div v-if="xColumnsOf(selected).length" class="grid grid-cols-2 gap-2 mt-2">
+              <label class="block">
+                <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+                  Add to each label
+                  <InfoHint label="About the label offset">
+                    Arithmetic on labels that are numbers. Columns named gdp60, gdp61 give ticks 60
+                    and 61; adding 1900 makes them 1960 and 1961. Labels that are not numbers are
+                    left alone.
+                  </InfoHint>
+                </span>
+                <input type="number" step="1" placeholder="0"
+                  :value="selected.dataSource?.xLabelOffset ?? ''"
+                  @change="patchWidget(selected.id, { dataSource: { xLabelOffset: Number($event.target.value) || 0 } })"
+                  class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+              </label>
+              <label class="block">
+                <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+                  Label pattern
+                  <InfoHint label="About the label pattern">
+                    Text around each label, with <code>{}</code> standing for it. <code>19{}</code>
+                    turns 60 into 1960; <code>Q{}</code> turns 1 into Q1; <code>{} kg</code> adds a
+                    unit. Applied after the offset, so the two work together. A pattern without
+                    <code>{}</code> is ignored — it would print the same tick all along the axis.
+                  </InfoHint>
+                </span>
+                <input type="text" placeholder="{}" maxlength="24"
+                  :value="selected.dataSource?.xLabelPattern || ''"
+                  @change="patchWidget(selected.id, { dataSource: { xLabelPattern: $event.target.value || undefined } })"
+                  class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+              </label>
             </div>
             <p v-if="xColumnsOf(selected).length" class="text-[10px] text-muted-foreground/70 mt-1 leading-snug">
               Axis will read: <span class="text-foreground/80">{{ xAxisPreview(selected) }}</span>

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -993,6 +993,17 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
               @input="patchWidget(selected.id, { dataSource: { tolPx: Number($event.target.value) } })"
               class="w-full accent-primary" />
           </label>
+          <label class="flex items-center gap-1.5 text-[11px] cursor-pointer select-none">
+            <input type="checkbox" class="accent-primary"
+              :checked="selected.dataSource?.zoomToFilter !== false"
+              @change="patchWidget(selected.id, { dataSource: { zoomToFilter: $event.target.checked } })" />
+            Zoom to what a chart selects
+            <InfoHint label="About zooming to a chart's selection">
+              Clicking a bar or a slice frames the features it selected. Charts only — a slider or a
+              search box is a control you are working in, and moving the camera under the hand using
+              it fights you. Turn it off where comparing categories in a fixed view matters more.
+            </InfoHint>
+          </label>
           <!-- The map following a LINKED filter. Off by default, and the one setting here whose
                failure mode is a map that LOOKS narrowed and is not — so the bound stays one click
                away rather than being left to the docs. -->

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -1763,6 +1763,20 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
                 ? 'border-primary text-primary bg-primary/10' : 'border-border text-foreground/70'">{{ f.name }}</button>
           </div>
         </div>
+        <label class="block">
+          <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+            Point size — {{ selected.style?.pointSize ?? 3.5 }} px
+            <InfoHint label="About point size">
+              How big each dot is drawn. The right size depends on how many points there are: a
+              dozen features want a mark you can see and hover, a few thousand want a grain small
+              enough that overlapping ones read as density rather than a solid blob.
+            </InfoHint>
+          </span>
+          <input type="range" min="1.5" max="8" step="0.5"
+            :value="selected.style?.pointSize ?? 3.5"
+            @input="patchWidget(selected.id, { style: { pointSize: Number($event.target.value) } })"
+            class="w-full accent-primary" />
+        </label>
       </template>
 
       <!-- Axis titles, for the two widget types that have axes. -->

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -125,7 +125,34 @@ const selected = computed(() => widgets.value.find(w => w.id === selectedId.valu
 
 function commit(next) { emit('update:modelValue', next) }
 function patchDash(patch) { commit({ ...dash.value, ...patch }) }
-function setWidgets(list) { patchDash({ widgets: list }) }
+
+//: Has anyone touched this grid, or is it still just a template sitting there?
+//:
+//: The distinction is the whole of the template-switching behaviour below. Loading a preset over
+//: widgets an author has arranged destroys work and must be asked for; loading one over widgets
+//: another preset put there five seconds ago destroys nothing, and asking is a button press for no
+//: reason. Anything already on the grid when this editor opens counts as the author's — it came out
+//: of a saved portal, and this component has no way to know how it got there.
+const presetTouched = ref(widgets.value.length > 0)
+//: Set while `applyPreset` commits, so its own write does not count as a touch.
+let applyingPreset = false
+//: The preset whose widgets are on the grid, or null if they came from anywhere else — a saved
+//: portal, or hand-built. Auto-replacing is only ever safe when THIS component put them there:
+//: `presetTouched` alone is not enough, because a portal loading into the editor after mount
+//: arrives without going through `setWidgets` and would look untouched.
+let appliedPreset = null
+//: The preset watcher runs immediately, which is how an empty grid gets its template. That first
+//: run is the editor OPENING, not the author choosing — and an offer to replace their layout the
+//: moment they open a saved portal would be alarming.
+let presetWatchOpened = false
+//: A template was chosen whose layout differs from work the author has done. Not applied, ASKED —
+//: see the banner in the template.
+const presetOffered = ref(false)
+
+function setWidgets(list) {
+  if (!applyingPreset) presetTouched.value = true
+  patchDash({ widgets: list })
+}
 function patchWidget(id, patch) {
   setWidgets(widgets.value.map(w => (w.id === id ? deepMerge(w, patch) : w)))
 }
@@ -585,11 +612,16 @@ function applyPreset(overwrite) {
     }
     return w
   })
+  applyingPreset = true
   commit({
     grid: preset.grid || { rowHeight: 90, gap: 10 },
     refresh: preset.refresh || 0,
     widgets: bound,
   })
+  applyingPreset = false
+  presetTouched.value = false      // this grid is the template's again, not anyone's work
+  appliedPreset = preset
+  presetOffered.value = false
   selectedId.value = null
   // After the commit, not during it: `autoRangeGauge` reads the committed widget back and patches
   // it, so it has to run against the model the author can now see.
@@ -603,7 +635,21 @@ const presetName = computed(() => (props.preset ? 'this template' : null))
 // a preset is available, load it. Only when the grid is genuinely empty — this must never overwrite
 // an author's work, which is why the overwrite path is a button they press.
 watch(() => props.preset, (p) => {
-  if (p && !widgets.value.length) applyPreset(false)
+  const opening = !presetWatchOpened
+  presetWatchOpened = true
+  if (!p) return
+  // Nothing there yet — a dashboard with no widgets is a blank page.
+  if (!widgets.value.length) { applyPreset(false); return }
+  // Widgets are there, but THIS component put them there from a template and nobody has touched
+  // them since. Switching should then just show the new one: someone is trying layouts on, and
+  // making them find "Reload template" after every choice is the editor pretending it did not
+  // understand. `appliedPreset` as well as `presetTouched`, because a portal that finished loading
+  // after mount never passed through `setWidgets` and would otherwise read as untouched.
+  if (appliedPreset && !presetTouched.value) { applyPreset(true); return }
+  // Real work, or work of unknown origin. Never overwrite it silently — but do not sit in silence
+  // either, which is what made choosing a template look like it had done nothing at all. Not on the
+  // first run: that is the editor opening, not a choice.
+  if (!opening) presetOffered.value = true
 }, { immediate: true })
 
 // The common opening order is "new portal → pick Dashboard → add layers", which means the preset
@@ -761,6 +807,21 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           :title="`Replace the current widgets with ${presetName}'s starting set`">↺ Reload template</button>
         <button @click="pickerOpen = !pickerOpen" class="text-xs text-primary hover:text-primary/80 font-medium">+ Add widget</button>
       </div>
+    </div>
+
+    <!-- Asked, not done. Choosing a template with work already on the grid used to change nothing
+         visible, leaving a quiet "Reload template" link as the only clue that a choice had been
+         registered at all. -->
+    <div v-if="presetOffered"
+      class="mb-3 p-2.5 rounded-lg border border-primary/40 bg-primary/5 flex items-start gap-2">
+      <span class="text-[11px] leading-snug flex-1">
+        This template has a different starting layout.
+        <span class="text-muted-foreground">Loading it replaces the widgets you have now.</span>
+      </span>
+      <button @click="applyPreset(true)"
+        class="text-[11px] font-medium text-primary hover:text-primary/80 shrink-0">Load it</button>
+      <button @click="presetOffered = false"
+        class="text-[11px] text-muted-foreground hover:text-foreground shrink-0">Keep mine</button>
     </div>
 
     <!-- The widget picker. Every type, always — a template's set is a starting point, not a menu. -->

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -750,8 +750,26 @@ function setLayer(w, value) {
  * One-shot, on the binding change the author just made. There is no stored "auto" flag to go stale:
  * the moment they drag the min/max inputs, nothing here fires again until they rebind the field.
  */
+//: Picking a column implies an aggregation of it, and clearing one implies counting rows again.
+//:
+//: `count` ignores `field` entirely, so a field chosen while Count is selected would be stored,
+//: displayed, and have no effect on the chart — the author sets the thing they came to set and the
+//: bars do not move. Sum is the promotion because "GDP per country" means the total, and Average /
+//: Minimum / Maximum are one dropdown away.
+//: The other direction: switching TO Count drops the field, so the stored config cannot say
+//: "count, of GDP" — a pair that reads as a measurement and behaves as a row tally.
+function setAggOp(w, op) {
+  const patch = { op: op };
+  if (op === 'count') patch.field = undefined
+  patchWidget(w.id, { dataSource: patch })
+}
+
 function setAggField(w, field) {
-  patchWidget(w.id, { dataSource: { field: field || undefined } })
+  const patch = { field: field || undefined }
+  const op = w.dataSource?.op || 'count'
+  if (field && op === 'count') patch.op = 'sum'
+  if (!field && op !== 'count') patch.op = 'count'
+  patchWidget(w.id, { dataSource: patch })
   if (w.type === 'gauge' && field) autoRangeGauge(w.id, field)
 }
 
@@ -1114,17 +1132,29 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
             <label class="block">
               <span class="text-[10px] text-muted-foreground block mb-0.5">Aggregation</span>
               <select :value="selected.dataSource?.op || 'count'"
-                @change="patchWidget(selected.id, { dataSource: { op: $event.target.value } })"
+                @change="setAggOp(selected, $event.target.value)"
                 class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60">
                 <option v-for="o in AGG_OPS" :key="o.id" :value="o.id">{{ o.name }}</option>
               </select>
             </label>
-            <label v-if="(selected.dataSource?.op || 'count') !== 'count'" class="block">
-              <span class="text-[10px] text-muted-foreground block mb-0.5">Field</span>
+            <!-- ALWAYS shown, not only once the aggregation is something other than Count.
+                 Hidden, it made "plot GDP per country" look impossible: the panel offered an
+                 aggregation and a grouping and no way to name the column, and Count -- the default --
+                 was the one setting under which the column picker did not exist. The order people
+                 think in is "which column", then "how to combine it". -->
+            <label class="block">
+              <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+                Field
+                <InfoHint label="About the field">
+                  The column being measured. Leave it empty to count rows; choose one and the
+                  aggregation becomes Sum, which you can change to Average, Minimum or Maximum.
+                  Only numeric columns are listed — the others have nothing to add up.
+                </InfoHint>
+              </span>
               <select :value="selected.dataSource?.field || ''"
                 @change="setAggField(selected, $event.target.value)"
                 class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60">
-                <option value="">—</option>
+                <option value="">— count rows —</option>
                 <option v-for="f in numericFields(selected)" :key="f.name" :value="f.name">{{ f.name }}</option>
               </select>
             </label>

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -1038,6 +1038,24 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           class="text-[11px] text-red-400 hover:text-red-500 px-1">✕</button>
       </div>
 
+      <!-- The line UNDER the title. Generated from the layer and the aggregation unless written,
+           which describes the query where the reader wants the subject. -->
+      <label class="block">
+        <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+          Subtitle
+          <InfoHint label="About the subtitle">
+            The small line beside the title. Left empty it names the layer and the aggregation —
+            useful while building, rarely what a reader wants to be told. Write anything here to
+            replace it.
+          </InfoHint>
+        </span>
+        <input type="text" maxlength="48"
+          :placeholder="TYPE_BY_ID[selected.type]?.name + ' — automatic'"
+          :value="selected.style?.subtitle || ''"
+          @change="patchWidget(selected.id, { style: { subtitle: $event.target.value || undefined } })"
+          class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+      </label>
+
       <!-- Type. Changing it REPLACES the widget in place, keeping its cell and its title. -->
       <label class="block">
         <span class="text-[10px] text-muted-foreground block mb-0.5">Widget type</span>

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -399,11 +399,64 @@ function gridStyle(w) {
     gridRow: `${(l.y || 0) + 1} / span ${l.h || 3}`,
   }
 }
+//: Two grid rectangles share a cell.
+function hits(a, b) {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+}
+
+//: Resolve overlaps by pushing the widgets the ANCHOR landed on downwards, cascading.
+//:
+//: CSS Grid does not object to two items in one cell — it stacks them — so a dragged widget simply
+//: sat on top of whatever was there, and the dashboard was saved that way. (A portal on the test
+//: instance had one table overlapping four other widgets, including the map.) Nothing warned,
+//: because nothing was checking.
+//:
+//: Push rather than block: a drag that refuses to land reads as a broken control, and the author's
+//: intent is the position they dragged TO. The anchor keeps exactly what it was given and everything
+//: it displaces moves down, which is the convention every grid dashboard uses.
+//:
+//: `from` is the layout as it stood when the drag STARTED, not the running one. Resolving against
+//: the running layout would accumulate — each pointermove pushing neighbours a little further —
+//: so dragging a widget across the grid and back would leave everything below it lower than it
+//: began. Recomputing from the snapshot makes any single drag reversible.
+function resolveOverlaps(list, anchorId, from) {
+  const base = from || list
+  const byId = {}
+  base.forEach((w) => { byId[w.id] = w.layout })
+  const anchor = list.find((w) => w.id === anchorId)
+  if (!anchor) return list
+
+  const placed = [{ id: anchorId, ...anchor.layout }]
+  const rest = list
+    .filter((w) => w.id !== anchorId && !w.layout?.overlay)   // overlays are pinned to the map
+    .map((w) => ({ w, start: byId[w.id] || w.layout }))
+    .sort((a, b) => (a.start.y - b.start.y) || (a.start.x - b.start.x))
+
+  const moved = {}
+  for (const { w, start } of rest) {
+    const box = { x: start.x, y: start.y, w: start.w, h: start.h }
+    // Bounded: the grid has no row limit, so an unbounded loop is a hang rather than a bad layout.
+    for (let guard = 0; guard < 400 && placed.some((p) => hits(p, box)); guard++) box.y += 1
+    placed.push({ id: w.id, ...box })
+    if (box.y !== (w.layout?.y ?? 0)) moved[w.id] = box.y
+  }
+  if (!Object.keys(moved).length && !from) return list
+  return list.map((w) => (
+    moved[w.id] !== undefined || (from && byId[w.id] && w.id !== anchorId)
+      ? { ...w, layout: { ...w.layout, ...byId[w.id], y: moved[w.id] !== undefined ? moved[w.id] : byId[w.id].y } }
+      : w))
+}
+
 function onPointerDown(ev, w, mode) {
   if (ev.button !== 0) return
   ev.preventDefault()
   selectedId.value = w.id
-  drag.value = { id: w.id, mode, startX: ev.clientX, startY: ev.clientY, orig: { ...w.layout } }
+  drag.value = {
+    id: w.id, mode, startX: ev.clientX, startY: ev.clientY, orig: { ...w.layout },
+    // Every widget's layout as it stood when the drag began — what collisions are resolved
+    // against, so a drag cannot accumulate displacement across its own pointermoves.
+    from: widgets.value.map((x) => ({ id: x.id, layout: { ...x.layout } })),
+  }
   window.addEventListener('pointermove', onPointerMove)
   window.addEventListener('pointerup', onPointerUp, { once: true })
 }
@@ -414,15 +467,14 @@ function onPointerMove(ev) {
   const dx = Math.round((ev.clientX - d.startX) / colPx)
   const dy = Math.round((ev.clientY - d.startY) / ROW_PX)
   const o = d.orig
-  if (d.mode === 'move') {
-    const x = Math.max(0, Math.min(GRID_COLS - o.w, o.x + dx))
-    const y = Math.max(0, o.y + dy)
-    patchWidget(d.id, { layout: { x, y } })
-  } else {
-    const w = Math.max(2, Math.min(GRID_COLS - o.x, o.w + dx))
-    const h = Math.max(2, Math.min(24, o.h + dy))
-    patchWidget(d.id, { layout: { w, h } })
-  }
+  const patch = d.mode === 'move'
+    ? { x: Math.max(0, Math.min(GRID_COLS - o.w, o.x + dx)), y: Math.max(0, o.y + dy) }
+    : { w: Math.max(2, Math.min(GRID_COLS - o.x, o.w + dx)),
+        h: Math.max(2, Math.min(24, o.h + dy)) }
+  // Resizing collides exactly as moving does — growing a widget onto its neighbour is the same
+  // problem — so both go through the resolver.
+  const next = widgets.value.map(w => (w.id === d.id ? deepMerge(w, { layout: patch }) : w))
+  setWidgets(resolveOverlaps(next, d.id, d.from))
 }
 function onPointerUp() {
   drag.value = null
@@ -437,13 +489,14 @@ function onKey(ev, w) {
   const d = map[ev.key]
   if (!d) return
   ev.preventDefault()
-  if (step === 'move') {
-    patchWidget(w.id, { layout: {
-      x: Math.max(0, Math.min(GRID_COLS - l.w, l.x + d[0])), y: Math.max(0, l.y + d[1]) } })
-  } else {
-    patchWidget(w.id, { layout: {
-      w: Math.max(2, Math.min(GRID_COLS - l.x, l.w + d[0])), h: Math.max(2, Math.min(24, l.h + d[1])) } })
-  }
+  const patch = step === 'move'
+    ? { x: Math.max(0, Math.min(GRID_COLS - l.w, l.x + d[0])), y: Math.max(0, l.y + d[1]) }
+    : { w: Math.max(2, Math.min(GRID_COLS - l.x, l.w + d[0])),
+        h: Math.max(2, Math.min(24, l.h + d[1])) }
+  // No snapshot here: each keypress is its own complete move, so resolving against the current
+  // layout is right — there is no burst of intermediate states to accumulate.
+  const next = widgets.value.map(x => (x.id === w.id ? deepMerge(x, { layout: patch }) : x))
+  setWidgets(resolveOverlaps(next, w.id, null))
 }
 
 // ── presets ─────────────────────────────────────────────────────────────────

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -1612,6 +1612,19 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
 
       <!-- gauge bands -->
       <template v-if="selected.type === 'gauge'">
+        <label class="block">
+          <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
+            Target
+            <InfoHint label="About the gauge target">
+              Drawn as a line across the dial, so the reading can be compared with the number that
+              matters at a glance rather than from memory. Leave it empty for a gauge that only
+              reports a level.
+            </InfoHint>
+          </span>
+          <input type="number" :value="selected.style?.target ?? ''" placeholder="none"
+            @input="patchWidget(selected.id, { style: { target: $event.target.value === '' ? undefined : Number($event.target.value) } })"
+            class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
+        </label>
         <div class="grid grid-cols-2 gap-2">
           <label class="block">
             <span class="text-[10px] text-muted-foreground block mb-0.5">Dial minimum</span>

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -195,6 +195,14 @@ function numericFields(w) { return fieldsOf(w).filter(c => isNumeric(c.type)) }
 //: How many columns may form the X axis. Mirrors `MAX_X_COLUMNS` in services/dashboard.py.
 const MAX_X_COLUMNS = 120
 function xColumnsOf(w) { return w?.dataSource?.xColumns || [] }
+//: Up to three columns naming a scatter's points on hover. Three is a line of hover text; more is a
+//: record, and a record is what clicking already puts in the details panel.
+function labelFieldsOf(w) { return w?.dataSource?.labelFields || [] }
+function toggleLabelField(w, name) {
+  const cur = labelFieldsOf(w)
+  const next = cur.includes(name) ? cur.filter(c => c !== name) : [...cur, name]
+  patchWidget(w.id, { dataSource: { labelFields: next.slice(0, 3) } })
+}
 //: Bars only. `colorMode` colours bars and `valueLabels` prints numbers on them; a line chart takes
 //: neither — its colours come from the series palette and it has no bar to write on. Both were shown
 //: for every chart kind, so choosing Line left two controls on screen that did nothing, and one of
@@ -1717,6 +1725,28 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           </label>
         </div>
       </template>
+      <!-- What a scatter's points are called. -->
+      <template v-if="selected.type === 'scatter'">
+        <div>
+          <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-1">
+            Name points on hover
+            <InfoHint label="About point names">
+              Columns whose values identify each dot when you hover it — a name, a code, a date.
+              Without them a scatter shows two numbers per feature and cannot say which feature, so
+              an outlier is visible and unidentifiable. Up to three; use the details panel for the
+              rest.
+            </InfoHint>
+          </span>
+          <div class="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
+            <button v-for="f in fieldsOf(selected)" :key="f.name"
+              @click="toggleLabelField(selected, f.name)"
+              class="px-2 py-0.5 rounded border text-[11px]"
+              :class="labelFieldsOf(selected).includes(f.name)
+                ? 'border-primary text-primary bg-primary/10' : 'border-border text-foreground/70'">{{ f.name }}</button>
+          </div>
+        </div>
+      </template>
+
       <!-- Axis titles, for the two widget types that have axes. -->
       <template v-if="['chart', 'scatter'].includes(selected.type)">
         <div class="grid grid-cols-2 gap-2">

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -193,8 +193,14 @@ function fieldsOf(w) {
 }
 function numericFields(w) { return fieldsOf(w).filter(c => isNumeric(c.type)) }
 //: How many columns may form the X axis. Mirrors `MAX_X_COLUMNS` in services/dashboard.py.
-const MAX_X_COLUMNS = 24
+const MAX_X_COLUMNS = 120
 function xColumnsOf(w) { return w?.dataSource?.xColumns || [] }
+//: Every numeric column at once. A wide file is wide by nature -- 57 years of GDP is 57 clicks --
+//: and a picker that only takes them one at a time is not a picker for this data.
+function allXColumns(w) {
+  patchWidget(w.id, { dataSource: { xColumns: numericFields(w).map(f => f.name).slice(0, MAX_X_COLUMNS) } })
+}
+function noXColumns(w) { patchWidget(w.id, { dataSource: { xColumns: [] } }) }
 function toggleXColumn(w, name) {
   const cur = xColumnsOf(w)
   const next = cur.includes(name) ? cur.filter(c => c !== name) : [...cur, name]
@@ -205,6 +211,13 @@ function toggleXColumn(w, name) {
 function xAxisPreview(w) {
   const names = xColumnsOf(w)
   if (names.length < 2) return names.join(', ')
+  //: Same order as `trimColumnLabels` in templates/shared/dashboard.js: the trailing number first,
+  //: because a shapefile's 10-character truncation makes the PREFIXES disagree (GDP_PerC_9 then
+  //: GDP_Per_10) and there is then no common affix to find.
+  const tails = names.map(n => (String(n).match(/(\d+)$/) || [null, null])[1])
+  if (tails.every(Boolean) && new Set(tails).size === names.length) {
+    return formatXLabels(tails.map(t => String(Number(t))), w).join(', ')
+  }
   let pre = names[0], suf = names[0]
   for (const n of names.slice(1)) {
     let p = 0
@@ -229,15 +242,19 @@ function xAxisPreview(w) {
   if (suf.length && !SEP.test(suf[0])) suf = ''
   const out = names.map(n => n.slice(pre.length, n.length - suf.length).replace(/^[_\-. ]+|[_\-. ]+$/g, ''))
   const trimmed = out.every(v => v.length) ? out : names
-  //: …then the author's own formatting, exactly as `formatColumnLabels` applies it at runtime.
+  return formatXLabels(trimmed, w).join(', ')
+}
+
+//: The author's own formatting, exactly as `formatColumnLabels` applies it at runtime.
+function formatXLabels(labels, w) {
   const off = Number(w?.dataSource?.xLabelOffset) || 0
   const patRaw = w?.dataSource?.xLabelPattern
   const pat = (patRaw && patRaw.includes('{}')) ? patRaw : null
-  return trimmed.map((lab) => {
+  return labels.map((lab) => {
     let v = String(lab)
     if (off) { const n = Number(v); if (v !== '' && isFinite(n)) v = String(n + off) }
     return pat ? pat.split('{}').join(v) : v
-  }).join(', ')
+  })
 }
 function isNumeric(type) {
   return /int|numeric|decimal|double|real|float|serial|bigint|smallint/i.test(String(type || ''))
@@ -1213,6 +1230,10 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           <div>
             <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-1">
               Columns as the X axis
+              <button @click="allXColumns(selected)"
+                class="ml-auto text-[10px] text-primary hover:text-primary/80">All</button>
+              <button @click="noXColumns(selected)"
+                class="text-[10px] text-muted-foreground hover:text-foreground">None</button>
               <InfoHint label="About plotting columns as the axis">
                 For data where one variable is spread across many columns — gdp_1990, gdp_2000,
                 gdp_2010. Each column you pick becomes a point on the axis, aggregated with the
@@ -1259,6 +1280,7 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
               </label>
             </div>
             <p v-if="xColumnsOf(selected).length" class="text-[10px] text-muted-foreground/70 mt-1 leading-snug">
+              <span class="text-foreground/70">{{ xColumnsOf(selected).length }} columns.</span>
               Axis will read: <span class="text-foreground/80">{{ xAxisPreview(selected) }}</span>
             </p>
             <p v-if="xColumnsOf(selected).length === 1" class="text-[10px] text-amber-500/90 mt-1 leading-snug">

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -192,6 +192,44 @@ function fieldsOf(w) {
   return (layer && layer.columns) ? layer.columns.filter(c => c && c.name) : []
 }
 function numericFields(w) { return fieldsOf(w).filter(c => isNumeric(c.type)) }
+//: How many columns may form the X axis. Mirrors `MAX_X_COLUMNS` in services/dashboard.py.
+const MAX_X_COLUMNS = 24
+function xColumnsOf(w) { return w?.dataSource?.xColumns || [] }
+function toggleXColumn(w, name) {
+  const cur = xColumnsOf(w)
+  const next = cur.includes(name) ? cur.filter(c => c !== name) : [...cur, name]
+  patchWidget(w.id, { dataSource: { xColumns: next.slice(0, MAX_X_COLUMNS) } })
+}
+//: What the trimmed axis will read, shown while choosing so the author can see whether the columns
+//: they picked produce sensible ticks. Same rule as the runtime's `trimColumnLabels`.
+function xAxisPreview(w) {
+  const names = xColumnsOf(w)
+  if (names.length < 2) return names.join(', ')
+  let pre = names[0], suf = names[0]
+  for (const n of names.slice(1)) {
+    let p = 0
+    while (p < pre.length && p < n.length && pre[p] === n[p]) p++
+    pre = pre.slice(0, p)
+    let q = 0
+    while (q < suf.length && q < n.length && suf[suf.length - 1 - q] === n[n.length - 1 - q]) q++
+    suf = suf.slice(suf.length - q)
+  }
+  // Same rule as `trimColumnLabels` in templates/shared/dashboard.js, and it has to STAY the same:
+  // this previews what that will draw, and a preview that disagrees is worse than none.
+  const D = /[0-9]/, SEP = /[_\-. ]/
+  while (pre.length && D.test(pre[pre.length - 1]) && names.some(n => D.test(n[pre.length] || ''))) {
+    pre = pre.slice(0, -1)
+  }
+  while (suf.length && D.test(suf[0]) && names.some(n => D.test(n[n.length - suf.length - 1] || ''))) {
+    suf = suf.slice(1)
+  }
+  const preOk = !pre.length || SEP.test(pre[pre.length - 1])
+    || (!D.test(pre[pre.length - 1]) && names.every(n => D.test(n[pre.length] || '')))
+  if (!preOk) pre = ''
+  if (suf.length && !SEP.test(suf[0])) suf = ''
+  const out = names.map(n => n.slice(pre.length, n.length - suf.length).replace(/^[_\-. ]+|[_\-. ]+$/g, ''))
+  return (out.every(v => v.length) ? out : names).join(', ')
+}
 function isNumeric(type) {
   return /int|numeric|decimal|double|real|float|serial|bigint|smallint/i.test(String(type || ''))
 }
@@ -1142,7 +1180,7 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
                  aggregation and a grouping and no way to name the column, and Count -- the default --
                  was the one setting under which the column picker did not exist. The order people
                  think in is "which column", then "how to combine it". -->
-            <label class="block">
+            <label v-if="!(selected.type === 'chart' && xColumnsOf(selected).length)" class="block">
               <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-0.5">
                 Field
                 <InfoHint label="About the field">
@@ -1161,11 +1199,40 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           </div>
         </template>
 
+        <!-- chart: WIDE data — columns as the X axis -->
+        <template v-if="selected.type === 'chart'">
+          <div>
+            <span class="text-[10px] text-muted-foreground flex items-center gap-1 mb-1">
+              Columns as the X axis
+              <InfoHint label="About plotting columns as the axis">
+                For data where one variable is spread across many columns — gdp_1990, gdp_2000,
+                gdp_2010. Each column you pick becomes a point on the axis, aggregated with the
+                setting above. “Group by” then draws one line per group instead of using it as the
+                axis. Leave this empty for ordinary charts.
+              </InfoHint>
+            </span>
+            <div class="flex flex-wrap gap-1 max-h-28 overflow-y-auto">
+              <button v-for="f in numericFields(selected)" :key="f.name"
+                @click="toggleXColumn(selected, f.name)"
+                class="px-2 py-0.5 rounded border text-[11px]"
+                :class="xColumnsOf(selected).includes(f.name)
+                  ? 'border-primary text-primary bg-primary/10' : 'border-border text-foreground/70'">{{ f.name }}</button>
+            </div>
+            <p v-if="xColumnsOf(selected).length" class="text-[10px] text-muted-foreground/70 mt-1 leading-snug">
+              Axis will read: <span class="text-foreground/80">{{ xAxisPreview(selected) }}</span>
+            </p>
+            <p v-if="xColumnsOf(selected).length === 1" class="text-[10px] text-amber-500/90 mt-1 leading-snug">
+              One column is a single point — pick at least two for an axis.
+            </p>
+          </div>
+        </template>
+
         <!-- chart: grouping -->
         <template v-if="selected.type === 'chart'">
           <div class="grid grid-cols-2 gap-2">
             <label class="block">
-              <span class="text-[10px] text-muted-foreground block mb-0.5">Group by</span>
+              <span class="text-[10px] text-muted-foreground block mb-0.5">{{
+                xColumnsOf(selected).length ? 'One line per' : 'Group by' }}</span>
               <select :value="selected.dataSource?.groupBy || ''"
                 @change="patchWidget(selected.id, { dataSource: { groupBy: $event.target.value } })"
                 class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60">

--- a/ui/src/components/portal/DashboardBuilder.vue
+++ b/ui/src/components/portal/DashboardBuilder.vue
@@ -1927,6 +1927,25 @@ function bandCount(w) { return layerOf(w)?.band_count || 1 }
           @input="patchDash({ refresh: Number($event.target.value) })"
           class="w-full text-xs bg-background border border-border rounded px-2 py-1 focus:outline-none focus:border-primary/60" />
       </label>
+      <label class="col-span-2 flex items-center gap-2 text-[11px] text-foreground/80">
+        <input type="checkbox" :checked="dash.grid?.fit === 'screen'"
+          @change="patchDash({ grid: { ...(dash.grid || {}), fit: $event.target.checked ? 'screen' : 'rows' } })"
+          class="accent-primary" />
+        <span class="flex items-center gap-1">
+          Fill the screen
+          <InfoHint label="About filling the screen">
+            Off, every row is exactly the row height above, so a board built on a laptop leaves
+            empty space below it on a larger monitor. On, the rows share the height of the window
+            instead — the widgets keep their relative proportions, since a widget two rows tall
+            still gets twice one row.
+            <br /><br />
+            It stretches, it does not squeeze: the row height stays the floor. On a screen too
+            short for the board — a phone, a portrait monitor, or simply a lot of widgets — it
+            scrolls exactly as it does now. Worth checking the board at the sizes your readers
+            actually use.
+          </InfoHint>
+        </span>
+      </label>
     </div>
   </div>
 </template>

--- a/ui/src/components/shared/GithubLink.vue
+++ b/ui/src/components/shared/GithubLink.vue
@@ -1,0 +1,88 @@
+<script setup>
+//: A way back to the source, on the DEMO instance only.
+//:
+//: Someone trying the demo is deciding whether to run this themselves, and the repository is the
+//: next thing they want. On a real install it would be noise: the operator already has the source,
+//: and a permanent link out of their own admin panel to someone else's project page is clutter at
+//: best. Same test the demo banner uses, and the same posture — anything other than a clear
+//: `{demo: true}` means "do not render".
+import { ref, onMounted } from 'vue'
+import { getDemoInfo } from '@/api'
+
+const REPO = 'bravemaster3/GeoDeploy'
+const URL = `https://github.com/${REPO}`
+//: A day. The count is a signal of scale, not a live figure, and nobody returns to a demo to watch
+//: it tick. The cache matters because GitHub allows 60 unauthenticated calls an hour PER IP — and a
+//: demo behind one address would spend that on a busy afternoon, so every visitor asking on every
+//: page load is the one thing that guarantees the number stops arriving.
+const TTL = 24 * 60 * 60 * 1000
+const CACHE = 'gd-gh-stars'
+
+const props = defineProps({ collapsed: { type: Boolean, default: false } })
+
+const show = ref(false)
+const stars = ref(null)
+
+function fmt(n) {
+  return n >= 1000 ? (n / 1000).toFixed(n >= 10000 ? 0 : 1).replace(/\.0$/, '') + 'k' : String(n)
+}
+
+async function loadStars() {
+  try {
+    const raw = localStorage.getItem(CACHE)
+    if (raw) {
+      const c = JSON.parse(raw)
+      if (c && Date.now() - c.at < TTL && typeof c.n === 'number') { stars.value = c.n; return }
+    }
+  } catch { /* private mode throws on read; ask GitHub instead */ }
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+    if (!res.ok) return                       // rate-limited or offline: the LINK still works
+    const data = await res.json()
+    if (typeof data.stargazers_count !== 'number') return
+    stars.value = data.stargazers_count
+    try { localStorage.setItem(CACHE, JSON.stringify({ n: stars.value, at: Date.now() })) } catch { /* see above */ }
+  } catch { /* the count is an ornament; its absence must not be an error */ }
+}
+
+onMounted(async () => {
+  try {
+    const { data } = await getDemoInfo()
+    show.value = !!data.demo
+  } catch {
+    show.value = false
+  }
+  if (show.value) loadStars()
+})
+</script>
+
+<template>
+  <a v-if="show" :href="URL" target="_blank" rel="noopener noreferrer"
+    :title="`GeoDeploy on GitHub${stars != null ? ` — ${stars.toLocaleString()} stars` : ''}`"
+    class="flex items-center rounded-md text-muted-foreground/80 hover:text-foreground hover:bg-muted/60 transition-colors"
+    :class="collapsed ? 'justify-center w-9 h-9 mx-auto' : 'gap-2.5 px-3 py-2 text-sm'">
+    <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+        0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01
+        1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95
+        0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0
+        1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0
+        3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01
+        8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+    </svg>
+    <template v-if="!collapsed">
+      <span class="truncate">View on GitHub</span>
+      <!-- The count only when it arrived. A star pill reading "—" says the link is broken when what
+           actually happened is that GitHub declined to answer this minute. -->
+      <span v-if="stars != null"
+        class="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground/70 tabular-nums">
+        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2l2.9 6.3 6.9.8-5.1 4.7 1.4 6.8L12 17.3 5.9 20.6l1.4-6.8L2.2 9.1l6.9-.8z"/>
+        </svg>
+        {{ fmt(stars) }}
+      </span>
+    </template>
+  </a>
+</template>

--- a/ui/src/composables/README.md
+++ b/ui/src/composables/README.md
@@ -61,4 +61,11 @@ identically, where a copy in each would drift.
 
 ## Last updated
 
+2026-08-31 (`portalThumbnail.js`: the size floor no longer refuses a plain capture. Bytes were a
+proxy for "did the map render" and got the common case backwards — a map zoomed in far enough to
+show no detail is a real picture that compresses to nothing, and it was discarded as "probably still
+blank". A small capture is now decoded and sampled at 32x32; only one with no colour variation at
+all is thrown away, and a picture that cannot be decoded here is never taken as evidence of a blank
+one.)
+
 2026-08-02

--- a/ui/src/composables/portalThumbnail.js
+++ b/ui/src/composables/portalThumbnail.js
@@ -28,6 +28,51 @@ const CAPTURE_TIMEOUT_MS = 25000   // an off-screen frame is cold: style, source
 const MIN_BYTES_REPLACE = 2048
 const MIN_BYTES_FIRST = 256
 
+//: Is the picture actually empty, rather than merely small?
+//:
+//: Byte size was only ever a PROXY for "did the map render", and it is a poor one in the direction
+//: that matters: a map zoomed in far enough to show no detail — a plain field, open water, a
+//: single-colour basemap at z18 — is a legitimate picture that compresses to almost nothing, and it
+//: was being discarded with the message "the map was probably still blank". It was not blank; it
+//: was plain.
+//:
+//: So a small capture is now decoded and looked at. A blank one is uniform: every pixel the same
+//: colour to within a rounding error. Anything with real variation is a real picture whatever it
+//: weighs. Sampled at 32x32, because deciding "is there anything here" needs no more than a
+//: thousand pixels and reading a full-size frame for it would be a waste on every publish.
+async function looksBlank(dataUrl) {
+  try {
+    const img = await new Promise((resolve, reject) => {
+      const i = new Image()
+      i.onload = () => resolve(i)
+      i.onerror = reject
+      i.src = dataUrl
+    })
+    const N = 32
+    const c = document.createElement('canvas')
+    c.width = N; c.height = N
+    const ctx = c.getContext('2d', { willReadFrequently: true })
+    if (!ctx) return false
+    ctx.drawImage(img, 0, 0, N, N)
+    const d = ctx.getImageData(0, 0, N, N).data
+    const min = [255, 255, 255], max = [0, 0, 0]
+    for (let i = 0; i < d.length; i += 4) {
+      // Fully transparent pixels are the blank case itself, not a colour to measure.
+      if (d[i + 3] === 0) continue
+      for (let k = 0; k < 3; k++) {
+        if (d[i + k] < min[k]) min[k] = d[i + k]
+        if (d[i + k] > max[k]) max[k] = d[i + k]
+      }
+    }
+    // 8 of 255: below this is compression noise on a flat fill, not content.
+    return Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]) < 8
+  } catch {
+    // A picture that cannot be decoded here is not evidence of a blank one, and refusing to store
+    // it on that basis would fail exactly the captures this check exists to rescue.
+    return false
+  }
+}
+
 // Returns { url } on success, or { error } naming what went wrong. NOT a bare null: four different
 // failures used to collapse into "no image", and telling them apart meant asking the operator to
 // read a browser console. The caller shows `error` verbatim.
@@ -126,9 +171,12 @@ export async function capturePortalThumbnail(portalId, { hasExisting = false } =
       return { error: reply.error || 'the map produced no image' }
     }
     const blob = await (await fetch(reply.dataUrl)).blob()
+    // SMALL is a reason to look, not a reason to refuse. Only a capture that is both small and
+    // actually featureless is thrown away — otherwise a plain map, which is the case most likely to
+    // produce a tiny file, was the one case guaranteed never to get a thumbnail.
     const floor = hasExisting ? MIN_BYTES_REPLACE : MIN_BYTES_FIRST
-    if (blob.size < floor) {
-      return { error: `the captured image was only ${blob.size} bytes (minimum ${floor}) — `
+    if (blob.size < floor && await looksBlank(reply.dataUrl)) {
+      return { error: `the captured image was ${blob.size} bytes and had no visible detail — `
                     + 'the map was probably still blank when it was taken' }
     }
     const { data } = await uploadPortalThumbnail(portalId, blob)

--- a/ui/src/lib/basemaps.js
+++ b/ui/src/lib/basemaps.js
@@ -3,24 +3,29 @@
  *
  * Here rather than in a view because more than one place needs them now, and a second copy of a
  * tile-URL list is a second place to fix when a provider changes a path — which they do.
+ *
+ * That warning came true: CARTO began requiring an API key and answered unauthenticated requests
+ * with watermarked tiles, and this copy went on serving them after the server's catalog had moved.
+ * MIRROR OF `api/geodeploy/services/portal_generator.BASEMAP_CATALOG` — same ids, same order, same
+ * URLs. Change that one first, then this.
  */
 export const BASEMAPS = [
-  { id: 'positron', name: 'Positron',
-    tiles: ['https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/light_all/4/8/5.png' },
-  { id: 'voyager', name: 'Voyager',
-    tiles: ['https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png', 'https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/rastertiles/voyager/4/8/5.png' },
-  { id: 'dark', name: 'Dark Matter',
-    tiles: ['https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png', 'https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png'],
-    attribution: '© OpenStreetMap © CARTO',
-    thumb: 'https://a.basemaps.cartocdn.com/dark_all/4/8/5.png' },
   { id: 'osm', name: 'OpenStreetMap',
     tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png'],
     attribution: '© OpenStreetMap contributors',
     thumb: 'https://a.tile.openstreetmap.org/4/8/5.png' },
+  { id: 'positron', name: 'Light Gray',
+    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}'],
+    attribution: '© Esri, HERE, Garmin, © OpenStreetMap contributors',
+    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/4/5/8' },
+  { id: 'voyager', name: 'Humanitarian',
+    tiles: ['https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', 'https://c.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png'],
+    attribution: '© OpenStreetMap contributors | Tiles: Humanitarian OSM Team, hosted by OpenStreetMap France',
+    thumb: 'https://a.tile.openstreetmap.fr/hot/4/8/5.png' },
+  { id: 'dark', name: 'Dark Gray',
+    tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}'],
+    attribution: '© Esri, HERE, Garmin, © OpenStreetMap contributors',
+    thumb: 'https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/4/5/8' },
   { id: 'topo', name: 'OpenTopoMap',
     tiles: ['https://a.tile.opentopomap.org/{z}/{x}/{y}.png', 'https://b.tile.opentopomap.org/{z}/{x}/{y}.png'],
     attribution: '© OpenStreetMap, SRTM | © OpenTopoMap (CC-BY-SA)',

--- a/ui/src/views/Layout.vue
+++ b/ui/src/views/Layout.vue
@@ -46,6 +46,13 @@
         </RouterLink>
       </nav>
 
+      <!-- Last in the column, above the footer: it is a way OUT of the app, and the things that
+           leave it belong at the bottom next to sign-out rather than among the pages. Renders
+           nothing outside the demo. -->
+      <div :class="collapsed ? 'px-2 pb-2' : 'px-3 pb-2'">
+        <GithubLink :collapsed="collapsed" />
+      </div>
+
       <!-- Footer: user + theme + logout -->
       <div class="border-t border-border text-xs text-muted-foreground"
         :class="collapsed ? 'py-3 flex flex-col items-center gap-2' : 'px-4 py-3 flex items-center gap-2 min-w-0'">
@@ -75,6 +82,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute, RouterLink, RouterView } from 'vue-router'
+import GithubLink from '@/components/shared/GithubLink.vue'
 import { useAuthStore } from '@/stores/auth'
 import logoDark from '@/assets/logo-dark.svg'
 import { DatabaseIcon, GlobeIcon, LayoutIcon, SettingsIcon, UsersIcon, ActivityIcon } from './icons'


### PR DESCRIPTION
A fortnight of building real dashboards with v1.5. Almost everything here is
something that could not be said, sized or read until someone tried to author a
board with it.

No migration and no configuration change: publish a portal again and it picks
all of this up.

## What is in it

- **Charts you can author** — columns as the X axis for wide data, trimmed and
  shifted tick labels, an overall line, author-written axis titles and
  subtitles, a measure field alongside a grouping field, gridlines and interval
  ticks, and a legend that gets its room before the plot does (on the
  multi-series line, the grouped bars *and* the pie).
- **Reading a dashboard** — multi-row table selection with the map fitting the
  whole selection, scatter hover labels and point size, a new selection that
  replaces rather than compounds, zoom-to-what-a-chart-selected, and
  **Fill the screen** so a board laid out on a laptop does not stop a third of
  the way down a monitor.
- **On the map** — CARTO out and OpenStreetMap first (the three that asked for
  an API key), draggable selection tools, a coordinate readout that names its
  CRS and shares one line with the scale bar and the attribution, and both
  readouts legible in dark mode.
- **Portals everywhere** — a dashboard's card thumbnail is the whole board, a
  plain map is no longer refused as a blank one, the legend opens beside the
  map on a phone, and a big number shrinks to fit its card.

## Findability

The repository had one topic ("demo") and a description containing none of the
words anyone searches; the docs shipped one identical meta description across
all eighteen pages. Repository metadata is set on GitHub directly; the per-page
descriptions, the home page `<title>` and a README section naming what people
call this thing are in here. A dead hero link on the docs home page
(`#three-kinds-of-portal`, which became "Four kinds" when dashboards shipped)
is fixed too.

Full detail in `CHANGELOG.md`.