### PR TITLE
Bump every GitHub Action to its latest major

### DIFF
--- a/.github/CI-NOTES.md
+++ b/.github/CI-NOTES.md
@@ -42,9 +42,32 @@ GitHub Actions CI and the community-template validation pipeline.
 - `ci.yml` exercises `api/` (pytest), `ui/` (vite build) and `cli/` (pytest + console script) — keep build/test commands here in sync with those folders' tooling.
 - `validate-template.yml` + `scripts/validate_template.py` enforce the contract documented in `templates/community/CONTRIBUTING.md`.
 
+## Action versions
+Every `actions/*` step is pinned to its latest MAJOR and they are moved together, because a repo
+that bumps one at a time ends up spread across four generations of runner requirements. What each
+crossing actually required, checked rather than assumed (2026-08-30):
+
+- **Node 24** is the substance of most of the majors (`checkout` v5, `setup-python` v6,
+  `upload-artifact` v5, `download-artifact` v6). They need runner **v2.327.1+**, which every
+  GitHub-hosted runner already exceeds.
+- **`download-artifact` v5** changed the output path for downloads **by ID**. Downloads **by name**
+  are explicitly unchanged, and by name is what `publish-cli.yml` does.
+- **`download-artifact` v8** now errors on a hash mismatch instead of warning. That is the behaviour
+  worth having on a release pipeline.
+- **`setup-node` v5** caches automatically when `package.json` has a `packageManager` field.
+  `ui/package.json` has none, so nothing changed here.
+- **`upload-pages-artifact` v4** stopped including dotfiles. `docs/` has none, and `docs/CNAME` —
+  which is what keeps the custom domain — is not a dotfile.
+- **`checkout` v7** blocks checking out a fork PR under `pull_request_target` / `workflow_run`.
+  No workflow here uses either trigger.
+
 ## Current status & known issues
 - CI runs unit/build checks only — no integration test spins up the full Docker stack, so tile-serving regressions (the kind debugged in `notes_temp/notes_for_future.md`) are **not** caught by CI. Verify those manually.
 - The API test suite is minimal (`/health`, initial setup status).
 
 ## Last updated
+2026-08-30 (every `actions/*` step bumped to its latest major — checkout v7, setup-python v7,
+setup-node v7, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5.
+See **Action versions** for what each crossing required.)
+
 2026-08-13 (added `publish-cli.yml` — Trusted Publishing to PyPI on a `cli-v*` tag)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -70,10 +70,10 @@ jobs:
         python-version: ["3.9", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -97,10 +97,10 @@ jobs:
     name: QGIS plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           # The floor the plugin actually has to run on: it vendors the client, and the oldest QGIS
           # anyone still runs ships 3.9.
@@ -235,10 +235,10 @@ jobs:
     name: UI build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The whole PR range, not just the tip — every commit needs the line, and a shallow clone
           # cannot see the earlier ones.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # NOTE: there is deliberately NO `actions/configure-pages` step here.
       #
       # It was added with `enablement: true` to switch Pages on automatically, and that is the only
@@ -41,7 +41,7 @@ jobs:
       #
       # A workflow that reconfigures the very thing it publishes to is not worth the convenience.
       # Pages source is now set once, by hand, to "GitHub Actions"; this workflow only ever UPLOADS.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
@@ -50,7 +50,7 @@ jobs:
       # --strict turns broken internal links and bad nav entries into build failures. A docs site
       # whose links quietly rot is worse than one that refuses to build.
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -63,4 +63,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -52,10 +52,10 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           # 3.9 is the package's floor (the QGIS plugin vendors it, QGIS 3.28 LTR ships 3.9). Test
           # on the floor: a 3.10+ syntax slip would otherwise reach PyPI and break exactly the
@@ -126,7 +126,7 @@ jobs:
           /tmp/verify/bin/pip install --quiet --no-deps cli/dist/*.whl
           /tmp/verify/bin/geodeploy --version
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: cli/dist/
@@ -143,7 +143,7 @@ jobs:
     permissions:
       id-token: write        # the OIDC token IS the credential — nothing else is needed
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -167,7 +167,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -9,10 +9,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
The pins had drifted several generations behind — `checkout` on v4 against v7, `download-artifact` on
v4 against v8 — across all five workflows. Moved together rather than one at a time, because bumping
them piecemeal leaves the repo spread over four sets of runner requirements.

| action | was | now |
|---|---|---|
| `actions/checkout` (×8) | v4 | **v7** |
| `actions/setup-python` (×6) | v5 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` (×2) | v4 | **v8** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

## Every "breaking" note, checked rather than assumed

- **Node 24** is the substance of most of them (`checkout` v5, `setup-python` v6, `upload-artifact`
  v5, `download-artifact` v6). They want runner **v2.327.1+**, which every GitHub-hosted runner
  already exceeds.
- **`download-artifact` v5** changed the output path for downloads **by ID**. Downloads **by name**
  are explicitly unchanged, and by name is what `publish-cli.yml` does. This one matters most: that
  workflow publishes to PyPI, and a version there can never be re-uploaded.
- **`download-artifact` v8** errors on a hash mismatch instead of warning — the behaviour worth
  having on a release pipeline.
- **`setup-node` v5** caches automatically when `package.json` declares a `packageManager`.
  `ui/package.json` declares none, so nothing changes.
- **`upload-pages-artifact` v4** stopped including dotfiles. `docs/` has none, and `docs/CNAME` —
  which holds the custom domain — is not a dotfile.
- **`checkout` v7** blocks checking out a fork PR under `pull_request_target` / `workflow_run`. No
  workflow here uses either trigger.

`.github/CI-NOTES.md` records that list, so the next bump starts from what is already established
rather than from the release notes again.

## Verification

All five workflows still parse as YAML. The real check is this PR's own run: CI, DCO and the
template validator all execute on the new versions here. `publish-cli.yml` does **not** run on a PR —
it is tag-triggered — so its first exercise will be the next `cli-v*` tag, which is why the
by-name/by-ID distinction above was worth confirming in advance rather than discovering at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)