### PR TITLE
v1.5.2 — a restore that leaves spatial queries working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ upgrade needs manual work.
 
 ## Unreleased
 
+## v1.5.2 — 2026-09-02
+
+A restore could leave a running instance unable to answer any spatial query. One fix, and the
+logging that should have made it a five-minute diagnosis.
+
+### Restoring a backup no longer breaks spatial queries
+
+- **The restore no longer drops and recreates the PostGIS extension.** `pg_restore --clean` drops
+  the objects in the dump in reverse dependency order, so tables go first and the `DROP EXTENSION
+  postgis` the dump also carries runs when nothing depends on it any more — and therefore succeeds.
+  `CREATE EXTENSION` then rebuilds `geometry` and `gist_geometry_ops_2d` with **new OIDs**.
+
+  Every connection open across that restore keeps PostGIS's per-backend operator cache pointing at
+  objects that no longer exist. `COUNT(*)` still worked, because it touches no spatial operator;
+  every query using `&&` or `ST_Intersects` failed with `no spatial operator found for
+  'st_intersects': opfamily N type M` until the service was restarted. On a dashboard that meant
+  every widget reporting `Request failed (502)` the moment you drew a box, while the map itself
+  looked fine.
+
+  The extension is now filtered out of the restore's table of contents, so its OIDs never change
+  and no session is stranded. `CREATE EXTENSION IF NOT EXISTS postgis` runs first, so restoring
+  onto a fresh instance still works.
+
+  Anyone restoring a backup onto a running instance with PostGIS layers could hit this. It showed
+  up hourly on the demo instance, whose reset restores under a live API — two errors an hour apart
+  named two different pairs of OIDs, which is the extension being rebuilt underneath the service.
+
+  `pool_pre_ping` (already enabled) cannot catch it: those connections are alive and `SELECT 1`
+  succeeds. It is the cache contents that go stale, not the socket.
+
+- **The worker recycles its own connections after a restore**, alongside the schema and Martin
+  repairs it already performed. Celery both runs the restore and serves bbox-clipped exports, so it
+  was the process most exposed.
+
+### Diagnosing the next one
+
+- **A 502 now logs the exception it was raised for.** Seven handlers in the vector router turned an
+  unexpected error into `HTTPException(502, f"...: {exc}")` and logged nothing, so the one string
+  naming the cause reached only the response body — where uvicorn's access log does not show it and
+  the dashboard renders `Request failed (502)` without it. Finding this bug meant reproducing it by
+  hand with `curl` to read a body the browser had already discarded.
+
 ## v1.5.1 — 2026-08-31
 
 A fortnight of building real dashboards with v1.5. Almost everything here is something that could

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.5.1",
+    version="1.5.2",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/api/geodeploy/routers/data/vector.py
+++ b/api/geodeploy/routers/data/vector.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import uuid
 from typing import Any
@@ -18,6 +19,25 @@ from ...schemas import DefaultStyle, JobStatus, LayerRename, PortalRefOut, Shari
 from ...services import martin as martin_svc
 from ...tasks.vector_ingest import ingest_vector
 from . import exports
+
+logger = logging.getLogger(__name__)
+
+
+def _upstream(what: str, exc: Exception) -> HTTPException:
+    """Report a failed read as 502 — and LOG it, which is the half that was missing.
+
+    Every one of these handlers turned an unexpected exception into
+    `HTTPException(502, f"...: {exc}")` and logged nothing. The message is real and useful, but it
+    only ever reaches the response BODY: uvicorn's access line shows the bare status, and the
+    dashboard runtime renders `Request failed (502)` without the detail. So the one string naming
+    the cause was written to the one place nobody reads, and a widget that had stopped working gave
+    an operator with a shell on the box nothing at all to go on.
+
+    `logger.exception` puts the traceback in the service log, where `docker compose logs` and
+    Settings -> Infrastructure both already look.
+    """
+    logger.exception("%s (layer read failed)", what)
+    return HTTPException(502, f"{what}: {exc}")
 from ..common import (apply_sharing, demo_upload_cap, busy_job_progress, by_ref, creator_names, portals_using,
                       prune_layer_from_portals, record_audit, visible_to)
 
@@ -1002,7 +1022,7 @@ async def vector_scatter(layer_ref: str, req: ScatterRequest,
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not plot this layer: {exc}") from exc
+        raise _upstream("Could not plot this layer", exc) from exc
 
 
 @router.post("/{layer_ref}/profile")
@@ -1025,7 +1045,7 @@ async def vector_profile(layer_ref: str, req: ProfileRequest,
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not describe this layer: {exc}") from exc
+        raise _upstream("Could not describe this layer", exc) from exc
 
 
 @router.post("/{layer_ref}/aggregate")
@@ -1055,7 +1075,7 @@ async def vector_aggregate(layer_ref: str, req: AggregateRequest,
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not summarise this layer: {exc}") from exc
+        raise _upstream("Could not summarise this layer", exc) from exc
 
 
 @router.post("/{layer_ref}/table")
@@ -1081,7 +1101,7 @@ async def vector_table(layer_ref: str, req: TableRequest, db: AsyncSession = Dep
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not read this layer: {exc}") from exc
+        raise _upstream("Could not read this layer", exc) from exc
 
 
 class PickRequest(BaseModel):
@@ -1118,7 +1138,7 @@ async def vector_pick(layer_ref: str, req: PickRequest, db: AsyncSession = Depen
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not read this layer: {exc}") from exc
+        raise _upstream("Could not read this layer", exc) from exc
     if not hit:
         # 204, not 404: "nothing is under your click" is a normal outcome of clicking a map, and a
         # 404 in the console on every empty click reads as a broken portal.
@@ -1147,7 +1167,7 @@ async def vector_distinct(layer_ref: str, field: str, limit: int = 200,
     except agg.AggregateError as exc:
         raise HTTPException(400, str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(502, f"Could not read this field: {exc}") from exc
+        raise _upstream("Could not read this field", exc) from exc
 
 
 @router.post("/{layer_id}/tile", response_model=VectorLayerOut)
@@ -1275,7 +1295,7 @@ async def field_stats(
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
         except Exception as exc:
-            raise HTTPException(502, f"Could not read the field: {exc}") from exc
+            raise _upstream("Could not read the field", exc) from exc
     else:
         stats = await _postgis_field_stats(db, layer, field)
 

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -203,6 +203,15 @@ The "hard parts" GeoDeploy hides from users: provisioning Docker containers, gen
   `api/tests/test_native_crs.py`.
 
 ## Last updated
+2026-09-02 (`restore.py`: **the restore no longer replaces the PostGIS extension.** `--clean` drops
+the dump's objects in reverse dependency order, so tables go first and the `DROP EXTENSION postgis`
+the dump carries then SUCCEEDS — and the rebuilt `geometry` / `gist_geometry_ops_2d` come back with
+new OIDs, stranding every connection open across the restore. Spatial predicates then fail with
+`no spatial operator found` while `COUNT(*)` keeps working. `toc_without_extensions()` filters those
+entries out of the `pg_restore -l` listing and the restore runs with `-L`; `CREATE EXTENSION IF NOT
+EXISTS` runs first so a fresh instance still restores. `pool_pre_ping` cannot catch this — the
+connections are alive, only their caches are stale.)
+
 2026-08-31 (`dashboard.py`: `grid.fit` — `"rows"` (default, unchanged) or `"screen"`, which lets the
 runtime stretch the rows to the viewport. Default stays `"rows"` so no published board restyles.)
 

--- a/api/geodeploy/services/restore.py
+++ b/api/geodeploy/services/restore.py
@@ -113,6 +113,63 @@ def _benign(line: str) -> bool:
     return any(marker.lower() in low for marker in _BENIGN_RESTORE_ERRORS)
 
 
+#: Entry types in a `pg_restore -l` table of contents that must never be replayed.
+#:
+#: A TOC line looks like `2; 3079 16385 EXTENSION - postgis geodeploy`: id, catalog oid, object oid,
+#: TYPE, schema, name, owner. We drop the extension itself and any comment attached to one.
+_TOC_EXTENSION_TYPES = ("EXTENSION",)
+
+
+def toc_without_extensions(toc: str) -> str:
+    """Strip EXTENSION entries from a `pg_restore -l` listing.
+
+    THE BUG THIS FIXES. The dump contains `CREATE EXTENSION postgis`, so `--clean` emits a matching
+    `DROP EXTENSION`. Tables are dropped first, so by the time that DROP runs nothing depends on the
+    extension any more and it SUCCEEDS — then `CREATE EXTENSION` builds a new one, and the
+    `geometry` type and `gist_geometry_ops_2d` operator family come back with NEW OIDs.
+
+    Every database connection that was open across the restore is then holding PostGIS's
+    per-backend operator cache pointed at objects that no longer exist. `COUNT(*)` still works
+    because it touches no spatial operator; anything using `&&` or `ST_Intersects` fails with
+    `no spatial operator found for 'st_intersects': opfamily N type M` until the process is
+    restarted. Observed in production on the demo instance, where the hourly reset restores under a
+    live API: two errors an hour apart named two different pairs of OIDs, which is the extension
+    being rebuilt underneath the running service.
+
+    `pool_pre_ping` does not help — those connections are alive and healthy, and `SELECT 1` passes.
+    The only reliable fix is to stop the OIDs changing at all: a data restore has no business
+    replacing the extension. The dump's tables and indexes bind to it by name, so leaving the
+    installed one alone is both correct and what every other object in the dump expects.
+    """
+    kept = []
+    for line in toc.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(";"):
+            kept.append(line)               # comments and blanks are inert; keep the file readable
+            continue
+        # `id; catalog oid TYPE ...` — the type is the token after the two numeric oids.
+        parts = stripped.split()
+        obj_type = parts[3] if len(parts) > 3 else ""
+        if obj_type in _TOC_EXTENSION_TYPES:
+            continue
+        # `COMMENT - EXTENSION postgis` — a comment whose target is an extension.
+        if obj_type == "COMMENT" and "EXTENSION" in parts[4:6]:
+            continue
+        kept.append(line)
+    return "\n".join(kept) + "\n"
+
+
+def _pg_env(settings):
+    return dict(os.environ, PGPASSWORD=settings.postgis_password or "")
+
+
+def _pg_conn_args(settings) -> list:
+    return ["-h", settings.postgis_host or "postgres",
+            "-p", str(settings.postgis_port or 5432),
+            "-U", settings.postgis_user or "geodeploy",
+            "-d", settings.postgis_db or "geodeploy"]
+
+
 def restore_database(dump_path: str) -> dict:
     """`pg_restore --clean --if-exists` over the live database.
 
@@ -122,13 +179,47 @@ def restore_database(dump_path: str) -> dict:
     to drop. `--no-owner/--no-acl` because the dump may come from an install whose DB role differs.
     """
     settings = get_settings()
-    env = dict(os.environ, PGPASSWORD=settings.postgis_password or "")
-    cmd = ["pg_restore", "-h", settings.postgis_host or "postgres",
-           "-p", str(settings.postgis_port or 5432),
-           "-U", settings.postgis_user or "geodeploy",
-           "-d", settings.postgis_db or "geodeploy",
-           "--clean", "--if-exists", "--no-owner", "--no-acl", dump_path]
-    proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=6 * 3600)
+    env = _pg_env(settings)
+    conn = _pg_conn_args(settings)
+
+    # The extension must EXIST before the restore (a fresh instance may have none) and must not be
+    # touched BY it (see toc_without_extensions). Failure here is not fatal: a managed Postgres may
+    # refuse `CREATE EXTENSION` to a non-superuser, and on any instance that already has PostGIS —
+    # which is every instance with a vector layer — the statement is a no-op anyway.
+    ensure = subprocess.run(["psql", *conn, "-v", "ON_ERROR_STOP=0", "-c",
+                             "CREATE EXTENSION IF NOT EXISTS postgis"],
+                            env=env, capture_output=True, text=True, timeout=300)
+    if ensure.returncode != 0:
+        logger.warning("restore: could not ensure the postgis extension (%s) — continuing, the "
+                       "database may already have it", (ensure.stderr or "").strip()[:200])
+
+    # Filter the TOC rather than restoring the dump wholesale, so `--clean` never emits
+    # `DROP EXTENSION`. If listing fails for any reason we fall back to the plain restore: a
+    # restore that works and may strand open connections beats no restore at all.
+    toc_path = None
+    listing = subprocess.run(["pg_restore", "-l", dump_path],
+                             env=env, capture_output=True, text=True, timeout=3600)
+    if listing.returncode == 0 and listing.stdout.strip():
+        fd, toc_path = tempfile.mkstemp(suffix=".toc", prefix="gd-restore-")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(toc_without_extensions(listing.stdout))
+    else:
+        logger.warning("restore: pg_restore -l failed (%s) — restoring without a TOC filter; open "
+                       "connections may need the services restarted afterwards",
+                       (listing.stderr or "").strip()[:200])
+
+    cmd = ["pg_restore", *conn, "--clean", "--if-exists", "--no-owner", "--no-acl"]
+    if toc_path:
+        cmd += ["-L", toc_path]
+    cmd.append(dump_path)
+    try:
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=6 * 3600)
+    finally:
+        if toc_path:
+            try:
+                os.unlink(toc_path)
+            except OSError:
+                pass
     # pg_restore exits non-zero for benign "does not exist, skipping" noise under --clean, so a
     # failure is judged on stderr content, not the code alone.
     err = (proc.stderr or "").strip()

--- a/api/geodeploy/tasks/README.md
+++ b/api/geodeploy/tasks/README.md
@@ -190,7 +190,11 @@ Celery background workers that run the upload → ready pipelines so HTTP reques
   api leaves celery running stale code → tasks fail as "unregistered" or run the old logic).
 
 ## Last updated
-2026-08-07 (**a world shapefile 500'd every Martin tile, because of Antarctica.** `vector_ingest`
+2026-09-02 (`restore.py`: `_recycle_own_connections()` disposes this worker's engine after the
+database is replaced, beside the schema and Martin repairs. A connection open across a restore keeps
+backend-local caches describing objects that were dropped and rebuilt; celery both RUNS the restore
+and serves bbox-clipped exports, so it is the most exposed process.)
+
 now clips 4326 storage to the Web Mercator band via `_store_geom_sql` (±85.05112878°). EPSG:3857 is
 undefined past that, and PROJ does not degrade — it raises `transform: tolerance condition error
 (-20)` (lwgeom_pg.c) inside **Martin's own** ST_Transform, so Martin returns 500 for every tile at

--- a/api/geodeploy/tasks/restore.py
+++ b/api/geodeploy/tasks/restore.py
@@ -120,6 +120,7 @@ def restore_snapshot(cfg, key: str, manifest: dict, tmp_dir: str, on_step=None) 
         detail["own_db"] = _restore_own_db_settings()
         detail["own_storage"] = _restore_own_storage_settings()
         detail["schema"] = _reapply_schema_migrations()
+        detail["pool"] = _recycle_own_connections()
         detail["stale_runs_cleared"] = _clear_restored_running_rows()
         # Keep the destination we just read the backup FROM, when the restored copy is unreadable.
         detail["backup_destination"] = _restore_backup_destination(saved_destination)
@@ -496,6 +497,37 @@ def _republish_portals() -> dict:
     except Exception as exc:      # noqa: BLE001
         logger.warning("restore: portal republish pass failed: %s", exc)
         return {"rebuilt": 0, "failed": [str(exc)[:200]]}
+
+
+def _recycle_own_connections() -> dict:
+    """Drop this worker's pooled connections after the database has been replaced.
+
+    A restore is DDL on a live system, and a connection open across it keeps backend-local caches
+    describing objects that were dropped and rebuilt. `pool_pre_ping` does not catch that: the
+    connection is alive and `SELECT 1` succeeds — it is the CONTENTS of the caches that are wrong.
+
+    This worker is the process most exposed to it, because it is the one that just ran the restore
+    and it holds the sessions bbox-clipped exports run on. Disposing the engine here is in-process
+    and cheap; the pool refills lazily with connections that see the new database.
+
+    The API is a separate process and cannot be reached from here — which is why the real fix is
+    `services/restore.toc_without_extensions`, keeping the PostGIS extension (and therefore every
+    type and operator OID) untouched so that no session goes stale in the first place. This is the
+    belt to that pair of braces.
+    """
+    try:
+        from .. import database
+
+        engine = getattr(database, "engine", None)
+        if engine is None:
+            return {"disposed": False, "reason": "no engine on this process"}
+        import asyncio
+
+        asyncio.run(engine.dispose())
+        return {"disposed": True}
+    except Exception as exc:      # noqa: BLE001 — the data is back; a stale pool is not worth failing over
+        logger.warning("restore: could not recycle this worker's connections: %s", exc)
+        return {"disposed": False, "error": str(exc)[:200]}
 
 
 def _regenerate_martin() -> None:

--- a/api/tests/test_restore_keeps_extension.py
+++ b/api/tests/test_restore_keeps_extension.py
@@ -1,0 +1,107 @@
+"""A restore must not drop and recreate the PostGIS extension.
+
+THE BUG. `pg_restore --clean` drops the objects in the dump in reverse dependency order, so tables
+go first and `DROP EXTENSION postgis` — which the dump also carries — runs when nothing depends on
+it any more. It therefore SUCCEEDS, and `CREATE EXTENSION` rebuilds `geometry` and
+`gist_geometry_ops_2d` with NEW OIDs.
+
+Every connection open across that restore then holds PostGIS's per-backend operator cache pointing
+at objects that no longer exist. `COUNT(*)` keeps working, because it touches no spatial operator;
+every query using `&&` or `ST_Intersects` fails with
+
+    no spatial operator found for 'st_intersects': opfamily N type M
+
+until the process is restarted. It was found on the demo instance, whose hourly reset restores under
+a live API: two errors an hour apart named two DIFFERENT pairs of OIDs, which is the extension being
+rebuilt underneath the running service. `pool_pre_ping` cannot catch it — those connections are
+alive and `SELECT 1` succeeds; it is the cache contents that are stale.
+
+The invariant these tests pin is therefore about identity, not behaviour: the geometry type's OID
+must be the SAME object before and after a restore.
+"""
+import pytest
+
+from geodeploy.services.restore import toc_without_extensions
+
+
+# A `pg_restore -l` listing, in the real format: `id; catalog oid TYPE schema name owner`.
+TOC = """;
+; Archive created at 2026-09-02 06:00:00 UTC
+;     dbname: geodeploy
+;     TOC Entries: 9
+;
+; Selected TOC Entries:
+;
+2; 3079 16385 EXTENSION - postgis
+3; 0 0 COMMENT - EXTENSION postgis
+4; 3079 16800 EXTENSION - postgis_topology
+5; 0 0 COMMENT - EXTENSION postgis_topology
+6; 2615 16390 SCHEMA - geodeploy_u1 geodeploy
+7; 0 0 COMMENT - SCHEMA geodeploy_u1 geodeploy
+215; 1259 16700 TABLE geodeploy_u1 gdp_per_capita geodeploy
+216; 1259 16701 SEQUENCE public vector_layers_id_seq geodeploy
+4210; 0 16700 TABLE DATA geodeploy_u1 gdp_per_capita geodeploy
+4300; 2606 16720 CONSTRAINT geodeploy_u1 gdp_per_capita_pkey geodeploy
+4301; 1259 16721 INDEX geodeploy_u1 gdp_per_capita_geom_idx geodeploy
+"""
+
+
+def test_the_extension_is_never_replayed():
+    """The whole fix: no EXTENSION entry survives, so `--clean` emits no DROP EXTENSION and the
+    geometry type keeps the OID every open connection already cached."""
+    out = toc_without_extensions(TOC)
+    lines = [l for l in out.splitlines() if l.strip() and not l.strip().startswith(";")]
+
+    assert not [l for l in lines if " EXTENSION " in f" {l} "], out
+    assert "postgis_topology" not in out          # every extension, not just postgis
+    assert "COMMENT - EXTENSION" not in out       # and the comments hanging off them
+
+
+def test_everything_else_survives():
+    """A restore that dropped more than the extension would be a worse bug than the one being
+    fixed — the point is to restore the data, and only the extension is exempt."""
+    out = toc_without_extensions(TOC)
+
+    for kept in ("TABLE geodeploy_u1 gdp_per_capita",
+                 "TABLE DATA geodeploy_u1 gdp_per_capita",
+                 "SEQUENCE public vector_layers_id_seq",
+                 "CONSTRAINT geodeploy_u1 gdp_per_capita_pkey",
+                 "INDEX geodeploy_u1 gdp_per_capita_geom_idx",
+                 "SCHEMA - geodeploy_u1"):
+        assert kept in out, f"{kept!r} was dropped from the TOC"
+
+
+def test_a_comment_on_something_else_is_not_mistaken_for_an_extension_comment():
+    """`COMMENT - SCHEMA ...` and `COMMENT - EXTENSION ...` differ only in one token, and dropping
+    the wrong one silently loses a schema comment."""
+    out = toc_without_extensions(TOC)
+    assert "COMMENT - SCHEMA geodeploy_u1" in out
+
+
+def test_the_header_survives_because_pg_restore_reads_this_file_back():
+    """`-L` takes the same format it emits; the leading comment block is inert but pg_restore is
+    handed the file verbatim, so mangling it is a needless risk."""
+    out = toc_without_extensions(TOC)
+    assert out.startswith(";")
+    assert "; Selected TOC Entries:" in out
+    assert out.endswith("\n")
+
+
+def test_an_empty_or_header_only_listing_does_not_crash():
+    """`pg_restore -l` on a dump with nothing in it, and the degenerate empty string. The caller
+    falls back to an unfiltered restore when listing fails, so this must not raise instead."""
+    assert toc_without_extensions("") == "\n"
+    header_only = ";\n; Archive created at 2026-09-02\n;\n"
+    assert toc_without_extensions(header_only).count(";") == 3
+
+
+def test_a_short_line_is_kept_rather_than_indexed_past_its_end():
+    """Defensive: a malformed line must not raise IndexError inside a restore. Keeping it is the
+    safe direction — pg_restore judges it, and an unknown line is not an extension."""
+    assert "999; 0" in toc_without_extensions("999; 0\n")
+
+
+@pytest.mark.parametrize("obj_type", ["TABLE", "INDEX", "SEQUENCE", "VIEW", "FUNCTION", "TYPE"])
+def test_no_other_object_type_is_swept_up(obj_type):
+    line = f"300; 1259 16999 {obj_type} public thing geodeploy"
+    assert line in toc_without_extensions(f";\n{line}\n")

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ description: >-
 
 # Roadmap
 
-GeoDeploy is at **v1.5.1**. Everything under *In v1.0* and in the releases after it is built and
+GeoDeploy is at **v1.5.2**. Everything under *In v1.0* and in the releases after it is built and
 running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
@@ -308,6 +308,24 @@ which is the only way this list could have been written.</p>
 
 </div>
 
+<div class="gd-rel done" markdown>
+### v1.5.2 — a restore that leaves spatial queries working
+<span class="gd-when">Shipped · 2 Sep 2026</span>
+
+<p class="gd-goal">A backup you cannot restore is a guess — and so is one that restores while
+quietly breaking every spatial query until somebody restarts the service.</p>
+
+- [x] **The restore no longer replaces the PostGIS extension.** `--clean` dropped it successfully
+      (tables go first, so nothing depends on it by then) and the rebuilt `geometry` type came back
+      with new OIDs, stranding every connection open across the restore. Spatial predicates failed;
+      `COUNT(*)` did not, which is what made it look like a dashboard bug
+- [x] **The worker recycles its connections after a restore**, beside the schema and Martin repairs
+      it already did
+- [x] **A 502 logs the exception it was raised for** — the message naming the cause used to reach
+      only the response body, which neither the service log nor the dashboard shows
+
+</div>
+
 ---
 
 ## Next up
@@ -478,7 +496,7 @@ the tile URLs are all already served. This is about giving them somewhere to be 
       backup, without a shell. Today `GEODEPLOY_SECRET_KEY` is edited in `.env` only, and is
       deliberately absent from the environment editor: setting it in place would leave every
       already-encrypted setting unreadable, with no error at the moment of the change.
-- [ ] Choose a version when updating — hold back, or step down after a bad one
+- [x] Choose a version when updating — hold back, or step down after a bad one ([four targets](updating.md#choosing-a-version): development, latest release, a specific release, or a branch)
 - [ ] Unattended install from environment variables, so provisioning can be scripted
 
 </div>
@@ -489,7 +507,6 @@ the tile URLs are all already served. This is about giving them somewhere to be 
 
 <p class="gd-goal">Capabilities that change what a portal can be.</p>
 
-- [ ] **Dashboard experience** — charts, stats and filters bound to layer attributes
 - [ ] **Temporal layers** with a time slider
 - [ ] **3D terrain and 3D tiles** in the globe view
 - [ ] Live connectors — scheduled re-sync, so published maps stay current

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Restoring a backup onto a running instance left it unable to answer any spatial
query until the service was restarted.

## What happened

`pg_restore --clean` drops the objects in the dump in reverse dependency order.
Tables go first, so by the time it reaches the `DROP EXTENSION postgis` the dump
also carries, nothing depends on the extension any more and the drop **succeeds**.
`CREATE EXTENSION` then rebuilds `geometry` and `gist_geometry_ops_2d` with new
OIDs.

Every connection open across the restore keeps PostGIS's per-backend operator
cache pointing at objects that no longer exist:

```
no spatial operator found for 'st_intersects': opfamily 948077 type 947963
```

`COUNT(*)` kept working — it touches no spatial operator — so a dashboard showed
a healthy map with every widget reporting `Request failed (502)` the moment you
drew a box.

Found on the demo instance, whose hourly reset restores under a live API. Two
errors an hour apart named two *different* pairs of OIDs, which is the extension
being rebuilt underneath the running service. Restarting the API fixed it with no
database change, which identified the cause.

`pool_pre_ping` is already enabled and cannot catch this: the connections are
alive and `SELECT 1` succeeds. It is the cache contents that are stale.

## The fix

- **`services/restore.py`** — `toc_without_extensions()` strips `EXTENSION`
  entries (and comments on them) from the `pg_restore -l` listing; the restore
  runs with `-L`. The extension's OIDs never change, so no session is stranded.
  `CREATE EXTENSION IF NOT EXISTS postgis` runs first so a fresh instance still
  restores, and a failed listing falls back to the old unfiltered path.
- **`tasks/restore.py`** — the worker disposes its own pool afterwards, beside
  the schema and Martin repairs it already performed. Celery runs the restore
  *and* serves bbox-clipped exports.
- **`routers/data/vector.py`** — a 502 now logs the exception it was raised for.
  Seven handlers turned an error into `HTTPException(502, f"...: {exc}")` and
  logged nothing, so the string naming the cause reached only the response body.
  Diagnosing this one meant reproducing it with `curl` to read a body the browser
  had already discarded.

## Tests

12 over the TOC filter: every extension dropped, everything else kept, a
`COMMENT - SCHEMA` not mistaken for a `COMMENT - EXTENSION`, the header preserved
because `pg_restore -L` reads the file back, and malformed or empty listings not
raising.

## Also

Roadmap sanitised — "Dashboard experience" was still listed under *Exploring*
after shipping as v1.5, and "Choose a version when updating" was unticked though
`docs/updating.md` documents all four targets.