### PR TITLE
v1.5.3 — finish the restore fix; v1.5.2 could not restore at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ upgrade needs manual work.
 
 ## Unreleased
 
+## v1.5.3 — 2026-09-02
+
+**Fixes a regression in v1.5.2.** If you are on v1.5.2 and your database has `postgis_topology` or
+`postgis_tiger_geocoder` installed — which the standard PostGIS image does — restoring a backup
+fails outright. Take this one.
+
+- **A restore no longer fails on the schemas its extensions own.** v1.5.2 stopped the restore
+  dropping the PostGIS extensions, which was right, but their schemas (`topology`, `tiger`) then
+  could not be dropped *or* recreated either. `pg_restore` reported `cannot drop schema topology
+  because other objects depend on it` and `schema "tiger" already exists`, neither of which was on
+  the tolerated list, so the restore raised and did nothing. Both are now recognised as the intended
+  outcome — the schema is exactly where it should be. `already exists` is tolerated for schemas
+  only; a table that already exists still fails, because that would mean `--clean` did not drop
+  something it was meant to replace.
+- **A missing `psql` can no longer fail a restore.** v1.5.2 added a `CREATE EXTENSION IF NOT EXISTS
+  postgis` step before the restore. A missing binary raises rather than returning an exit code, so
+  on an image without `postgresql-client` that best-effort step would have taken the whole restore
+  down with it. It now degrades to a warning, as intended.
+- **An end-to-end restore test.** Builds a real spatial table, dumps it the way `backup.py` does,
+  restores it through `restore_database()`, and asserts the rows return, the `geometry` type keeps
+  the SAME OID, and `&&` / `ST_Intersects` still run. The v1.5.2 regression is exactly what it
+  caught; the previous tests covered the table-of-contents filter as a pure function and could not
+  see it.
+
 ## v1.5.2 — 2026-09-02
 
 A restore could leave a running instance unable to answer any spatial query. One fix, and the

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.5.2",
+    version="1.5.3",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/api/geodeploy/services/restore.py
+++ b/api/geodeploy/services/restore.py
@@ -105,12 +105,23 @@ _BENIGN_RESTORE_ERRORS = (
     "cannot drop extension",
     "must be owner of extension",       # a managed Postgres refuses the drop for a different reason
     "extension \"postgis\" already exists",
+    # KEEPING the extensions has a consequence: the schemas they own (`topology` and `tiger` from
+    # postgis_topology and postgis_tiger_geocoder, which the standard postgis image installs) now
+    # survive the restore too. The dump still carries their DROP and CREATE, so pg_restore reports
+    # that it cannot drop a schema things depend on, and then that the schema already exists. Both
+    # are the intended outcome stated as an error — the schema is exactly where it should be.
+    "cannot drop schema",
+    "must be owner of schema",
 )
 
 
 def _benign(line: str) -> bool:
     low = line.lower()
-    return any(marker.lower() in low for marker in _BENIGN_RESTORE_ERRORS)
+    if any(marker.lower() in low for marker in _BENIGN_RESTORE_ERRORS):
+        return True
+    # `schema "tiger" already exists` — tolerated, while a TABLE that already exists is not, because
+    # that would mean `--clean` failed to drop something it was supposed to replace.
+    return 'already exists' in low and 'schema "' in low
 
 
 #: Entry types in a `pg_restore -l` table of contents that must never be replayed.
@@ -186,19 +197,33 @@ def restore_database(dump_path: str) -> dict:
     # touched BY it (see toc_without_extensions). Failure here is not fatal: a managed Postgres may
     # refuse `CREATE EXTENSION` to a non-superuser, and on any instance that already has PostGIS —
     # which is every instance with a vector layer — the statement is a no-op anyway.
-    ensure = subprocess.run(["psql", *conn, "-v", "ON_ERROR_STOP=0", "-c",
-                             "CREATE EXTENSION IF NOT EXISTS postgis"],
-                            env=env, capture_output=True, text=True, timeout=300)
-    if ensure.returncode != 0:
-        logger.warning("restore: could not ensure the postgis extension (%s) — continuing, the "
-                       "database may already have it", (ensure.stderr or "").strip()[:200])
+    #
+    # OSError as well as a non-zero exit: `psql` is a NEW dependency of this function, and the one
+    # thing it must never do is turn a working restore into a failed one. The image pins
+    # postgresql-client-16 for pg_dump, so it is there — but a missing binary raises FileNotFoundError
+    # from subprocess.run rather than returning a code, and letting that escape would mean an
+    # instance that can no longer restore at all. This step is best-effort by design: every instance
+    # that has a vector layer already has the extension.
+    try:
+        ensure = subprocess.run(["psql", *conn, "-v", "ON_ERROR_STOP=0", "-c",
+                                 "CREATE EXTENSION IF NOT EXISTS postgis"],
+                                env=env, capture_output=True, text=True, timeout=300)
+        if ensure.returncode != 0:
+            logger.warning("restore: could not ensure the postgis extension (%s) — continuing, the "
+                           "database may already have it", (ensure.stderr or "").strip()[:200])
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("restore: could not run psql to ensure the postgis extension (%s) — "
+                       "continuing; the database almost certainly already has it", exc)
 
     # Filter the TOC rather than restoring the dump wholesale, so `--clean` never emits
     # `DROP EXTENSION`. If listing fails for any reason we fall back to the plain restore: a
     # restore that works and may strand open connections beats no restore at all.
     toc_path = None
-    listing = subprocess.run(["pg_restore", "-l", dump_path],
-                             env=env, capture_output=True, text=True, timeout=3600)
+    try:
+        listing = subprocess.run(["pg_restore", "-l", dump_path],
+                                 env=env, capture_output=True, text=True, timeout=3600)
+    except (OSError, subprocess.SubprocessError) as exc:
+        listing = subprocess.CompletedProcess([], 1, "", str(exc))
     if listing.returncode == 0 and listing.stdout.strip():
         fd, toc_path = tempfile.mkstemp(suffix=".toc", prefix="gd-restore-")
         with os.fdopen(fd, "w", encoding="utf-8") as fh:

--- a/api/tests/test_restore_roundtrip.py
+++ b/api/tests/test_restore_roundtrip.py
@@ -1,0 +1,142 @@
+"""A real dump, restored by the real code path, asserting the thing that actually broke.
+
+`test_restore_keeps_extension.py` covers the TOC filter as a pure function. This is the other half:
+take a dump made the way `services/backup.py` makes them — including the `CREATE EXTENSION postgis`
+every such dump carries — restore it with `restore_database()`, and check that
+
+  1. the data comes back, and
+  2. the `geometry` type is the SAME OBJECT afterwards, and
+  3. a spatial query still runs.
+
+(2) is the invariant. Before the fix, `--clean` dropped the extension successfully (tables go first,
+so nothing depends on it by then) and `CREATE EXTENSION` rebuilt it with a new OID, stranding every
+connection that was open across the restore. This test would have failed on that.
+
+It also answers the question a user asks after a fix like this: do the backups I already have still
+restore? They are ordinary `pg_dump -Fc` archives and nothing about the backup side changed, so the
+dump built here is the same shape as one taken months ago.
+"""
+import os
+import subprocess
+
+import pytest
+
+from geodeploy.config import get_settings
+from geodeploy.services.restore import restore_database
+
+def _have(binary: str) -> bool:
+    """`which` is not universally present in a slim image, so ask the binary itself."""
+    try:
+        return subprocess.run([binary, "--version"], capture_output=True, timeout=30).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+# CI runs on a runner that carries the postgres client tools, so these DO run there. A local image
+# built without postgresql-client skips them rather than failing — but a silent skip is how a
+# regression test stops testing anything, so the reason names the missing tool.
+_MISSING = [b for b in ("pg_dump", "pg_restore", "psql") if not _have(b)]
+pytestmark = pytest.mark.skipif(
+    bool(_MISSING), reason=f"postgres client tools not on PATH: {', '.join(_MISSING)}")
+
+TABLE = "gd_restore_roundtrip"
+
+
+def _psql(sql: str) -> str:
+    s = get_settings()
+    env = dict(os.environ, PGPASSWORD=s.postgis_password or "")
+    proc = subprocess.run(
+        ["psql", "-h", s.postgis_host or "postgres", "-p", str(s.postgis_port or 5432),
+         "-U", s.postgis_user or "geodeploy", "-d", s.postgis_db or "geodeploy",
+         "-tAc", sql],
+        env=env, capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, f"psql failed: {proc.stderr.strip()}\nSQL: {sql}"
+    return proc.stdout.strip()
+
+
+def _dump(path: str) -> None:
+    s = get_settings()
+    env = dict(os.environ, PGPASSWORD=s.postgis_password or "")
+    proc = subprocess.run(
+        ["pg_dump", "-h", s.postgis_host or "postgres", "-p", str(s.postgis_port or 5432),
+         "-U", s.postgis_user or "geodeploy", "-d", s.postgis_db or "geodeploy",
+         "-Fc", "--no-owner", "--no-acl", "-f", path],
+        env=env, capture_output=True, text=True, timeout=600)
+    assert proc.returncode == 0, f"pg_dump failed: {proc.stderr.strip()}"
+
+
+@pytest.fixture
+def spatial_table():
+    _psql("CREATE EXTENSION IF NOT EXISTS postgis")
+    _psql(f"DROP TABLE IF EXISTS {TABLE}")
+    _psql(f"CREATE TABLE {TABLE} (id serial PRIMARY KEY, name text, geom geometry(Point, 4326))")
+    _psql(f"CREATE INDEX {TABLE}_geom_idx ON {TABLE} USING gist (geom)")
+    _psql(f"INSERT INTO {TABLE} (name, geom) VALUES "
+          "('ankara', ST_SetSRID(ST_MakePoint(32.85, 39.93), 4326)), "
+          "('athens', ST_SetSRID(ST_MakePoint(23.73, 37.98), 4326)), "
+          "('oslo',   ST_SetSRID(ST_MakePoint(10.75, 59.91), 4326))")
+    yield
+    _psql(f"DROP TABLE IF EXISTS {TABLE}")
+
+
+def _geometry_oid() -> str:
+    return _psql("SELECT oid FROM pg_type WHERE typname = 'geometry'")
+
+
+def test_a_restore_keeps_the_geometry_type_the_same_object(tmp_path, spatial_table):
+    """THE regression. A new OID here means every connection open across the restore is stranded."""
+    dump = str(tmp_path / "roundtrip.dump")
+    _dump(dump)
+    before = _geometry_oid()
+
+    _psql(f"DELETE FROM {TABLE} WHERE name = 'oslo'")
+    restore_database(dump)
+
+    assert _geometry_oid() == before, (
+        "the PostGIS extension was rebuilt by the restore; every session open across it now holds "
+        "an operator cache pointing at objects that no longer exist"
+    )
+
+
+def test_the_data_comes_back(tmp_path, spatial_table):
+    """A restore that protects the extension and loses the rows would be a worse bug."""
+    dump = str(tmp_path / "roundtrip.dump")
+    _dump(dump)
+
+    _psql(f"DELETE FROM {TABLE}")
+    assert _psql(f"SELECT count(*) FROM {TABLE}") == "0"
+
+    restore_database(dump)
+    assert _psql(f"SELECT count(*) FROM {TABLE}") == "3"
+    assert _psql(f"SELECT name FROM {TABLE} WHERE name = 'oslo'") == "oslo"
+
+
+def test_spatial_queries_still_run_after_a_restore(tmp_path, spatial_table):
+    """The symptom as the user meets it: `COUNT(*)` keeps working while anything touching a spatial
+    operator fails. Both are asserted, because only the second one ever broke."""
+    dump = str(tmp_path / "roundtrip.dump")
+    _dump(dump)
+    restore_database(dump)
+
+    assert _psql(f"SELECT count(*) FROM {TABLE}") == "3"
+
+    box = "ST_MakeEnvelope(20, 35, 45, 45, 4326)"
+    assert _psql(f"SELECT count(*) FROM {TABLE} WHERE geom && {box}") == "2"
+    assert _psql(f"SELECT count(*) FROM {TABLE} "
+                 f"WHERE geom && {box} AND ST_Intersects(geom, {box})") == "2"
+
+
+def test_the_index_is_still_bound_to_a_live_operator_family(tmp_path, spatial_table):
+    """The error named an opfamily and a type. After a restore they must still resolve to each
+    other, which is what `no spatial operator found` means when they do not."""
+    dump = str(tmp_path / "roundtrip.dump")
+    _dump(dump)
+    restore_database(dump)
+
+    family = _psql(
+        "SELECT o.opcfamily FROM pg_index i JOIN pg_opclass o ON o.oid = i.indclass[0] "
+        f"WHERE i.indrelid = '{TABLE}'::regclass AND o.opcname LIKE 'gist_geometry%'")
+    assert family, "the spatial index did not survive the restore"
+    assert _psql(f"SELECT count(*) FROM pg_amop WHERE amopfamily = {family}") != "0", (
+        "the operator family survived as an empty shell — the index exists but no operator resolves"
+    )

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ description: >-
 
 # Roadmap
 
-GeoDeploy is at **v1.5.2**. Everything under *In v1.0* and in the releases after it is built and
+GeoDeploy is at **v1.5.3**. Everything under *In v1.0* and in the releases after it is built and
 running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
@@ -323,6 +323,24 @@ quietly breaking every spatial query until somebody restarts the service.</p>
       it already did
 - [x] **A 502 logs the exception it was raised for** — the message naming the cause used to reach
       only the response body, which neither the service log nor the dashboard shows
+
+</div>
+
+<div class="gd-rel done" markdown>
+### v1.5.3 — the restore fix, finished
+<span class="gd-when">Shipped · 2 Sep 2026</span>
+
+<p class="gd-goal">v1.5.2 kept the PostGIS extensions installed and then could not restore at all on
+a database that has <code>postgis_topology</code> or <code>postgis_tiger_geocoder</code> — which the
+standard image installs. A failed restore is worse than the bug it was fixing.</p>
+
+- [x] **A restore no longer fails on the schemas its extensions own** — `topology` and `tiger` can
+      be neither dropped nor recreated once the extension stays, and that is the intended outcome,
+      not an error
+- [x] **A missing `psql` degrades to a warning** rather than taking the restore down with it
+- [x] **An end-to-end restore test** — dump a real spatial table, restore it through the real code
+      path, assert the rows come back and the `geometry` type keeps the same OID. It is what caught
+      the v1.5.2 regression, which the pure-function tests could not see
 
 </div>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**Fixes a regression in v1.5.2.** On a database with `postgis_topology` or
`postgis_tiger_geocoder` — which the standard PostGIS image installs — v1.5.2
cannot restore a backup at all.

## What v1.5.2 broke

Keeping the PostGIS extensions installed was the right fix for the stranded
connections. It also made the schemas those extensions own (`topology`, `tiger`)
impossible to drop *and* impossible to recreate. The dump still carries both
statements:

```
pg_restore: error: cannot drop schema topology because other objects depend on it
pg_restore: error: schema "tiger" already exists
```

Neither was on the tolerated list, so `restore_database` raised and the restore
did nothing. A degraded restore is recoverable by restarting a service; a failed
one leaves you with no restore.

## The fix

- Both outcomes are recognised as the intent of keeping the extension, stated as
  an error. `already exists` is tolerated for **schemas only** — a table that
  already exists still fails, because that would mean `--clean` did not drop
  something it was meant to replace.
- The `CREATE EXTENSION IF NOT EXISTS postgis` step v1.5.2 added calls `psql`,
  and a missing binary raises rather than returning an exit code — so a
  best-effort step could have taken the whole restore down. Both new subprocess
  calls now degrade to a warning.

## The test that should have come first

`test_restore_roundtrip.py` dumps a real spatial table the way `backup.py` does,
restores it through `restore_database()`, and asserts the rows come back, the
`geometry` type keeps the **same OID**, and `&&` / `ST_Intersects` still run.

That is what caught this. The existing tests cover the table-of-contents filter
as a pure function; they passed throughout and could not see it. Its skip guard
also asks each binary directly instead of shelling out to `which`, which exists
in a slim image where the postgres tools do not — the first run skipped silently.

16 tests pass against PostGIS 16 with a version-matched client.