### PR TITLE
v1.5.4 — a restore that does not lie about the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ upgrade needs manual work.
 
 ## Unreleased
 
+## v1.5.4 — 2026-09-02
+
+**A restore could leave an instance reporting "GeoDeploy cannot reach its database" while the
+database was answering perfectly.** Found on the demo, whose hourly reset restores under a live API.
+
+- **A restore now leaves `setup_config` as one row with its primary key.** `pg_restore --clean`
+  drops that table and recreates it EMPTY, and the API keeps serving throughout — that is what an
+  in-place restore means. The first request to read the instance's configuration finds no `id = 1`,
+  so a fresh default row is inserted into the gap. `pg_restore` then COPYs the snapshot's row on top
+  and its closing `ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id)` fails with `Key (id)=(1) is
+  duplicated`.
+
+  The table is then left with **two rows and no primary key, permanently** — and because the key is
+  gone, every later restore can add another. Which row the API reads decides whether it believes it
+  has a database, and the inserted one is blank: it names no host, so a healthy instance reports
+  itself unreachable. Published portals keep working throughout, because they are static bundles
+  served by nginx and never read `setup_config` — which makes the fault look stranger than it is.
+
+  The repair runs in the restore's repair phase, before `_restore_own_db_settings()`: that function
+  UPDATEs this row, and with duplicates present it would fix one copy while the API read the other.
+  It keeps whichever row names a database host, which is what distinguishes the snapshot's real row
+  from the placeholder, and puts the primary key back.
+
+**If you are on an affected instance**, updating repairs it at the next restore. To fix it
+immediately:
+
+```sql
+DELETE FROM setup_config WHERE ctid NOT IN (
+  SELECT ctid FROM setup_config
+   ORDER BY (coalesce(postgis_host, '') <> '') DESC, ctid LIMIT 1);
+ALTER TABLE setup_config ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id);
+```
+
 ## v1.5.3 — 2026-09-02
 
 **Fixes a regression in v1.5.2.** If you are on v1.5.2 and your database has `postgis_topology` or

--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,7 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.5.3",
+    version="1.5.4",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/api/geodeploy/tasks/README.md
+++ b/api/geodeploy/tasks/README.md
@@ -190,7 +190,12 @@ Celery background workers that run the upload → ready pipelines so HTTP reques
   api leaves celery running stale code → tasks fail as "unregistered" or run the old logic).
 
 ## Last updated
-2026-09-02 (`restore.py`: `_recycle_own_connections()` disposes this worker's engine after the
+2026-09-02 (`restore.py`: `_repair_setup_config()` collapses `setup_config` back to ONE row
+and restores its primary key. `pg_restore --clean` empties the table, the live API inserts a blank
+default into the gap, the snapshot's row lands on top and ADD CONSTRAINT fails — leaving two rows,
+no key, and an instance reporting "cannot reach its database" while the database answers. Runs
+BEFORE `_restore_own_db_settings()`, which updates that row. Plus `_recycle_own_connections()`.)
+
 database is replaced, beside the schema and Martin repairs. A connection open across a restore keeps
 backend-local caches describing objects that were dropped and rebuilt; celery both RUNS the restore
 and serves bbox-clipped exports, so it is the most exposed process.)

--- a/api/geodeploy/tasks/restore.py
+++ b/api/geodeploy/tasks/restore.py
@@ -117,6 +117,7 @@ def restore_snapshot(cfg, key: str, manifest: dict, tmp_dir: str, on_step=None) 
         # Repair what replacing the database broke — the schema is now the SNAPSHOT'S, and its
         # in-flight rows are frozen. Inside this function so no caller can forget them.
         # FIRST, before anything reads setup_config: the row now describes the snapshot's instance.
+        detail["setup_config"] = _repair_setup_config()
         detail["own_db"] = _restore_own_db_settings()
         detail["own_storage"] = _restore_own_storage_settings()
         detail["schema"] = _reapply_schema_migrations()
@@ -497,6 +498,61 @@ def _republish_portals() -> dict:
     except Exception as exc:      # noqa: BLE001
         logger.warning("restore: portal republish pass failed: %s", exc)
         return {"rebuilt": 0, "failed": [str(exc)[:200]]}
+
+
+#: `setup_config` holds ONE row, `id = 1`. These put it back to that when a restore has left more.
+_SETUP_CONFIG_REPAIR = (
+    # Keep a single row, preferring one that actually names a database host: the row the live API
+    # inserts during the restore is a bare `SetupConfig(id=1)` with every field defaulted, so
+    # "has a host" is what tells the snapshot's real row from the placeholder.
+    """DELETE FROM setup_config WHERE ctid NOT IN (
+         SELECT ctid FROM setup_config
+          ORDER BY (coalesce(postgis_host, '') <> '') DESC, ctid
+          LIMIT 1)""",
+    # And put the primary key back, which pg_restore could not add while the duplicate existed.
+    """DO $$
+       BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'setup_config_pkey') THEN
+           ALTER TABLE setup_config ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id);
+         END IF;
+       END $$""",
+)
+
+
+def _repair_setup_config() -> dict:
+    """Collapse `setup_config` back to one row with its primary key.
+
+    THE RACE. `pg_restore --clean` drops `setup_config` and recreates it EMPTY. The API is still
+    serving throughout — that is the whole point of an in-place restore — and the first request that
+    reads the instance's configuration finds no `id = 1`, so `routers/setup._get_or_create_config`
+    inserts a fresh default row into the gap. `pg_restore` then COPYs the snapshot's row in on top,
+    and its closing `ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id)` fails:
+
+        could not create unique index "setup_config_pkey"
+        DETAIL: Key (id)=(1) is duplicated.
+
+    The table is then left with two rows AND no primary key, permanently, and every later restore
+    can add another. Whichever row the API reads first decides whether it believes it has a
+    database: observed in production as "GeoDeploy cannot reach its database" on an instance whose
+    database was answering perfectly — the blank row won, and it names no host.
+
+    Ordered before `_restore_own_db_settings()` deliberately: that function UPDATEs this row, and
+    with duplicates present it would fix one copy while the API kept reading the other.
+
+    Not a new problem introduced by keeping the PostGIS extension (see `services/restore`), but the
+    same class: a restore is DDL against a live system, and everything it drops is missing for a
+    moment that something else can act on.
+    """
+    applied, failed = 0, []
+    for stmt in _SETUP_CONFIG_REPAIR:
+        try:
+            with state_db.connect() as conn:
+                conn.execute(stmt)
+            applied += 1
+        except Exception as exc:      # noqa: BLE001 — the data is back; report and carry on
+            logger.warning("restore: setup_config repair step failed: %s", exc)
+            failed.append(str(exc)[:200])
+    return {"applied": applied, "failed": failed}
 
 
 def _recycle_own_connections() -> dict:

--- a/api/tests/test_restore_setup_config.py
+++ b/api/tests/test_restore_setup_config.py
@@ -1,0 +1,142 @@
+"""A restore must leave `setup_config` as one row with its primary key.
+
+THE RACE. `pg_restore --clean` drops `setup_config` and recreates it EMPTY, while the API keeps
+serving — that is what an in-place restore means. The first request to read the instance's
+configuration finds no `id = 1` and `routers/setup._get_or_create_config` inserts a fresh default
+row into the gap. `pg_restore` then COPYs the snapshot's row on top, and its closing
+
+    ALTER TABLE ONLY public.setup_config ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id)
+
+fails with `Key (id)=(1) is duplicated`. The table is then left with two rows and NO primary key,
+permanently, and every later restore can add another.
+
+Which row the API reads decides whether it believes it has a database. Observed in production as
+"GeoDeploy cannot reach its database" on an instance whose database was answering perfectly: the
+blank row won, and a blank row names no host.
+
+These tests drive `_repair_setup_config()` against a real table, because the bug is entirely about
+what SQL leaves behind and a mock of the database would have asserted my own assumptions back at me.
+"""
+import subprocess
+
+import pytest
+
+from geodeploy import state_db
+from geodeploy.tasks.restore import _repair_setup_config
+
+
+def _have(binary: str) -> bool:
+    try:
+        return subprocess.run([binary, "--version"], capture_output=True, timeout=30).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _have("psql"), reason="psql not on PATH")
+
+
+def _rows():
+    with state_db.connect() as conn:
+        conn.row_factory = state_db.dict_row
+        return conn.execute(
+            "SELECT id, postgis_host, postgis_db FROM setup_config ORDER BY ctid").fetchall()
+
+
+def _has_pkey() -> bool:
+    with state_db.connect() as conn:
+        return bool(conn.execute(
+            "SELECT 1 FROM pg_constraint WHERE conname = 'setup_config_pkey'").fetchone())
+
+
+#: `setup_config` carries NOT NULL columns whose defaults live in the ORM, not the DDL, so a raw
+#: INSERT has to supply them. Reading them from the catalog rather than listing them keeps this
+#: test working when a release adds another one — which it will.
+def _insert_row(**values):
+    with state_db.connect() as conn:
+        conn.row_factory = state_db.dict_row
+        cols = conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name = 'setup_config' AND is_nullable = 'NO' "
+            "AND column_default IS NULL").fetchall()
+        zero = {"boolean": False, "integer": 0, "bigint": 0, "double precision": 0.0}
+        row = {c["column_name"]: zero.get(c["data_type"], "") for c in cols}
+        row.update(values)
+        names = ", ".join(row)
+        holes = ", ".join(["?"] * len(row))
+        conn.execute(f"INSERT INTO setup_config ({names}) VALUES ({holes})", tuple(row.values()))
+
+
+def _reset_table():
+    with state_db.connect() as conn:
+        conn.execute("ALTER TABLE setup_config DROP CONSTRAINT IF EXISTS setup_config_pkey")
+        conn.execute("DELETE FROM setup_config")
+
+
+@pytest.fixture
+def wrecked_setup_config():
+    """Exactly the state a restore leaves: the snapshot's row, a blank one the live API inserted,
+    and no primary key because ADD CONSTRAINT could not run over the duplicate."""
+    _reset_table()
+    # the blank row the API creates when it finds the table empty mid-restore: every field
+    # defaulted, which is what makes it recognisable
+    _insert_row(id=1, completed=False, postgis_port=5432)
+    # the snapshot's real row, COPYed in afterwards
+    _insert_row(id=1, completed=True, postgis_type="local", postgis_host="geodeploy-postgres",
+                postgis_port=5432, postgis_db="geodeploy", postgis_user="geodeploy")
+    yield
+    _reset_table()
+    _insert_row(id=1, completed=True, postgis_host="geodeploy-postgres", postgis_db="geodeploy")
+    with state_db.connect() as conn:
+        conn.execute("ALTER TABLE setup_config ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id)")
+
+
+def test_the_duplicate_is_collapsed_to_one_row(wrecked_setup_config):
+    assert len(_rows()) == 2, "fixture did not reproduce the duplicate"
+    _repair_setup_config()
+    assert len(_rows()) == 1
+
+
+def test_the_row_that_survives_is_the_one_naming_a_database(wrecked_setup_config):
+    """THE symptom. Keeping the blank row is what made a healthy instance report that it could not
+    reach its database — a row with no host names nothing to connect to."""
+    _repair_setup_config()
+    row = _rows()[0]
+    assert row["postgis_host"] == "geodeploy-postgres"
+    assert row["postgis_db"] == "geodeploy"
+
+
+def test_the_primary_key_comes_back(wrecked_setup_config):
+    """Without it every later restore can add another duplicate, so the damage compounds."""
+    assert not _has_pkey(), "fixture did not reproduce the missing key"
+    _repair_setup_config()
+    assert _has_pkey()
+
+
+def test_it_is_a_no_op_on_a_healthy_table(wrecked_setup_config):
+    """It runs after EVERY restore, and the overwhelmingly common case is nothing to fix. Repairing
+    twice must therefore change nothing the second time."""
+    _repair_setup_config()
+    before = _rows()
+    out = _repair_setup_config()
+    assert _rows() == before
+    assert _has_pkey()
+    assert not out["failed"], out
+
+
+def test_an_empty_table_does_not_raise(wrecked_setup_config):
+    """`--clean` truly emptied it and nothing has written yet — repairing must not be the thing
+    that fails the restore."""
+    _reset_table()
+    out = _repair_setup_config()
+    assert not out["failed"], out
+    assert _rows() == []
+
+
+def test_three_rows_are_collapsed_too(wrecked_setup_config):
+    """The table has no key while it is broken, so a second restore adds a third row. The repair
+    must handle the compounded case, not only the first one."""
+    _insert_row(id=1, completed=False, postgis_port=5432)
+    assert len(_rows()) == 3
+    _repair_setup_config()
+    assert len(_rows()) == 1
+    assert _rows()[0]["postgis_host"] == "geodeploy-postgres"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ description: >-
 
 # Roadmap
 
-GeoDeploy is at **v1.5.3**. Everything under *In v1.0* and in the releases after it is built and
+GeoDeploy is at **v1.5.4**. Everything under *In v1.0* and in the releases after it is built and
 running in production; the groups at the end are what comes next.
 
 <div class="gd-legend" markdown>
@@ -341,6 +341,23 @@ standard image installs. A failed restore is worse than the bug it was fixing.</
 - [x] **An end-to-end restore test** — dump a real spatial table, restore it through the real code
       path, assert the rows come back and the `geometry` type keeps the same OID. It is what caught
       the v1.5.2 regression, which the pure-function tests could not see
+
+</div>
+
+<div class="gd-rel done" markdown>
+### v1.5.4 — a restore that does not lie about the database
+<span class="gd-when">Shipped · 2 Sep 2026</span>
+
+<p class="gd-goal">An in-place restore is DDL against a live system. Everything it drops is missing
+for a moment that something else can act on — and one of those moments left an instance insisting it
+had no database.</p>
+
+- [x] **`setup_config` survives a restore as one row with its primary key.** The API inserts a blank
+      default row into the window where `--clean` has emptied the table, the snapshot's row lands on
+      top, and the primary key can no longer be created — leaving two rows, no key, and an instance
+      that reports "cannot reach its database" while the database answers normally
+- [x] Repaired before `_restore_own_db_settings()`, which updates that row and would otherwise fix
+      one copy while the API read the other
 
 </div>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geodeploy-ui",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Keep setup_config to one row across a restore

A restore could leave an instance reporting "GeoDeploy cannot reach its
database" while the database was answering perfectly.

`pg_restore --clean` drops setup_config and recreates it EMPTY, and the API
keeps serving throughout — that is what an in-place restore means. The first
request to read the instance's configuration finds no `id = 1`, so
`_get_or_create_config` inserts a fresh default row into the gap. pg_restore
then COPYs the snapshot's row on top and its closing

    ALTER TABLE ONLY public.setup_config
        ADD CONSTRAINT setup_config_pkey PRIMARY KEY (id)

fails with `Key (id)=(1) is duplicated`. Two rows, no primary key, permanently
— and without the key every later restore can add another.

Whichever row the API reads decides whether it believes it has a database, and
the inserted one is blank: it names no host, so a healthy instance reports
itself unreachable. Published portals keep working the whole time, because they
are static bundles served by nginx and never read setup_config, which makes the
fault look stranger than it is.

_repair_setup_config() runs in the repair phase BEFORE _restore_own_db_settings(),
which updates this row and would otherwise fix one copy while the API read the
other. It keeps whichever row names a database host — the discriminator is that
the row the API inserts is a bare SetupConfig(id=1) with every field defaulted —
and puts the key back.

Six tests against a real table: the duplicate collapses, the surviving row is
the one naming a database, the key returns, it is a no-op on a healthy table, an
empty table does not raise, and three rows collapse too. Their fixtures read the
NOT NULL columns from information_schema rather than listing them, because those
defaults live in the ORM and a hand-written INSERT goes stale the next time a
column is added.

Found in production on the demo instance.
