### PR TITLE
"No basemap" removes the basemap, rather than only hiding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ upgrade needs manual work.
 
 ## Unreleased
 
+- **"No basemap" now actually removes the basemap.** Choosing it in the portal editor appeared to
+  do nothing, and the reason was not in the editor: its preview is a real published bundle, and the
+  bundle builder looked `__none__` up in the basemap catalog, found nothing (there is no service
+  behind it — it is the absence of one) and left the template's own basemap in place. The runtime
+  switcher could still turn it off afterwards, which is why it seemed that only the published
+  portal honoured the setting. The basemap is now taken out of the style at publish, on a white
+  ground, so a portal opens the way it was authored with no flash of a map nobody asked for.
+
 ## v1.6 — 2026-09-10
 
 ### The QGIS round trip, closed

--- a/api/geodeploy/services/README.md
+++ b/api/geodeploy/services/README.md
@@ -314,6 +314,7 @@ range. `test_per_class_symbology.py` pins that.
 symbols for classes the map draws differently.
 
 ## Last updated
+2026-09-11 (**`apply_basemap_choice`** — the basemap decision extracted from `build_portal_bundle`, and "no basemap" honoured there. `__none__` is not a catalog entry, so `_BASEMAP_BY_ID.get` returned None and the template's basemap stayed baked in; the runtime switcher could still hide it, which is why it looked as though only the published portal honoured the choice while the editor ignored it — the editor's preview IS a published bundle. Extracted because `build_portal_bundle` reads the container's `/templates` mount and cannot be driven from a test. Tests: `api/tests/test_no_basemap.py` (21).)
 2026-09-08b (**external sources: every kind a web map can draw.** `xyz | wms | wfs` becomes
 `xyz | wms | wmts | wfs | ogcapi | vectortile | pmtiles`, with four new nullable columns
 (`source_layer`, `matrix_set`, `min_zoom`, `max_zoom`) and a migration for them.

--- a/api/geodeploy/services/portal_generator.py
+++ b/api/geodeploy/services/portal_generator.py
@@ -72,6 +72,17 @@ BASEMAP_CATALOG = [
 
 _BASEMAP_BY_ID = {b["id"]: b for b in BASEMAP_CATALOG}
 
+#: "No basemap" — the data on a plain ground. NOT a catalog entry, because there is no service
+#: behind it: it is the absence of one. The same sentinel the editor (`ui/src/lib/basemaps.js`) and
+#: the published runtime (`templates/shared/portal.js`) use, restated here because this is the file
+#: that decides what a published bundle actually contains.
+NO_BASEMAP_ID = "__none__"
+
+#: What a map stands on when no basemap does. A real `background` layer rather than nothing at all:
+#: with no painted ground, what shows through the map is the canvas, which is black.
+GROUND_LAYER = {"id": "gd-ground", "type": "background",
+                "paint": {"background-color": "#ffffff"}}
+
 
 def _ref(layer) -> str:
     """A layer's STABLE public id for baked URLs (models.new_uid). Published portals outlive the
@@ -950,21 +961,7 @@ def build_portal_bundle(slug: str, title: str, user_data: dict, template_id: str
         },
     }
 
-    # Repoint the template's base raster source at the admin-chosen basemap (so the published portal
-    # OPENS on it, no flash) and record the id so portal.js marks the matching switcher option active.
-    bm = _BASEMAP_BY_ID.get(basemap)
-    if bm:
-        base_src_id = next((lyr.get("source") for lyr in basemap_style.get("layers", [])
-                            if lyr.get("type") == "raster"), None)
-        if base_src_id is None and "basemap" in full_style["sources"]:
-            base_src_id = "basemap"
-        if base_src_id and base_src_id in full_style["sources"]:
-            full_style["sources"][base_src_id]["tiles"] = bm["tiles"]
-            full_style["sources"][base_src_id]["attribution"] = bm["attribution"]
-            # The builtin base layer NOW shows the chosen basemap, so portal.js must NOT swap it for the
-            # catalog copy on load (that redundant swap is a visible flash). See setupBasemaps.
-            full_style["geodeploy"]["baseRepointed"] = True
-        full_style["geodeploy"]["defaultBasemap"] = bm["id"]
+    apply_basemap_choice(full_style, basemap_style, user_data, basemap)
 
     # MapLibre v5 reads `projection` from the STYLE. Baking it means a globe portal loads as a globe
     # rather than loading flat and being corrected afterwards — the style's own projection was
@@ -2536,6 +2533,59 @@ def read_deck_core_bbox(s3_key: str | None) -> list | None:
     except Exception:
         pass
     return None
+
+
+def apply_basemap_choice(full_style: dict, basemap_style: dict, user_data: dict,
+                         basemap: str | None) -> None:
+    """Put the author's basemap choice INTO the bundle, in place. Three cases, and all three matter.
+
+    **A catalog basemap** repoints the template's own base raster source at it, so the published
+    portal OPENS on that basemap rather than loading the template's and being corrected — a
+    correction the reader sees as a flash.
+
+    **"No basemap"** takes the basemap OUT. This is the case that was missing, and it failed in a
+    way that pointed at the wrong place: `__none__` is deliberately not in `BASEMAP_CATALOG` —
+    there is no service behind it — so `_BASEMAP_BY_ID.get` returned None, nothing ran, and the
+    template's basemap stayed. The runtime switcher could still turn it off afterwards, which is
+    why it looked as though only the published portal honoured the setting while the editor
+    ignored it. The editor's preview IS a published bundle; it was honouring it exactly as much as
+    the portal was, which was not at all.
+
+    Removing it here rather than hiding it at runtime also means no flash of a map nobody asked
+    for, and `baseRepointed` tells `setupBasemaps` there is nothing left to swap in on load.
+
+    **Nothing chosen** leaves the template alone, which is what every portal published before
+    basemap selection existed depends on. So does an id the catalog does not know: a typo, or a
+    basemap since removed, must not silently publish a blank map.
+    """
+    if basemap == NO_BASEMAP_ID:
+        # Only the TEMPLATE's sources go. A user source that happens to share a name with one of
+        # them is the map's actual data, and dropping it would empty the portal.
+        template_sources = set(basemap_style.get("sources", {}))
+        keep = set(user_data.get("sources") or {})
+        full_style["sources"] = {k: v for k, v in full_style["sources"].items()
+                                 if k in keep or k not in template_sources}
+        full_style["layers"] = [dict(GROUND_LAYER)] + list(user_data.get("layers") or [])
+        # A vector template's sprite belongs to layers that are no longer here.
+        full_style["sprite"] = ""
+        full_style["geodeploy"]["defaultBasemap"] = NO_BASEMAP_ID
+        full_style["geodeploy"]["baseRepointed"] = True
+        return
+
+    bm = _BASEMAP_BY_ID.get(basemap)
+    if not bm:
+        return
+    base_src_id = next((lyr.get("source") for lyr in basemap_style.get("layers", [])
+                        if lyr.get("type") == "raster"), None)
+    if base_src_id is None and "basemap" in full_style["sources"]:
+        base_src_id = "basemap"
+    if base_src_id and base_src_id in full_style["sources"]:
+        full_style["sources"][base_src_id]["tiles"] = bm["tiles"]
+        full_style["sources"][base_src_id]["attribution"] = bm["attribution"]
+        # The builtin base layer NOW shows the chosen basemap, so portal.js must NOT swap it for
+        # the catalog copy on load (that redundant swap is a visible flash). See setupBasemaps.
+        full_style["geodeploy"]["baseRepointed"] = True
+    full_style["geodeploy"]["defaultBasemap"] = bm["id"]
 
 
 def _load_basemap(template_dir: Path) -> dict:

--- a/api/tests/test_no_basemap.py
+++ b/api/tests/test_no_basemap.py
@@ -1,0 +1,161 @@
+""""No basemap" has to be honoured by the BUNDLE, not only by the runtime switcher.
+
+REPORTED AS: "when you choose none as the basemap in the portal editor, it doesn't actually change
+to None. it does nothing."
+
+WHY IT LOOKED LIKE AN EDITOR BUG AND WAS NOT. The editor's preview is a REAL published bundle in an
+iframe — that is what makes it faithful — so what the preview shows is decided at publish, here.
+`__none__` is deliberately not in `BASEMAP_CATALOG` (there is no service behind it; it is the
+absence of one), so `_BASEMAP_BY_ID.get(basemap)` returned None, the repoint block did not run, and
+the template's own basemap stayed baked in. The runtime switcher could still turn it off
+afterwards, which is exactly why it seemed that only the published portal honoured the setting: the
+editor was honouring it precisely as much as the portal was, which was not at all.
+
+So the basemap is taken OUT of the style at publish rather than hidden afterwards — no flash of a
+map nobody asked for, and a portal that opens on the plain ground it was authored with.
+
+Driven through `apply_basemap_choice` rather than `build_portal_bundle`, which reads the
+container's `/templates` mount. The decision is the part with the logic; extracting it is what
+makes it testable at all.
+"""
+import copy
+
+import pytest
+
+from geodeploy.services import portal_generator as pg
+
+TEMPLATE_STYLE = {
+    "sprite": "https://tiles.example.org/sprite",
+    "sources": {"basemap": {"type": "raster", "tiles": ["https://t.example/{z}/{x}/{y}.png"],
+                            "tileSize": 256, "attribution": "© Somebody"}},
+    "layers": [{"id": "basemap", "type": "raster", "source": "basemap"}],
+}
+
+USER_DATA = {
+    "sources": {"vector_4": {"type": "vector", "tiles": ["/tiles/gd.roads/{z}/{x}/{y}"]}},
+    "layers": [{"id": "vector-4", "type": "line", "source": "vector_4",
+                "source-layer": "gd.roads", "metadata": {"geodeploy:layer_id": 4}}],
+}
+
+
+def build(basemap):
+    """The style a publish would write, for one basemap choice."""
+    template = copy.deepcopy(TEMPLATE_STYLE)
+    user = copy.deepcopy(USER_DATA)
+    style = {
+        "version": 8,
+        "sprite": template.get("sprite", ""),
+        "sources": {**template["sources"], **user["sources"]},
+        "layers": template["layers"] + user["layers"],
+        "geodeploy": {},
+    }
+    pg.apply_basemap_choice(style, template, user, basemap)
+    return style
+
+
+class TestTheSentinelIsShared:
+    def test_the_id_matches_the_editor_and_the_runtime(self):
+        # Three surfaces must agree on this string or the choice is dropped between them:
+        # `ui/src/lib/basemaps.js`, `templates/shared/portal.js`, and here.
+        assert pg.NO_BASEMAP_ID == "__none__"
+
+    def test_it_is_not_a_catalog_entry(self):
+        # …and must not become one. The catalog is a list of SERVICES, and everything that consumes
+        # it — the switcher, the editor's picker, `_BASEMAP_BY_ID` — expects tiles behind each id.
+        assert pg.NO_BASEMAP_ID not in {b["id"] for b in pg.BASEMAP_CATALOG}
+        assert pg._BASEMAP_BY_ID.get(pg.NO_BASEMAP_ID) is None
+
+    def test_the_ground_is_a_real_layer(self):
+        # With no painted ground, what shows through the map is the canvas — black. That is why
+        # this is a `background` layer rather than simply nothing.
+        assert pg.GROUND_LAYER["type"] == "background"
+        assert pg.GROUND_LAYER["paint"]["background-color"] == "#ffffff"
+
+
+class TestChoosingNone:
+    def test_the_templates_basemap_is_removed(self):
+        style = build("__none__")
+        assert "basemap" not in style["sources"], "the template's tiles are still in the bundle"
+        assert not [lyr for lyr in style["layers"] if lyr.get("type") == "raster"]
+
+    def test_a_white_ground_is_painted_instead(self):
+        style = build("__none__")
+        ground = style["layers"][0]
+        assert ground["id"] == "gd-ground" and ground["type"] == "background"
+        assert ground["paint"]["background-color"] == "#ffffff"
+
+    def test_the_runtime_is_told_which_option_is_active(self):
+        # Or the switcher opens with the wrong row ticked, telling the reader the portal is showing
+        # a basemap that is not there.
+        assert build("__none__")["geodeploy"]["defaultBasemap"] == "__none__"
+
+    def test_and_told_not_to_swap_anything_in_on_load(self):
+        # `baseRepointed` is what stops `setupBasemaps` calling `selectBasemap` on load. The bundle
+        # already IS the chosen state; driving the switcher again would be a visible flash.
+        assert build("__none__")["geodeploy"]["baseRepointed"] is True
+
+    def test_the_attribution_goes_with_the_basemap(self):
+        # A credit for a service the portal no longer fetches is a false statement about the map.
+        import json
+        assert "Somebody" not in json.dumps(build("__none__")["sources"])
+
+    def test_a_vector_templates_sprite_goes_too(self):
+        # It belongs to layers that are no longer in the style.
+        assert build("__none__")["sprite"] == ""
+
+
+class TestTheDataSurvives:
+    """The one thing worse than a basemap that will not go is a portal whose data went with it."""
+
+    def test_the_portals_own_layers_are_still_drawn(self):
+        style = build("__none__")
+        drawn = [lyr for lyr in style["layers"] if lyr["id"] != "gd-ground"]
+        assert [lyr["id"] for lyr in drawn] == ["vector-4"]
+
+    def test_its_source_survives_the_filtering(self):
+        assert "vector_4" in build("__none__")["sources"]
+
+    def test_the_ground_is_under_the_data_not_over_it(self):
+        assert build("__none__")["layers"][0]["id"] == "gd-ground"
+
+    def test_a_user_source_named_like_the_templates_is_kept(self):
+        """The filter removes the TEMPLATE's sources. A data source that happens to be called
+        `basemap` is the map itself, and dropping it would empty the portal."""
+        template = copy.deepcopy(TEMPLATE_STYLE)
+        user = {"sources": {"basemap": {"type": "vector", "tiles": ["/tiles/mine/{z}/{x}/{y}"]}},
+                "layers": [{"id": "mine", "type": "line", "source": "basemap"}]}
+        style = {"version": 8, "sprite": "", "sources": {**template["sources"], **user["sources"]},
+                 "layers": template["layers"] + user["layers"], "geodeploy": {}}
+        pg.apply_basemap_choice(style, template, user, "__none__")
+        assert style["sources"]["basemap"]["type"] == "vector"
+        assert [lyr["id"] for lyr in style["layers"]] == ["gd-ground", "mine"]
+
+
+class TestEveryOtherChoiceIsUnchanged:
+    def test_a_real_basemap_is_repointed(self):
+        other = pg.BASEMAP_CATALOG[1]
+        style = build(other["id"])
+        assert style["sources"]["basemap"]["tiles"] == other["tiles"]
+        assert style["sources"]["basemap"]["attribution"] == other["attribution"]
+        assert style["geodeploy"]["defaultBasemap"] == other["id"]
+        assert style["geodeploy"]["baseRepointed"] is True
+
+    def test_choosing_nothing_leaves_the_template_alone(self):
+        # A portal published before basemap selection existed must look exactly as it did.
+        style = build(None)
+        assert style["sources"]["basemap"]["tiles"] == TEMPLATE_STYLE["sources"]["basemap"]["tiles"]
+        assert "defaultBasemap" not in style["geodeploy"]
+        assert "baseRepointed" not in style["geodeploy"]
+
+    @pytest.mark.parametrize("unknown", ["not-a-basemap", "", "none", "None", "__None__"])
+    def test_an_unknown_id_is_not_mistaken_for_none(self, unknown):
+        # A typo, a case difference, or a basemap removed from the catalog must leave the
+        # template's own basemap rather than silently publishing a blank map.
+        style = build(unknown)
+        assert style["sources"]["basemap"]["tiles"] == TEMPLATE_STYLE["sources"]["basemap"]["tiles"]
+        assert style["layers"][0]["type"] == "raster"
+
+    def test_the_data_is_untouched_by_a_repoint(self):
+        style = build(pg.BASEMAP_CATALOG[1]["id"])
+        assert "vector_4" in style["sources"]
+        assert any(lyr["id"] == "vector-4" for lyr in style["layers"])


### PR DESCRIPTION
Reported as "choosing none in the portal editor does nothing" — and the editor was innocent.

The editor's preview is a **real published bundle** in an iframe, which is what makes it faithful. So what the preview shows is decided at publish. `__none__` is deliberately not in `BASEMAP_CATALOG` (there is no service behind it; it is the absence of one), so `_BASEMAP_BY_ID.get(basemap)` returned `None`, the repoint block never ran, and the template's own basemap stayed baked in. The runtime switcher could still turn it off afterwards — which is exactly why it looked as though only the published portal honoured the setting.

The basemap is now taken **out** of the style at publish rather than hidden at runtime: no flash of a map nobody asked for, and `baseRepointed` tells `setupBasemaps` there is nothing left to swap in on load. A white `background` layer goes underneath, because with no painted ground what shows through is the canvas — black.

Only the *template's* sources are dropped: a data source that happens to be called `basemap` is the map itself.

The decision is now `apply_basemap_choice`, extracted from a 200-line I/O function that reads the container's `/templates` mount and therefore could not be driven from a test. That is why there are 21 checks here — including the cases that must **not** change: a real basemap still repoints, a portal that chose nothing looks exactly as it did, and an unknown id leaves the template's basemap rather than silently publishing a blank map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmv2QANmjQoBE2axSptU9D