### PR TITLE
Say that the GeoLibre importer has no button

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -438,7 +438,13 @@ round trip, not yet scheduled.</p>
 
 - [x] **A `.geolibre.json` importer** — `POST /api/interop/geolibre/preview` (a dry run that
       says what would be imported) and `/publish` (creates a layer per source and builds the
-      portal). Shipped in v1.0
+      portal). Shipped in v1.0, and **API-only**: it reads a whole project — XYZ and COG layers,
+      extruded buildings, a 3D-Z track, categorized, graduated and single-symbol vectors, the
+      story sections and the 3D view — carrying raw MapLibre paint for what the friendly style
+      cannot say, and a `source_identity` on every layer for a future write-back
+- [ ] **Somewhere to drop the file** — the importer has no button. Today it is a `curl` to
+      `/api/interop/geolibre/preview`, which means nobody who has not read the API reference knows
+      it exists
 - [ ] **Push from GeoLibre** — the other end: a "Publish to GeoDeploy" plugin inside
       GeoLibre, so a project goes across without exporting a file first
 - [ ] Write-back: expose a layer as editable GeoJSON and re-ingest the edit


### PR DESCRIPTION
"Shipped in v1.0" was true and still misleading.

The importer is real: the 5.5 KB sample project parses into a portal with its view, basemap and story, and seven layers covering XYZ, COG, extruded buildings, a 3D-Z track, categorized, graduated and single-symbol vectors — carrying raw MapLibre paint for what the friendly style cannot express, and a `source_identity` on each layer for a future write-back. 27 tests cover it and they pass.

But there is no way to reach it without `curl`: no entry in the web app, nothing in the CLI. Someone reading "importer: shipped" will go looking for it and not find it — which is what happened as soon as the line was read back to me.

The tick keeps what is genuinely built and now says **API-only** in as many words; a new open item names the missing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmv2QANmjQoBE2axSptU9D