### PR TITLE
A hatched polygon comes home hatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ upgrade needs manual work.
 
 ## Unreleased
 
+## v1.6.3 — 2026-09-11
+
+- **A hatched polygon comes home hatched.** Opening a portal from GeoDeploy drew every pattern
+  fill — hatch, cross, dense, line, point — as a solid block of colour, on every route at once
+  (fast preview, editable, with a token and without), because every route ends in the same symbol
+  builder. Two faults, both on the way back. A solid fill was painted *under* the tile in the same
+  colour as the hatch drawn on top of it, which is a solid block by definition: measured at 82%
+  transparent in QGIS and 0% after the trip home. And the tile's width was stated in millimetres
+  where `QgsRasterFillSymbolLayer` counts in **pixels** — the one size in the plugin whose default
+  unit is not millimetres — so a 16-pixel hatch drew at 4 and its diagonals collapsed into a grey
+  stipple that reads as a flat wash.
+- **A plain fill beneath a pattern is carried in the tile.** MapLibre draws `fill-pattern`
+  *instead of* `fill-color`, so a red polygon with a black hatch published with the red missing.
+  The fill underneath is now painted into the tile itself, which is the only place it can live —
+  and is what lets the browser and QGIS draw the same thing. A polygon that is *only* a pattern
+  says it has no outline, rather than being given the default blue one.
+- Eleven pattern kinds are now pinned by **rendering** them and comparing the ink, in both QGIS
+  images. The style dictionary looked correct throughout this bug, which is why the check is a
+  measurement of pixels rather than of keys.
+
 ## v1.6.2 — 2026-09-11
 
 - **A colour's own transparency now travels.** QGIS has *two* opacities and only one of them was

--- a/integrations/qgis-plugin/README.md
+++ b/integrations/qgis-plugin/README.md
@@ -78,6 +78,14 @@ fastest source it offers, and upload a QGIS layer back — with its styling. Sit
     drawn as a regular grid at the same density, which is a different picture and says so. Every
     size goes through `_px_of`: QGIS states these in MILLIMETRES by default, and reading one as a
     pixel turns a 4 mm hatch into a solid block.
+    **The tile carries the fill beneath it** (`_base_colour`), because MapLibre draws
+    `fill-pattern` *instead of* `fill-color` and a plain fill under a hatch has nowhere else to
+    live — without it a red polygon with a black hatch published with the red gone. The symbol
+    builder therefore must NOT paint a fill under the tile either (`symbology._has_pattern`), or
+    the hatch lands on a block of its own colour and the polygon reads as solid. **And writing the
+    tile back is the one size in this plugin that is not millimetres by default:**
+    `QgsRasterFillSymbolLayer.width` counts PIXELS, so `_raster_layer` states points and sets the
+    unit — handing it millimetres drew every tile at a quarter size.
   - `vendor/geodeploy/` — the published client, checked in (see below).
 - `scripts/test_real_qgis.py` — **the round trip against a real PyQGIS**, and the only test here
   that is not stubbed. Every other `scripts/test_*.py` replaces the QGIS classes, and the stubs
@@ -366,6 +374,14 @@ Findings in `vendor/` are fixed in `cli/geodeploy` and re-vendored — never edi
 `vendor.py --check` fails.
 
 ## Last updated
+2026-09-11 (**a hatched polygon comes home hatched.** Every pattern fill opened from GeoDeploy as a
+solid block, on all three routes, because a solid fill was painted under the tile in the same
+colour as the hatch on top of it — and because the tile's width was given in millimetres where
+`QgsRasterFillSymbolLayer` counts pixels, drawing a 16px hatch at 4px. A plain fill that really is
+underneath is now painted INTO the tile, which is also what MapLibre needs. Pinned by rendering
+eleven pattern kinds and comparing the ink: the style dict was correct the whole time, so only
+pixels could catch it. See `notes_temp/notes_for_future.md`.)
+
 2026-09-10 (**one path for a portal, token or not.** There were two implementations of "what does
 this portal look like": with a token the plugin asked the API for the authored `layer_configs`;
 without one it read `style.json` and translated the MapLibre paint BACKWARDS. That reverse is lossy

--- a/integrations/qgis-plugin/geodeploy_qgis/fills.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/fills.py
@@ -118,7 +118,7 @@ def _base_colour(symbol, above: int):
         try:
             if under.brushStyle() != solid:
                 continue
-        except Exception:               # noqa: BLE001  # nosec B110 - a brush we cannot read is not a base
+        except Exception:               # noqa: BLE001  # nosec B112 - a brush we cannot read is not a base
             continue
         found = under.color()
     return found

--- a/integrations/qgis-plugin/geodeploy_qgis/fills.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/fills.py
@@ -86,7 +86,7 @@ def from_qgis(symbol):
         if not isinstance(symbol, QgsFillSymbol):
             return {}, notes
         for i in range(symbol.symbolLayerCount()):
-            block, note = _tile_for(symbol.symbolLayer(i))
+            block, note = _tile_for(symbol.symbolLayer(i), _base_colour(symbol, i))
             if note:
                 notes.append(note)
             if block and "__centroid__" in block:
@@ -99,16 +99,41 @@ def from_qgis(symbol):
     return {}, notes
 
 
-def _tile_for(sl):
+def _base_colour(symbol, above: int):
+    """The flat colour a pattern at index `above` is drawn ON TOP of, or None.
+
+    A hatched polygon in QGIS is usually two symbol layers: a plain fill, and the hatch over it.
+    GeoDeploy carries ONE tile for the pair, because `fill-pattern` replaces `fill-color` in
+    MapLibre and a fill under a pattern has nowhere else to go — so the plain half is painted into
+    the tile and the pattern drawn over it. Only a layer BELOW the pattern counts, and only one
+    that actually paints: a `NoBrush` fill is the outline-only case and has no colour to lend.
+    """
+    from qgis.PyQt.QtCore import Qt
+    solid = symbology.enum(Qt, "BrushStyle", "SolidPattern")
+    found = None
+    for i in range(above):
+        under = symbol.symbolLayer(i)
+        if not isinstance(under, QgsSimpleFillSymbolLayer):
+            continue
+        try:
+            if under.brushStyle() != solid:
+                continue
+        except Exception:               # noqa: BLE001  # nosec B110 - a brush we cannot read is not a base
+            continue
+        found = under.color()
+    return found
+
+
+def _tile_for(sl, base=None):
     """`(block, note)` for one symbol layer — `(None, None)` when it is not a pattern."""
     if isinstance(sl, QgsSimpleFillSymbolLayer):
-        return _brush_tile(sl)
+        return _brush_tile(sl, base)
     if isinstance(sl, QgsLinePatternFillSymbolLayer):
-        return _line_tile(sl)
+        return _line_tile(sl, base)
     if isinstance(sl, QgsPointPatternFillSymbolLayer):
-        return _point_tile(sl)
+        return _point_tile(sl, base)
     if isinstance(sl, QgsRandomMarkerFillSymbolLayer):
-        return _random_tile(sl)
+        return _random_tile(sl, base)
     if _is_centroid(sl):
         # NOT a tile: a centroid fill draws ONE marker per polygon, at its centre. MapLibre places a
         # symbol layer's icons at a polygon's label point by default, so it is a marker, not a
@@ -116,9 +141,9 @@ def _tile_for(sl):
         marker = _centroid_marker(sl)
         return ({"__centroid__": marker} if marker else None), None
     if isinstance(sl, QgsSVGFillSymbolLayer):
-        return _image_tile(sl, sl.svgFilePath(), _px_of(sl, "patternWidth"), svg=True)
+        return _image_tile(sl, sl.svgFilePath(), _px_of(sl, "patternWidth"), svg=True, base=base)
     if isinstance(sl, QgsRasterFillSymbolLayer):
-        return _image_tile(sl, sl.imageFilePath(), _px_of(sl, "width"), svg=False)
+        return _image_tile(sl, sl.imageFilePath(), _px_of(sl, "width"), svg=False, base=base)
     return None, None
 
 
@@ -144,7 +169,7 @@ def _centroid_marker(sl):
     return block
 
 
-def _brush_tile(sl):
+def _brush_tile(sl, base=None):
     """A Qt hatch, cross or dense pattern, painted the way QGIS paints it."""
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtGui import QBrush
@@ -153,7 +178,7 @@ def _brush_tile(sl):
     none_ = symbology.enum(Qt, "BrushStyle", "NoBrush")
     if style in (solid, none_):
         return None, None               # a plain fill is describable; it needs no tile
-    image = _canvas(BRUSH_TILE_PX)
+    image = _canvas(BRUSH_TILE_PX, base=base)
     painter = _painter(image)
     try:
         painter.fillRect(0, 0, BRUSH_TILE_PX, BRUSH_TILE_PX, QBrush(sl.color(), style))
@@ -162,7 +187,7 @@ def _brush_tile(sl):
     return _encode(image), None
 
 
-def _line_tile(sl):
+def _line_tile(sl, base=None):
     """Hatch lines at a spacing and an angle.
 
     THE ANGLE IS SNAPPED, and this is the one real approximation in the module. A square tile can
@@ -186,7 +211,7 @@ def _line_tile(sl):
 
     side = spacing if angle in (0.0, 90.0) else spacing * math.sqrt(2.0)
     side = int(max(MIN_TILE_PX, min(MAX_TILE_PX, round(side))))
-    image = _canvas(side)
+    image = _canvas(side, base=base)
     painter = _painter(image)
     try:
         pen = QPen(sl.color())
@@ -212,14 +237,14 @@ def _line_tile(sl):
     return _encode(image), note
 
 
-def _point_tile(sl):
+def _point_tile(sl, base=None):
     """Markers on a grid. Closes at exactly distanceX x distanceY."""
     w = int(max(MIN_TILE_PX, min(MAX_TILE_PX, round(_px_of(sl, "distanceX") or 12))))
     h = int(max(MIN_TILE_PX, min(MAX_TILE_PX, round(_px_of(sl, "distanceY") or 12))))
-    return _marker_grid(sl, w, h), None
+    return _marker_grid(sl, w, h, base), None
 
 
-def _random_tile(sl):
+def _random_tile(sl, base=None):
     """A scattered fill, drawn as a REGULAR one at the same density.
 
     Randomness has no period, so there is no tile that reproduces it. A grid at the same density is
@@ -234,12 +259,12 @@ def _random_tile(sl):
         # of the equivalent square is the square root of the converted area over the count.
         side = math.sqrt(max(1.0, (area * MM_TO_PX) / count))
     side = int(max(MIN_TILE_PX, min(MAX_TILE_PX, round(side))))
-    return _marker_grid(sl, side, side), (
+    return _marker_grid(sl, side, side, base), (
         "its randomly scattered fill was drawn as an evenly spaced one at the same density: a "
         "random pattern has no repeating tile")
 
 
-def _marker_grid(sl, w: int, h: int):
+def _marker_grid(sl, w: int, h: int, base=None):
     """One marker centred in a w x h tile, repeated at every neighbouring offset so an overhang
     reappears on the opposite edge instead of being clipped."""
     from qgis.PyQt.QtCore import QSize
@@ -253,7 +278,7 @@ def _marker_grid(sl, w: int, h: int):
         return None
     if marker is None or marker.isNull():
         return None
-    image = _canvas(w, h)
+    image = _canvas(w, h, base)
     painter = _painter(image)
     try:
         x = (w - marker.width()) / 2.0
@@ -267,7 +292,7 @@ def _marker_grid(sl, w: int, h: int):
 
 
 
-def _embedded_tile(payload: str):
+def _embedded_tile(payload: str, base=None):
     """`({image, width, height}, None)` for a `base64:` image the symbol carries inline."""
     import base64
     try:
@@ -279,13 +304,21 @@ def _embedded_tile(payload: str):
         image = QImage.fromData(raw)
         if image.isNull():
             return None, None
+        if base is not None and base.alpha() > 0:
+            ground = _canvas(image.width(), image.height(), base)
+            painter = _painter(ground)
+            try:
+                painter.drawImage(0, 0, image)
+            finally:
+                painter.end()
+            return _encode(ground), None
         return ({"image": "data:image/png;base64," + payload,
                  "width": image.width(), "height": image.height()}, None)
     except Exception:                   # noqa: BLE001  # nosec B110
         return None, None
 
 
-def _image_tile(sl, path: str, width_px: float, svg: bool):
+def _image_tile(sl, path: str, width_px: float, svg: bool, base=None):
     """An SVG or raster fill: the source image IS the tile, at the width QGIS repeats it.
 
     `path` may be a FILE or a `base64:` blob. The plugin writes patterns embedded now — a file path
@@ -295,9 +328,9 @@ def _image_tile(sl, path: str, width_px: float, svg: bool):
     if not path:
         return None, None
     if str(path).startswith("base64:"):
-        return _embedded_tile(str(path)[len("base64:"):])
+        return _embedded_tile(str(path)[len("base64:"):], base)
     side = int(max(MIN_TILE_PX, min(MAX_TILE_PX, round(width_px or 24))))
-    image = _canvas(side)
+    image = _canvas(side, base=base)
     painter = _painter(image)
     try:
         if svg:
@@ -324,12 +357,27 @@ def _image_tile(sl, path: str, width_px: float, svg: bool):
 
 # ── Plumbing ─────────────────────────────────────────────────────────────────────────────────────
 
-def _canvas(w: int, h: int | None = None):
-    """A transparent ARGB image. Transparent, not white: a hatch shows the fill beneath it."""
+def _canvas(w: int, h: int | None = None, base=None):
+    """An ARGB image to draw a tile on — transparent, or filled with the fill that sits beneath it.
+
+    TRANSPARENT BY DEFAULT, because a hatch shows what is under it. `base` is that "under it" when
+    the symbol actually has one, and it has to be painted INTO the tile rather than left to the
+    renderer: MapLibre draws `fill-pattern` INSTEAD of `fill-color`, so a red polygon with a black
+    hatch published as a transparent polygon with a black hatch — the red simply gone. Baking it in
+    is what makes the browser and QGIS draw the same thing, since QGIS cannot show a fill through
+    an opaque tile either.
+    """
     from qgis.PyQt.QtGui import QImage
     image = QImage(int(w), int(h if h is not None else w),
                    symbology.enum(QImage, "Format", "Format_ARGB32_Premultiplied"))
     image.fill(0)
+    if base is not None and base.alpha() > 0:
+        from qgis.PyQt.QtGui import QPainter
+        painter = QPainter(image)
+        try:
+            painter.fillRect(0, 0, image.width(), image.height(), base)
+        finally:
+            painter.end()
     return image
 
 
@@ -559,7 +607,16 @@ def _raster_layer(uri, block):
     layer.setImageFilePath(path)
     width = block.get("width")
     if width:
-        layer.setWidth(round(float(width) / MM_TO_PX, 3))
+        # IN POINTS, AND SAID SO. A raster fill's width unit defaults to PIXELS, not millimetres —
+        # it is the one size in this plugin whose default is not mm — so converting the tile's
+        # pixel width into millimetres and leaving the unit alone stated a quarter of the size. A
+        # 16px hatch tile drew at 4px, which is smaller than the pattern's own period: the
+        # diagonals collapsed into a grey stipple that reads as a flat wash, not a hatch.
+        #
+        # Points, like every other size here, so `_points_unit` is the same call the rest of the
+        # module makes and the number means the same thing everywhere.
+        layer.setWidth(round(float(width) * symbology.CSS_PX_TO_POINTS, 3))
+        _points_unit(layer, "setWidthUnit")
     return layer
 
 

--- a/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
+++ b/integrations/qgis-plugin/geodeploy_qgis/metadata.txt
@@ -13,7 +13,7 @@ about=GeoDeploy is a self-hosted spatial data platform and geoportal builder. Th
     QGIS to an instance: browse what it publishes (no account needed for public data), add a layer
     using the fastest source it offers, and upload a QGIS layer back — including multi-gigabyte
     files, which go straight to object storage. Pure Python, no external dependencies.
-version=0.7.1
+version=0.7.2
 author=Koffi Dodji Noumonvi
 email=noumonvikoffidodji@hotmail.fr
 
@@ -32,7 +32,16 @@ license=Apache-2.0
 
 ; The client is vendored under vendor/geodeploy — a plugin cannot pip-install into a user's QGIS.
 ; It is the same package published as `geodeploy` on PyPI, kept identical by integrations/qgis-plugin/scripts/vendor.py.
-changelog=0.7.1 - A COLOUR'S OWN TRANSPARENCY TRAVELS. QGIS has two opacities and only one was
+changelog=0.7.2 - A HATCHED POLYGON COMES HOME HATCHED. Opening a portal from GeoDeploy drew
+    every pattern fill as a solid block of colour, on all three routes at once. Two faults, both
+    in the way back: a solid fill was painted under the tile in the SAME colour as the hatch on
+    top of it, and the tile's own width was stated in millimetres where a raster fill counts in
+    pixels, so a 16-pixel hatch drew at 4 and its diagonals collapsed into a stipple. A plain fill
+    that really does sit under a pattern is now painted INTO the tile, which is also what the
+    browser needed: MapLibre draws fill-pattern instead of fill-color, so a red polygon with a
+    black hatch used to publish with the red missing. Eleven pattern kinds are now checked by
+    rendering them and comparing the ink.
+    0.7.1 - A COLOUR'S OWN TRANSPARENCY TRAVELS. QGIS has two opacities and only one was
     read: "Layer rendering - Opacity" dims the whole symbol, the alpha slider inside the colour
     picker dims just that colour, and QColor.name() drops the second. A polygon whose fill was set
     fully transparent in the colour dialog published as a solid block - while the portal card,

--- a/integrations/qgis-plugin/geodeploy_qgis/symbology.py
+++ b/integrations/qgis-plugin/geodeploy_qgis/symbology.py
@@ -578,6 +578,18 @@ def _apply_marker_placement(symbol, layer0, style: dict) -> None:
 
 
 
+def _has_pattern(style) -> bool:
+    """Whether this style's polygons are drawn as a repeating tile rather than a flat colour."""
+    try:
+        try:                            # a package, inside QGIS
+            from . import fills as _fills
+        except ImportError:             # exec'd standalone by the test harness
+            import fills as _fills
+        return bool(_fills.has_pattern(style))
+    except Exception:                   # noqa: BLE001 - no pattern module, no pattern
+        return False
+
+
 def _decorate_symbol(symbol, style) -> None:
     """Add a pattern fill or a centre marker on top of a symbol that is otherwise finished.
 
@@ -715,7 +727,21 @@ def _symbol_of(geometry_type, color: str | None, style: dict):
         # to the whole symbol, border included, so setting it to zero here made an outline-only
         # polygon vanish completely on the way back. The brush is what has to go.
         opacity = float(style.get("fill_opacity", DEFAULT_FILL_OPACITY))
-        if opacity <= 0 and _set_brush(layer0, False):
+        # A PATTERN REPLACES THE FILL; IT IS NOT PAINTED OVER ONE.
+        #
+        # MapLibre drops `fill-color` the moment a `fill-pattern` is set — the tile carries its own
+        # colours, the base colour among them — so the portal draws the tile over nothing. Putting
+        # a solid fill underneath here painted the polygon in the style's colour and then drew a
+        # hatch of THE SAME COLOUR on top of it: a solid block. Reported exactly that way, from
+        # every route at once — "hashed polygons are coming back solid filled instead of hashed" —
+        # because every route ends in this branch. Measured at 82% transparent in QGIS and 0% after
+        # the trip home.
+        #
+        # `fill_opacity` still applies, the same as `fill-opacity` does to a pattern in the browser,
+        # so a hatch can still be a wash.
+        if _has_pattern(style) and _set_brush(layer0, False):
+            symbol.setOpacity(opacity)
+        elif opacity <= 0 and _set_brush(layer0, False):
             symbol.setOpacity(1.0)
         else:
             _set_brush(layer0, True)
@@ -4157,6 +4183,19 @@ def _style_from_symbol(symbol) -> dict:
         # is usually a plain fill with a hatch stacked on it. See `fills.py` for why the tile is
         # REBUILT rather than photographed.
         style.update(_fill_pattern_of(symbol))
+        # AND THE OPACITY A PATTERN CARRIES IS THE SYMBOL'S ALONE. Every colour in the tile was
+        # painted with its own alpha already in it, so multiplying by a colour's alpha a second
+        # time here — which is what `_paint_opacity` does, rightly, for a flat fill — would fade
+        # the hatch twice.
+        if style.get("fill_pattern"):
+            own = _number(_call_or_none(symbol, "opacity"), 1.0)
+            style["fill_opacity"] = round(max(0.0, min(1.0, 1.0 if own is None else own)), 3)
+            # AND A PATTERN ON ITS OWN HAS NO BORDER. Only a simple fill layer carries one, so a
+            # symbol built entirely from a hatch says nothing about an outline — and both renderers
+            # fill that silence with their default, which is a blue edge nobody drew. Saying "none"
+            # is the true reading of a symbol that has no stroke in it.
+            if "outline_color" not in style:
+                style["outline_color"] = "none"
     style.update(_size_from_qgis(symbol, layer0))
     return style
 

--- a/integrations/qgis-plugin/scripts/test_roundtrip_matrix.py
+++ b/integrations/qgis-plugin/scripts/test_roundtrip_matrix.py
@@ -796,6 +796,122 @@ def colour_alpha():
           abs((again.get("line_opacity") or 0) - 0.4) < 0.02, again.get("line_opacity"))
 
 
+def pattern_fills():
+    """A HATCHED POLYGON COMES HOME HATCHED — measured in ink, not in keys.
+
+    REPORTED AS: "hashed polygons are coming back solid filled instead of hashed", from every route
+    at once — fast preview, editable, with a token and without. Every route ends in the same
+    symbol builder, and that builder painted a solid fill in the style's colour and then let
+    `fills.decorate` lay the hatch ON TOP OF IT — in the same colour. A hatch QGIS drew 82%
+    transparent came back 0% transparent: a block.
+
+    Two faults, and neither shows up in a style dict, which is why this section renders:
+
+    * the fill under the pattern. MapLibre drops `fill-color` the moment `fill-pattern` is set, so
+      the browser draws the tile over nothing; QGIS has to do the same, and the plain fill a symbol
+      really does have underneath is painted INTO the tile instead (`fills._base_colour`);
+    * the tile's SIZE. `QgsRasterFillSymbolLayer.width` defaults to PIXELS — the one size in this
+      plugin whose default is not millimetres — and it was being handed millimetres, so a 16px tile
+      drew at 4px and the diagonals collapsed into a grey stipple that reads as a flat wash.
+
+    So the assertion is INK: the mean alpha of the rendered swatch, which is the same number for
+    two hatches that look alike and a very different one for a hatch and a block. Pixel counting
+    would call two identical hatches different the moment one lands half a pixel over.
+    """
+    section("Pattern fills — a hatch is still a hatch on the way home")
+    from qgis.core import (QgsFillSymbol, QgsLinePatternFillSymbolLayer,
+                           QgsPointPatternFillSymbolLayer, QgsSingleSymbolRenderer)
+    from qgis.PyQt.QtCore import QSize
+    from qgis.PyQt.QtGui import QColor
+
+    def ink(symbol, n=64):
+        """Mean alpha of what this symbol paints, 0-100."""
+        image = symbol.asImage(QSize(n, n))
+        total = 0
+        for y in range(n):
+            for x in range(n):
+                total += image.pixelColor(x, y).alpha()
+        return total * 100 // (n * n * 255)
+
+    def build(kind):
+        """A fresh symbol every time — `QgsSingleSymbolRenderer` OWNS the one it is given."""
+        if kind == "line-pattern over a plain fill":
+            symbol = QgsFillSymbol.createSimple({"color": "#c43c39", "outline_color": "#000000"})
+            hatch = QgsLinePatternFillSymbolLayer()
+            hatch.setLineAngle(45); hatch.setDistance(2.0); hatch.setColor(QColor("#111111"))
+            symbol.appendSymbolLayer(hatch)
+            return symbol
+        if kind == "a line-pattern hatch alone":
+            symbol = QgsFillSymbol()
+            hatch = QgsLinePatternFillSymbolLayer()
+            hatch.setLineAngle(45); hatch.setDistance(2.0); hatch.setColor(QColor("#c43c39"))
+            symbol.changeSymbolLayer(0, hatch)
+            return symbol
+        if kind == "a point pattern over a plain fill":
+            symbol = QgsFillSymbol.createSimple({"color": "#c43c39"})
+            symbol.appendSymbolLayer(QgsPointPatternFillSymbolLayer())
+            return symbol
+        symbol = QgsFillSymbol.createSimple({"color": "#c43c39", "outline_color": "#000000"})
+        symbol.symbolLayer(0).setBrushStyle(enum(Qt, "BrushStyle", kind))
+        return symbol
+
+    # Qt's OWN hatch brushes are what "Fill style: Diagonal / Cross / Dense" is in the Symbology
+    # panel, and they are the ones that came back solid: the hatch colour IS the style's colour,
+    # so a solid fill under it is invisible as a fault and total as a difference.
+    kinds = ["BDiagPattern", "FDiagPattern", "DiagCrossPattern", "HorPattern", "VerPattern",
+             "CrossPattern", "Dense3Pattern", "Dense6Pattern",
+             "line-pattern over a plain fill", "a line-pattern hatch alone",
+             "a point pattern over a plain fill"]
+    for kind in kinds:
+        source = make_layer("Polygon")
+        source.setRenderer(QgsSingleSymbolRenderer(build(kind)))
+        drawn = ink(source.renderer().symbol())
+        style = symbology.from_qgis(source) or {}
+        block = style.get("fill_pattern") or {}
+        check("{0}: travels as a tile".format(kind),
+              str(block.get("image", "")).startswith("data:image/"), sorted(style))
+
+        target = make_layer("Polygon")
+        symbology.apply_to_qgis(target, style)
+        back = ink(target.renderer().symbol())
+        check("{0}: comes home drawing the same amount of ink".format(kind),
+              abs(drawn - back) <= 8, "QGIS drew {0}%, it came back {1}%".format(drawn, back))
+
+    # THE ONE THAT WAS REPORTED, stated as its own check so the failure names the symptom: a hatch
+    # that comes back opaque everywhere is a solid block, whatever else is true of it.
+    source = make_layer("Polygon")
+    source.setRenderer(QgsSingleSymbolRenderer(build("BDiagPattern")))
+    style = symbology.from_qgis(source) or {}
+    target = make_layer("Polygon")
+    symbology.apply_to_qgis(target, style)
+    rebuilt = target.renderer().symbol()
+    check("a diagonal hatch does not come back as a solid block", ink(rebuilt) < 40,
+          "{0}% ink — a solid fill is 100".format(ink(rebuilt)))
+    # …and the reason it used to: the fill UNDER the pattern must not paint.
+    base = rebuilt.symbolLayer(0)
+    getter = getattr(base, "brushStyle", None)
+    brush = getter() if callable(getter) else None
+    check("...because nothing solid is painted under the tile",
+          brush is None or brush == enum(Qt, "BrushStyle", "NoBrush"), brush)
+
+    # A PLAIN FILL BENEATH A PATTERN IS CARRIED IN THE TILE, since `fill-pattern` leaves no room
+    # for `fill-color`. Without this the red polygon with a black hatch published transparent.
+    source = make_layer("Polygon")
+    source.setRenderer(QgsSingleSymbolRenderer(build("line-pattern over a plain fill")))
+    style = symbology.from_qgis(source) or {}
+    target = make_layer("Polygon")
+    symbology.apply_to_qgis(target, style)
+    check("a fill beneath a hatch is baked into the tile", ink(target.renderer().symbol()) >= 90,
+          "{0}% ink — the fill under it went missing".format(ink(target.renderer().symbol())))
+
+    # AND THE WEB DRAWS THE TILE, NOT THE COLOUR — the parity half of the same fact.
+    if WEB is None:
+        skip("MapLibre draws the pattern instead of the colour", "the web renderer is not mounted")
+    else:
+        tile = WEB.fill_pattern(style)
+        check("MapLibre is given the same tile", bool(tile.get("image")), tile.keys())
+
+
 def label_matrix():
     """Every label property, both directions, on a feature layer and on a vector-tile layer.
 
@@ -1879,7 +1995,8 @@ def main():
     print("QGIS {0}   |   web renderer: {1}".format(
         Qgis.QGIS_VERSION, "mounted" if WEB is not None else "NOT MOUNTED (sections skipped)"))
     for run in (registry_sweep, renderer_sweep, unit_matrix, per_class_matrix, property_matrix,
-                scope_matrix, colour_alpha, label_matrix, label_rules, tile_matrix,
+                scope_matrix, colour_alpha, pattern_fills, label_matrix, label_rules,
+                tile_matrix,
                 special_renderers,
                 zero_is_a_size, lines_made_of_markers, pictures_are_the_right_size,
                 tiles_match_the_portal, stacked_strokes, maplibre_matrix,


### PR DESCRIPTION
Reported: *"when I open the portal as group in qgis from geodeploy, all paths, fast draw, editable,
with or without token, then hashed polygons are coming back solid filled instead of hashed."*

All three routes, because all three end in the same symbol builder. **Two faults, and neither is
visible in a style dict** — `fill_pattern` was present, correct and byte-identical across the round
trip the whole time. Only the pixels were wrong, which is why the new checks render.

### A solid fill was painted under the tile

…in the style's own colour, and `fills.decorate` then laid the hatch on top of it — in that same
colour. A solid block by definition. Measured on a diagonal hatch:

```
QGIS drew   : clear=82%   rgba(196,60,57,255):12%
came back as: clear= 0%   rgba(196,60,57,255):47%   rgba(197,60,57,255):47%
```

MapLibre drops `fill-color` the moment `fill-pattern` is set, so the browser draws the tile over
nothing. QGIS has to do the same.

### The tile's width was in millimetres, and a raster fill counts in pixels

`QgsRasterFillSymbolLayer.width` defaults to `RenderPixels` — the one size in this plugin whose
default unit is not millimetres. Handing it `px / MM_TO_PX` drew a 16px hatch tile at 4px, finer
than the hatch's own period, so the diagonals collapsed into a grey stipple that reads as a flat
wash rather than as a small hatch. Now stated in points with the unit set, like every other size
here.

### A fill beneath a pattern travels in the tile

`fill-pattern` takes the colour's slot, so a plain fill under a hatch has nowhere else to live —
a red polygon with a black hatch published with the red missing. It is painted into the tile now
(`fills._base_colour`), which is what lets the browser and QGIS draw the same thing. And a polygon
that is *only* a pattern says it has no outline, rather than being given the default blue one.

### Verification

A new `pattern_fills()` section renders eleven pattern kinds — the Qt brush hatches, a line
pattern over a fill, a line pattern alone, a point pattern — and compares the **ink** (mean alpha)
before and after, plus the reported symptom as its own check. Against the code before this change
it fails eleven times with `QGIS drew 15%, it came back 100%`.

- 569 matrix checks, 0 failed — qgis:ltr and qgis:4.2
- 349 real-QGIS checks, 0 failed — both images
- every non-QGIS script green, `test_package.py` 39 checks on the built 0.7.2 zip

Plugin **0.7.2**. Plugin-only change; the instance needs nothing. Re-push a layer for the portal to
gain the baked-in base colour.