### PR TITLE
The plugin docs point at a demo that exists, at the top

### DIFF
--- a/docs/qgis.md
+++ b/docs/qgis.md
@@ -13,6 +13,23 @@ it can see is what your account can see, and what it publishes is what a portal 
 the same Python client the [CLI](cli.md) is built on — so anything you can do here, you can also
 script. ([Which interface should I use?](api-reference.md#which-interface-should-i-use))
 
+!!! tip "You do not need an instance to try this"
+    [**geodeploy-demo.kndev.org**](https://geodeploy-demo.kndev.org) is a live GeoDeploy, and the
+    plugin works against it like any other. [Install the plugin](#install), paste that URL, and
+    press **Connect** — with no token at all you get its public portals and layers, and **Add to
+    map** brings one into QGIS styled the way the portal draws it.
+
+    To push *back* — upload a layer, save styling, publish a group as a portal — you need a token,
+    and the demo gives you one in under a minute:
+
+    1. Open the demo and **join with a name** — no email, no password.
+    2. **Settings ▸ API tokens ▸ Create token**, with **write** access.
+    3. Copy it (it is shown once) and paste it into the plugin's **Token** box.
+
+    Two things about the demo specifically: everyone shares **one workspace**, so treat what you
+    put there as public; and it is **wiped every hour, on the hour**, which invalidates tokens
+    along with everything else. If writes suddenly start failing, make a new token.
+
 ## Which QGIS you need
 
 | | |
@@ -90,8 +107,8 @@ them, with a link to the tokens page of the instance you are connected to.
 
 #### Quick start against the demo
 
-    URL:   https://demo.geodeploy.org
-    Token: create one under Settings -> API tokens after signing in
+    URL:   https://geodeploy-demo.kndev.org
+    Token: join with a name, then Settings -> API tokens -> Create token (write)
 
 Connect, pick any layer in QGIS, tick **Send its styling too**, and press **Upload selected
 layers**. It appears in **My Data** on the instance, styled the way QGIS drew it. Note that the demo


### PR DESCRIPTION
Asked: is it clear, from the start of the plugin docs, that you can try this against the demo with
a generated token? **No, twice over.**

### The address was wrong

The "Quick start against the demo" told the reader to paste `https://demo.geodeploy.org`:

```
https://demo.geodeploy.org         code=000     (no answer — the host does not resolve)
https://geodeploy-demo.kndev.org   code=200
```

Not a 404 — nothing there at all. Following the documented steps could only fail, and fail in the
way that reads as *the plugin* being unable to connect.

### And it was buried

It sat four levels down, under **Connect ▸ Getting a token ▸ Quick start**. Somebody deciding
whether the plugin is worth installing never got that far. "Is there something I can try this
against?" belongs before the QGIS version table, not after the token instructions.

### Now

A tip block directly under the intro: the demo's real address, that **browsing it needs no token
at all**, and the three steps to a write token (join with a name → Settings ▸ API tokens → paste),
plus the two things that will otherwise surprise you — one shared workspace, and an hourly wipe
that invalidates tokens.

Checked against the running demo rather than assumed: `/api/public` answers anonymously with six
portals and ten layers, which is exactly what the plugin reads when no token is set.

`mkdocs build --strict` passes and the `#install` anchor resolves in the built HTML.