### PR TITLE
A signal is retried; a failed check is not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,27 @@ jobs:
 
       - name: The symbology round trip, against QGIS itself
         working-directory: integrations/qgis-plugin
-        run: python3 -u scripts/test_real_qgis.py
+        # A NATIVE CRASH IS RETRIED ONCE; A FAILED CHECK IS NEVER RETRIED. PyQGIS occasionally
+        # dies from a signal here instead of returning a verdict — SIGSEGV (139) and SIGABRT (134)
+        # both seen, on the 4.2 image, at a different place each time, and passing on a rerun of
+        # the identical commit. It has been chased twice: 300 rounds of the section it last died
+        # in, and 9 full runs under GC stress, neither reproduced it, so there is no fix to make
+        # and pretending otherwise would be worse than saying so.
+        #
+        # What is NOT papered over: an exit code below 128 is a real result and fails immediately,
+        # so a broken round trip still stops the build on the first try. Only a signal gets the
+        # second attempt, and it is announced as a warning so the flake stays visible in the run
+        # summary rather than disappearing. `faulthandler` is enabled inside each script, so the
+        # crashing run now prints the Python stack it died on — which is the thing that will
+        # eventually turn this into a diagnosis.
+        run: |
+          set +e
+          python3 -u scripts/test_real_qgis.py
+          code=$?
+          set -e
+          if [ "$code" -lt 128 ]; then exit "$code"; fi
+          echo "::warning::PyQGIS was killed by signal $((code - 128)), not a failed check. Retrying once; the crash printed a Python stack above."
+          python3 -u scripts/test_real_qgis.py
 
       - name: The round trip as a matrix, generated from QGIS's registries
         # The other half of the file above. That one is a REGRESSION suite — every check exists
@@ -145,7 +165,14 @@ jobs:
         # stdlib precisely so it can be imported beside PyQGIS. It reports them as skipped rather
         # than failing if it cannot.
         working-directory: integrations/qgis-plugin
-        run: python3 -u scripts/test_roundtrip_matrix.py
+        run: |
+          set +e
+          python3 -u scripts/test_roundtrip_matrix.py
+          code=$?
+          set -e
+          if [ "$code" -lt 128 ]; then exit "$code"; fi
+          echo "::warning::PyQGIS was killed by signal $((code - 128)), not a failed check. Retrying once; the crash printed a Python stack above."
+          python3 -u scripts/test_roundtrip_matrix.py
 
       - name: Every symbol QGIS offers is classified
         # Reads QGIS's OWN registries — symbol layers, renderers, data-defined properties — and
@@ -153,7 +180,14 @@ jobs:
         # something the table does not classify, so a new QGIS version forces a decision instead
         # of quietly widening a gap nobody has written down.
         working-directory: integrations/qgis-plugin
-        run: python3 -u scripts/coverage_report.py
+        run: |
+          set +e
+          python3 -u scripts/coverage_report.py
+          code=$?
+          set -e
+          if [ "$code" -lt 128 ]; then exit "$code"; fi
+          echo "::warning::PyQGIS was killed by signal $((code - 128)), not a failed check. Retrying once; the crash printed a Python stack above."
+          python3 -u scripts/coverage_report.py
 
   qgis-plugin:
     name: QGIS plugin

--- a/integrations/qgis-plugin/scripts/coverage_report.py
+++ b/integrations/qgis-plugin/scripts/coverage_report.py
@@ -26,10 +26,22 @@ Run it the way `test_real_qgis.py` runs:
     docker run --rm -v <plugin-dir>:/src -w /src -e QT_QPA_PLATFORM=offscreen \\
         qgis/qgis:ltr python3 scripts/coverage_report.py
 """
+import faulthandler
 import os
 import sys
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# A CRASH OUT OF QGIS'S C++ SIDE MUST SAY WHERE IT WAS. These scripts die from a SIGSEGV or a
+# SIGABRT often enough to have their own note in `notes_temp/notes_for_future.md` — a borrowed
+# symbol pointer read after its temporary is gone is the classic one — and the shell reports it as
+# nothing but `Segmentation fault (core dumped)`, exit 139. Which of the hundreds of checks was
+# running is then a matter of reading the last line that happened to be flushed.
+#
+# `faulthandler` prints the Python stack from the signal handler, so the answer arrives with the
+# crash instead of being reconstructed from it. It costs nothing when nothing crashes.
+faulthandler.enable()
+
 from qgis.core import (Qgis, QgsApplication, QgsPalLayerSettings,  # noqa: E402
                        QgsSymbolLayer)
 

--- a/integrations/qgis-plugin/scripts/test_real_qgis.py
+++ b/integrations/qgis-plugin/scripts/test_real_qgis.py
@@ -27,6 +27,7 @@ Run it:
 `qgis/qgis:ltr` is 3.44; `qgis/qgis:4.2` is the Qt6 build. Both must pass, and CI runs both.
 Exit code 0 = every check passed; 1 = at least one failed, each printed with what it expected.
 """
+import faulthandler
 import os
 import sys
 import traceback
@@ -36,6 +37,17 @@ PLUGIN = os.path.join(HERE, "..", "geodeploy_qgis")
 
 # ── Real QGIS, headless ──────────────────────────────────────────────────────────────────────────
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# A CRASH OUT OF QGIS'S C++ SIDE MUST SAY WHERE IT WAS. These scripts die from a SIGSEGV or a
+# SIGABRT often enough to have their own note in `notes_temp/notes_for_future.md` — a borrowed
+# symbol pointer read after its temporary is gone is the classic one — and the shell reports it as
+# nothing but `Segmentation fault (core dumped)`, exit 139. Which of the hundreds of checks was
+# running is then a matter of reading the last line that happened to be flushed.
+#
+# `faulthandler` prints the Python stack from the signal handler, so the answer arrives with the
+# crash instead of being reconstructed from it. It costs nothing when nothing crashes.
+faulthandler.enable()
+
 from qgis.core import (QgsApplication, QgsFeature, QgsField, QgsGeometry, QgsPointXY,  # noqa: E402
                        QgsVectorLayer)
 

--- a/integrations/qgis-plugin/scripts/test_roundtrip_matrix.py
+++ b/integrations/qgis-plugin/scripts/test_roundtrip_matrix.py
@@ -26,6 +26,7 @@ The `/api` mount is OPTIONAL: without it the MapLibre sections are skipped and r
 so the script still runs anywhere the plugin does. Exit code 0 = everything passed.
 """
 import json
+import faulthandler
 import os
 import sys
 import traceback
@@ -34,6 +35,17 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PLUGIN_ROOT = os.path.normpath(os.path.join(HERE, ".."))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# A CRASH OUT OF QGIS'S C++ SIDE MUST SAY WHERE IT WAS. These scripts die from a SIGSEGV or a
+# SIGABRT often enough to have their own note in `notes_temp/notes_for_future.md` — a borrowed
+# symbol pointer read after its temporary is gone is the classic one — and the shell reports it as
+# nothing but `Segmentation fault (core dumped)`, exit 139. Which of the hundreds of checks was
+# running is then a matter of reading the last line that happened to be flushed.
+#
+# `faulthandler` prints the Python stack from the signal handler, so the answer arrives with the
+# crash instead of being reconstructed from it. It costs nothing when nothing crashes.
+faulthandler.enable()
+
 from qgis.core import QgsApplication                                            # noqa: E402
 
 QgsApplication.setPrefixPath(os.environ.get("QGIS_PREFIX_PATH", "/usr"), True)


### PR DESCRIPTION
The `QGIS 4.2 (real PyQGIS)` job exited **139** on the merge of #115 — a **documentation-only** PR,
one markdown file. The same commit's own PR run had passed that job minutes earlier, and
[a rerun of the merge commit passed](https://github.com/bravemaster3/GeoDeploy/actions/runs/34644101897)
with nothing changed. The repository's code is not the variable.

It is the second occurrence. Both on the **4.2** image only, never `ltr`; both at a **different
place** (once `corrupted size vs. prev_size`, once a clean `Segmentation fault (core dumped)`
immediately after the `Rule-based` section header, before its first check printed); both passing on
a rerun.

### Not diagnosed, and not pretended otherwise

The obvious suspect is the borrowed-pointer trap already recorded in `notes_for_future.md`: a
symbol taken out of a rule tree and read after its temporary is gone segfaults exactly like this.
So the harness's own rule builder was run **300 times** on 4.2 with `gc.collect()` between every
round — plain, ELSE, scale-limited and nested rule trees, built, read, applied back and read again.
No crash. An earlier occurrence survived 9 full runs under GC stress.

There is no fix to make yet. Two things that help anyway:

### 1. The next crash will say where it was

`faulthandler.enable()` in `test_real_qgis.py`, `test_roundtrip_matrix.py` and
`coverage_report.py`. The standing complaint about this class of failure — written down twice in
the repo — is that it arrives as nothing but `Segmentation fault (core dumped)` and leaves you
guessing which of 349 checks was running. Now the signal handler prints the Python stack.

### 2. CI distinguishes a crash from a verdict

| exit code | what happens |
| --- | --- |
| 0 | pass |
| 1 (a failed check) | **fails immediately** — no retry |
| ≥ 128 (killed by a signal) | `::warning::` in the run summary, then one more attempt |

A genuinely broken round trip still stops the build on the first try. Only a native crash gets the
second run, and it stays visible rather than being silently swallowed. Verified against exit codes
0, 1, 139 and 134.

### Nothing here touches the plugin

No file under `geodeploy_qgis/` changed, so **0.7.2 does not need re-uploading anywhere**. This is
the harness and the workflow.

349 + 569 checks and the coverage report pass on qgis:ltr and qgis:4.2 with faulthandler enabled.