### PR TITLE
The API says which version it is, and a test keeps it saying so

### DIFF
--- a/api/geodeploy/main.py
+++ b/api/geodeploy/main.py
@@ -317,7 +317,10 @@ def _ensure_martin_config(settings) -> None:
 
 app = FastAPI(
     title="GeoDeploy API",
-    version="1.5.4",
+    # KEPT IN STEP WITH THE CHANGELOG by `api/tests/test_version_string.py`. This literal
+    # went three releases stale once, and a live instance told operators it was 1.5.4
+    # while running 1.6.4 — bump it when you cut a release.
+    version="1.6.4",
     description="Self-hosted spatial data management and geoportal builder",
     lifespan=lifespan,
     # Every response, not only the ones we thought to guard: a NaN anywhere in the content used to

--- a/api/tests/test_version_string.py
+++ b/api/tests/test_version_string.py
@@ -1,0 +1,48 @@
+"""The version the API advertises is the version that was released.
+
+FOUND STALE, ON A LIVE INSTANCE. `/api/openapi.json` said `1.5.4` while the platform was at v1.6.4
+— three releases and a month behind. The string is hard-coded in `main.py`, it had been bumped by
+hand exactly twice in the project's life, and nothing checked it, so it drifted the moment somebody
+cut a release without remembering this particular literal. It is not cosmetic: it is what an
+operator reads to answer "did the update actually take?", and a wrong answer there sends them
+looking for a fault that does not exist.
+
+So the CHANGELOG is the single source of truth and this is the thing that keeps them in step.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CHANGELOG = REPO / "CHANGELOG.md"
+
+#: `## v1.6.4 — 2026-09-11`, and also `## v1.6 — …`. Not `## Unreleased`, which has no version.
+HEADING = re.compile(r"^##\s+v(\d+\.\d+(?:\.\d+)?)\b", re.M)
+
+
+def released_version() -> str:
+    """The newest version the changelog names."""
+    found = HEADING.search(CHANGELOG.read_text(encoding="utf-8"))
+    assert found, "CHANGELOG.md has no `## vX.Y` heading to read a version from"
+    return found.group(1)
+
+
+def test_the_api_advertises_the_released_version():
+    from geodeploy.main import app
+
+    expected = released_version()
+    assert app.version == expected, (
+        "the API advertises {0} but the newest release in CHANGELOG.md is {1} — bump "
+        "`version=` in api/geodeploy/main.py when you cut a release, or /api/openapi.json "
+        "and the docs page will keep telling operators the wrong thing".format(
+            app.version, expected)
+    )
+
+
+def test_the_changelog_heading_is_the_one_being_read():
+    """A guard on the guard: if the changelog's format changes, this test must fail loudly rather
+    than quietly matching nothing and passing whatever `app.version` happens to say."""
+    text = CHANGELOG.read_text(encoding="utf-8")
+    assert text.lstrip().startswith("# Changelog")
+    assert "## Unreleased" in text, "the Unreleased heading is what the version regex must skip"
+    assert HEADING.search(text).start() > text.index("## Unreleased"), (
+        "the newest version heading should sit below `## Unreleased`")


### PR DESCRIPTION
`/api/openapi.json` on a live instance reports **1.5.4** while the platform is at **v1.6.4** —
three releases and a month behind:

```
$ curl -s https://geodeploy-demo.kndev.org/api/openapi.json | head -c 160
{"openapi":"3.1.0","info":{"title":"GeoDeploy API", … "version":"1.5.4"},…
```

The string is hard-coded in `main.py`, it had been bumped by hand exactly twice in the project's
life (`git log -S` finds one commit), and nothing checked it — so it went stale the first time a
release was cut without remembering that particular literal.

Not cosmetic: it is what an operator reads to answer *"did the update actually take?"*, and a wrong
answer sends them hunting for a fault that is not there. It is also the version an API client sees.

### The fix is the test, not the bump

Bumped to 1.6.4, and tied to the CHANGELOG so it cannot drift again — the newest `## vX.Y.Z`
heading is the source of truth, and the failure message names the literal to change:

```
AssertionError: the API advertises 1.5.4 but the newest release in CHANGELOG.md is 1.6.4 —
bump `version=` in api/geodeploy/main.py when you cut a release, or /api/openapi.json and the
docs page will keep telling operators the wrong thing
```

A second test guards the guard: if the changelog's format moves, the regex must fail loudly rather
than quietly matching nothing and passing whatever the app happens to claim.

Verified both ways — passes at 1.6.4, fails with the message above when the old string is put back.

### How it was found

Auditing the last unmerged local branch before deleting it. The branch was a superseded copy of
work that shipped as v1.5.4, and the one line it had bumped turned out to be the line that then
stopped being bumped.